### PR TITLE
add /usr/lib/systemd to DEFAULT_HARDCODED_LIB_PATH_EXCEPTIONS

### DIFF
--- a/SpecCheck.py
+++ b/SpecCheck.py
@@ -30,7 +30,7 @@ DEFAULT_BIARCH_PACKAGES = '^(gcc|glibc)'
 # Don't check for hardcoded library paths in packages which can have
 # their noarch files in /usr/lib/<package>/*, or packages that can't
 # be installed on biarch systems
-DEFAULT_HARDCODED_LIB_PATH_EXCEPTIONS = '/lib/(modules|cpp|perl5|rpm|hotplug|firmware)($|[\s/,])'
+DEFAULT_HARDCODED_LIB_PATH_EXCEPTIONS = '/lib/(modules|cpp|perl5|rpm|hotplug|firmware|systemd)($|[\s/,])'
 
 
 def re_tag_compile(tag):


### PR DESCRIPTION
Spec files that need to install files into, e.g.,
/usr/lib/systemd/system-generators will generate a
hardcoded-library-path error.  This commit adds /usr/lib/systemd to
the list of exceptions for this check.