### PR TITLE
Add openSUSE Leap 15.0 travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - DIST=centos7 PYTHON=python PYTEST=py.test FLAKE8=true
   - DIST=fedora28 PYTHON=python3 PYTEST=py.test-3 FLAKE8=flake8-3
   - DIST=fedoradev PYTHON=python3 PYTEST=py.test-3 FLAKE8=flake8-3
+  - DIST=leap15 PYTHON=python3 PYTEST=py.test FLAKE8=flake8
 
 before_install:
   - docker build -t $DIST -f test/Dockerfile-$DIST .

--- a/test/Dockerfile-leap15
+++ b/test/Dockerfile-leap15
@@ -1,0 +1,11 @@
+FROM opensuse/leap:15
+
+RUN zypper -n install \
+        cpio bzip2 groff make elfutils xz \
+        perl python binutils desktop-file-utils \
+        python3-rpm \
+        python3-pytest \
+        python3-flake8
+
+WORKDIR /usr/src/rpmlint
+COPY . .


### PR DESCRIPTION
This is the stable openSUSE release that can be used
for regression testing.