### PR TITLE
TagsCheck.py: accept SPDX "and" and "or" operators in all-uppercase spelling

### DIFF
--- a/TagsCheck.py
+++ b/TagsCheck.py
@@ -416,7 +416,7 @@ lib_devel_number_regex = re.compile(r'^lib(.*?)([0-9.]+)(_[0-9.]+)?-devel')
 invalid_url_regex = re.compile(Config.getOption('InvalidURL'), re.IGNORECASE)
 lib_package_regex = re.compile(r'(?:^(?:compat-)?lib.*?(\.so.*)?|libs?[\d-]*)$', re.IGNORECASE)
 leading_space_regex = re.compile(r'^\s+')
-license_regex = re.compile(r'\(([^)]+)\)|\s(?:and|or)\s')
+license_regex = re.compile(r'\(([^)]+)\)|\s(?:and|or|AND|OR)\s')
 invalid_version_regex = re.compile(r'([0-9](?:rc|alpha|beta|pre).*)', re.IGNORECASE)
 # () are here for grouping purpose in the regexp
 forbidden_words_regex = re.compile(r'(%s)' % Config.getOption('ForbiddenWords'), re.IGNORECASE)


### PR DESCRIPTION
With this patch applied, a license like "BSD-3-Clause AND BSD-2-Clause"
can be spelled with an all upper-case or all lower-case conjunction.
Spelling the conjunction in mixed case is not accepted, however:
matching is not case-insensitive.