### PR TITLE
BinariesCheck: lower memory requirements, fix chroot/chdir detection

### DIFF
--- a/BinariesCheck.py
+++ b/BinariesCheck.py
@@ -216,23 +216,23 @@ class BinaryInfo(object):
                     chroot_index = -99
                     chdir_index = -99
                     for line in p.stdout:
-                        r = BinaryInfo.objdump_call_regex.search(line)
-                        if not r:
+                        res = BinaryInfo.objdump_call_regex.search(line)
+                        if not res:
                             continue
-                        if b'@plt' not in r.group(1):
+                        if b'@plt' not in res.group(1):
                             pass
-                        elif b'chroot@plt' in r.group(1):
+                        elif b'chroot@plt' in res.group(1):
                             chroot_index = index
                             if abs(chroot_index - chdir_index) <= 2:
                                 self.chroot_near_chdir = True
                                 break
-                        elif b'chdir@plt' in r.group(1):
+                        elif b'chdir@plt' in res.group(1):
                             chdir_index = index
                             if abs(chroot_index - chdir_index) <= 2:
                                 self.chroot_near_chdir = True
                                 break
                         index += 1
-                if p.wait():
+                if p.wait() and not self.chroot_near_chdir:
                     printWarning(pkg, 'binaryinfo-objdump-failed', file)
                     self.chroot_near_chdir = True  # avoid false positive
 

--- a/BinariesCheck.py
+++ b/BinariesCheck.py
@@ -216,7 +216,7 @@ class BinaryInfo(object):
                     chroot_index = -99
                     chdir_index = -99
                     for line in p.stdout:
-                        r = objdump_call_regex.search(line)
+                        r = BinaryInfo.objdump_call_regex.search(line)
                         if not r:
                             continue
                         if b'@plt' not in r.group(1):

--- a/BinariesCheck.py
+++ b/BinariesCheck.py
@@ -54,6 +54,8 @@ class BinaryInfo(object):
     setuid_call_regex = create_regexp_call('set(?:res|e)?uid')
     setgroups_call_regex = create_regexp_call('(?:ini|se)tgroups')
     chroot_call_regex = create_regexp_call('chroot')
+    # 401eb8:   e8 c3 f0 ff ff          callq  400f80 <chdir@plt>
+    objdump_call_regex = re.compile(b'callq?\s(.*)')
 
     forbidden_functions = Config.getOption("WarnOnFunction")
     if forbidden_functions:
@@ -208,11 +210,8 @@ class BinaryInfo(object):
             if self.chroot and self.chdir:
                 p = subprocess.Popen(
                     ['env', 'LC_ALL=C', 'objdump', '-d', path],
-                    stdout=subprocess.PIPE, bufsize=1)
+                    stdout=subprocess.PIPE, bufsize=-1)
                 with p.stdout:
-                    # we want that :
-                    # 401eb8:   e8 c3 f0 ff ff          callq  400f80 <chdir@plt>
-                    objdump_call_regex = re.compile(b'callq?\s(.*)')
                     index = 0
                     chroot_index = -99
                     chdir_index = -99


### PR DESCRIPTION
Do not read whole output of objdump -d into memory, but read and process
the output while it is created (issue#67).
Also correct expression to find 'chdir@plt' in output (issue#66)