### PR TITLE
Workaround slowness due to python-magic bug

### DIFF
--- a/Pkg.py
+++ b/Pkg.py
@@ -698,8 +698,10 @@ class Pkg(AbstractPkg):
                 pkgfile.provides = parse_deps(provides[idx])
                 pkgfile.lang = b2s(langs[idx])
                 pkgfile.magic = magics[idx]
-                if not pkgfile.magic and _magic:
-                    pkgfile.magic = _magic.file(pkgfile.path)
+                if not pkgfile.magic and pkgfile.size and not pkgfile.is_ghost and _magic:
+                    f = open(pkgfile.path)
+                    pkgfile.magic = _magic.descriptor(f.fileno())
+                    f.close()
                 if pkgfile.magic is None:
                     pkgfile.magic = ''
                 elif Pkg._magic_from_compressed_re.search(pkgfile.magic):

--- a/Pkg.py
+++ b/Pkg.py
@@ -10,6 +10,7 @@
 
 import os
 import re
+import stat
 import subprocess
 import sys
 import tempfile
@@ -698,7 +699,13 @@ class Pkg(AbstractPkg):
                 pkgfile.provides = parse_deps(provides[idx])
                 pkgfile.lang = b2s(langs[idx])
                 pkgfile.magic = magics[idx]
-                if not pkgfile.magic and pkgfile.size and not pkgfile.is_ghost and _magic:
+                if not pkgfile.magic and stat.S_ISDIR(pkgfile.mode):
+                    pkgfile.magic = 'directory'
+                elif not pkgfile.magic and stat.S_ISLNK(pkgfile.mode):
+                    pkgfile.magic = 'symbolic link'
+                elif not pkgfile.magic and not pkgfile.size:
+                    pkgfile.magic = 'empty'
+                elif not pkgfile.magic and not pkgfile.is_ghost and _magic:
                     f = open(pkgfile.path)
                     pkgfile.magic = _magic.descriptor(f.fileno())
                     f.close()

--- a/Pkg.py
+++ b/Pkg.py
@@ -707,8 +707,11 @@ class Pkg(AbstractPkg):
                     pkgfile.magic = 'empty'
                 elif not pkgfile.magic and not pkgfile.is_ghost and _magic:
                     f = open(pkgfile.path)
-                    pkgfile.magic = _magic.descriptor(f.fileno())
-                    f.close()
+                    if f:
+                        pkgfile.magic = _magic.descriptor(f.fileno())
+                        f.close()
+                    else:
+                        Pkg.warn("Could not open " + pkgfile.path)
                 if pkgfile.magic is None:
                     pkgfile.magic = ''
                 elif Pkg._magic_from_compressed_re.search(pkgfile.magic):


### PR DESCRIPTION
The file method evaluates the file twice, the descriptor method does not
show this problem. For large packages (e.g. kernel), this saves several
minutes of run time.