### PR TITLE
Add openSUSE Leap 42.3 travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - DIST=centos7 PYTHON=python PYTEST=py.test FLAKE8=true
   - DIST=fedora28 PYTHON=python3 PYTEST=py.test-3 FLAKE8=flake8-3
   - DIST=fedoradev PYTHON=python3 PYTEST=py.test-3 FLAKE8=flake8-3
+  - DIST=leap423 PYTHON=python2 PYTEST=py.test FLAKE8=flake8
 
 before_install:
   - docker build -t $DIST -f test/Dockerfile-$DIST .

--- a/test/Dockerfile-leap423
+++ b/test/Dockerfile-leap423
@@ -1,0 +1,11 @@
+FROM opensuse/leap:42.3
+
+RUN zypper -n install \
+        cpio bzip2 groff make elfutils xz \
+        perl python binutils desktop-file-utils \
+        rpm-python \
+        python-pytest \
+        python-flake8
+
+WORKDIR /usr/src/rpmlint
+COPY . .


### PR DESCRIPTION
This is one of the older openSUSE releases that can be used
for regression testing against old rpm / python releases.