### PR TITLE
get_default_valid_rpmgroups: Don't fail if rpm is partially installed

### DIFF
--- a/Pkg.py
+++ b/Pkg.py
@@ -227,7 +227,7 @@ def get_default_valid_rpmgroups(filename=None):
                 groupsfiles = [x for x in p.files() if x.endswith('/GROUPS')]
                 if groupsfiles:
                     filename = groupsfiles[0]
-        except KeyError:  # the rpm package might not be installed
+        except (KeyError, TypeError):  # the rpm package might not be installed
             pass
     if filename and os.path.exists(filename):
         with open(filename) as fobj:


### PR DESCRIPTION
A catch-all exception was added to handle the case where the rpm package
was not installed dec4821 ("get_default_valid_rpmgroups: Don't fail if
the rpm package is not installed", 2015-07-24).  That catch-all was
later tightened in c1945e3 ("Avoid catch-all except statements",
2017-10-24).

The rpm package can also trigger a TypeError exception when installed
without docs or all languages, as is commonly done in container images.
Catch TypeError exception as well.