### PR TITLE
Treat Sphinx inventory files as binary

### DIFF
--- a/rpmlint/FilesCheck.py
+++ b/rpmlint/FilesCheck.py
@@ -304,6 +304,9 @@ def peek(filename, pkg, length=1024):
     # Ditto RDoc RI files
     if fl.endswith('.ri') and '/ri/' in fl:
         return (chunk, False)
+    # And Sphinx inventory files
+    if fl.endswith('.inv') and chunk.startsWith('# Sphinx inventory'):
+        return (chunk, False)
 
     # Binary if control chars are > 30% of the string
     control_chars = chunk.translate(None, printable_extended_ascii)


### PR DESCRIPTION
Sphinx, a tool commonly used to produce documentation for Python projects, produces inventory files with extension `.inv` that contain a plaintext header followed by raw zlib data. When the zlib data is short enough, this fools [the heuristic used][heuristic] to determine if a file is text or binary. Since these files are often included in documentation packages, this can produce false positives for the `wrong-file-end-of-line-encoding` check and the subsequent `file-not-utf8` check.

[heuristic]: https://github.com/rpm-software-management/rpmlint/blob/c1dbe704c42749abd1b2f3abec9fdf374c0ef986/rpmlint/FilesCheck.py#L280-L313