### PR TITLE
Fix deprecation warnings with new pytest

### DIFF
--- a/test/test_binaries.py
+++ b/test/test_binaries.py
@@ -14,15 +14,15 @@ def binariescheck():
 
 
 @pytest.mark.parametrize('package', ['binary/cyrus-imapd', 'binary/dovecot'])
-def test_forbidden_c_calls(tmpdir, package):
-    output, test = binariescheck()
+def test_forbidden_c_calls(tmpdir, package, binariescheck):
+    output, test = binariescheck
     test.check(get_tested_package(package, tmpdir))
     assert 'crypto-policy-non-compliance' in output.print_results(output.results)
 
 
 @pytest.mark.parametrize('package', ['binary/ngircd'])
-def test_waived_forbidden_c_calls(tmpdir, package):
-    output, test = binariescheck()
+def test_waived_forbidden_c_calls(tmpdir, package, binariescheck):
+    output, test = binariescheck
     test.check(get_tested_package(package, tmpdir))
     # there are 3 warnings/etc
     assert len(output.results) == 3

--- a/test/test_distribution.py
+++ b/test/test_distribution.py
@@ -14,8 +14,8 @@ def distributioncheck():
 
 
 @pytest.mark.parametrize('package', ['binary/ngircd'])
-def test_distribution_tags(tmpdir, package):
-    output, test = distributioncheck()
+def test_distribution_tags(tmpdir, package, distributioncheck):
+    output, test = distributioncheck
     test.check(get_tested_package(package, tmpdir))
     assert len(output.results) == 2
     out = output.print_results(output.results)

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -40,8 +40,8 @@ def chunk_from_pyc(version, size=16):
 
 
 @pytest.mark.parametrize('package', ['binary/python3-power'])
-def test_python_bytecode_magic(tmpdir, package):
-    output, test = filescheck()
+def test_python_bytecode_magic(tmpdir, package, filescheck):
+    output, test = filescheck
     test.check(get_tested_package(package, tmpdir))
     assert not output.results
     out = output.print_results(output.results)
@@ -61,8 +61,8 @@ def test_pyc_mtime_from_chunk(version, mtime):
 
 
 @pytest.mark.parametrize('package', ['binary/netmask-debugsource'])
-def test_devel_files(tmpdir, package):
-    output, test = filescheck()
+def test_devel_files(tmpdir, package, filescheck):
+    output, test = filescheck
     test.check(get_tested_package(package, tmpdir))
     assert len(output.results) == 5
     out = output.print_results(output.results)

--- a/test/test_menuxdg.py
+++ b/test/test_menuxdg.py
@@ -14,8 +14,8 @@ def menuxdgcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/menuxdg1'])
-def test_raises_parse_error(tmpdir, package):
-    output, test = menuxdgcheck()
+def test_raises_parse_error(tmpdir, package, menuxdgcheck):
+    output, test = menuxdgcheck
     test.check(get_tested_package(package, tmpdir))
     assert len(output.results) == 4
     out = output.print_results(output.results)

--- a/test/test_pam_check.py
+++ b/test/test_pam_check.py
@@ -14,8 +14,8 @@ def pamcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/PamCheck'])
-def test_pam_check(tmpdir, package):
-    output, test = pamcheck()
+def test_pam_check(tmpdir, package, pamcheck):
+    output, test = pamcheck
     test.check(get_tested_package(package, tmpdir))
     assert len(output.results) == 1
     out = output.print_results(output.results)

--- a/test/test_rpmfile.py
+++ b/test/test_rpmfile.py
@@ -14,8 +14,8 @@ def rpmfilescheck():
 
 
 @pytest.mark.parametrize('package', ['binary/apache-commons-collections-testframework-javadoc'])
-def test_distribution_tags(tmpdir, package):
-    output, test = rpmfilescheck()
+def test_distribution_tags(tmpdir, package, rpmfilescheck):
+    output, test = rpmfilescheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     assert 'filename-too-long-for-joliet' in out

--- a/test/test_scl.py
+++ b/test/test_scl.py
@@ -16,9 +16,9 @@ def sclcheck():
 
 
 @pytest.mark.parametrize('package', ['spec/SpecCheck'])
-def test_nonscl_spec_silent(package):
+def test_nonscl_spec_silent(package, sclcheck):
     """SCL check on non-SCL spec has to be silent"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -26,9 +26,9 @@ def test_nonscl_spec_silent(package):
 
 
 @pytest.mark.parametrize('package', ['binary/python3-power'])
-def test_nonscl_binary_silent(tmpdir, package):
+def test_nonscl_binary_silent(tmpdir, package, sclcheck):
     """SCL check on non-SCL spec has to be silent"""
-    output, test = sclcheck()
+    output, test = sclcheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     assert not out
@@ -36,13 +36,13 @@ def test_nonscl_binary_silent(tmpdir, package):
 
 @pytest.mark.parametrize('package', ['nodejs010-1', 'nodejs010-nodejs-0.10.3',
                                      'nodejs010-nodejs-forever'])
-def test_scl_source_rpm(tmpdir, package):
+def test_scl_source_rpm(tmpdir, package, sclcheck):
     """
     A bunch of testing source RPM packages using SCL
     Assuming they are all OK and except silent output
     While adding more checks, this might change
     """
-    output, test = sclcheck()
+    output, test = sclcheck
     test.check(get_tested_package(os.path.join('source', package), tmpdir))
     out = output.print_results(output.results)
     assert not out
@@ -50,22 +50,22 @@ def test_scl_source_rpm(tmpdir, package):
 
 @pytest.mark.parametrize('package', ['nodejs010-runtime', 'nodejs010-nodejs-0.10.3',
                                      'nodejs010-nodejs-oauth'])
-def test_scl_binary_rpm(tmpdir, package):
+def test_scl_binary_rpm(tmpdir, package, sclcheck):
     """
     A bunch of testing binary RPM packages using SCL
     Assuming they are all OK and except silent output
     While adding more checks, this might change
     """
-    output, test = sclcheck()
+    output, test = sclcheck
     test.check(get_tested_package(os.path.join('binary', package), tmpdir))
     out = output.print_results(output.results)
     assert not out
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs-good', 'spec/nodejs010'])
-def test_correct_spec(package):
+def test_correct_spec(package, sclcheck):
     """Tests probably correct nodejs.spec and nodejs010.spec"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -73,9 +73,9 @@ def test_correct_spec(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs-undeclared', 'spec/nodejs010-undeclared'])
-def test_undeclared(package):
+def test_undeclared(package, sclcheck):
     """Tests SCL specs without %scl definition or %scl_package calls"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -83,9 +83,9 @@ def test_undeclared(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs010-nobuild'])
-def test_nobuild(package):
+def test_nobuild(package, sclcheck):
     """Tests SCL metapackage without build subpackage"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -93,9 +93,9 @@ def test_nobuild(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs010-noruntime'])
-def test_noruntime(package):
+def test_noruntime(package, sclcheck):
     """Tests SCL metapackage without runtime subpackage"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -104,9 +104,9 @@ def test_noruntime(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs010-missing-requires'])
-def test_missing_requires(package):
+def test_missing_requires(package, sclcheck):
     """Tests SCL metapackage without scl-utils-build (B)Rs"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -115,9 +115,9 @@ def test_missing_requires(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs010-alien-subpackage', 'spec/nodejs010-alien-subpackage-n'])
-def test_alien_subpackage(package):
+def test_alien_subpackage(package, sclcheck):
     """Tests SCL metapackage with extra subpackage"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -126,9 +126,9 @@ def test_alien_subpackage(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs010-nosclinstall'])
-def test_nosclinstall(package):
+def test_nosclinstall(package, sclcheck):
     """Tests SCL metapackage that doesn't call %scl_install"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -136,9 +136,9 @@ def test_nosclinstall(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs010-noarch-libdir'])
-def test_noarch(package):
+def test_noarch(package, sclcheck):
     """Tests noarch SCL metapackages (not) containing %{_libdir}"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -146,9 +146,9 @@ def test_noarch(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs010-badfiles'])
-def test_badfiles(package):
+def test_badfiles(package, sclcheck):
     """Tests SCL metapackage %files section checks"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -158,9 +158,9 @@ def test_badfiles(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs-no-pkg_name'])
-def test_no_pkg_name(package):
+def test_no_pkg_name(package, sclcheck):
     """Tests SCL spec without pkg_name definition"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -168,9 +168,9 @@ def test_no_pkg_name(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs-name-without-prefix'])
-def test_name_without_prefix(package):
+def test_name_without_prefix(package, sclcheck):
     """Tests SCL spec without prefixed name"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -178,11 +178,11 @@ def test_name_without_prefix(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs-name-with-noncondition-prefix'])
-def test_name_with_prefix_without_condition(package):
+def test_name_with_prefix_without_condition(package, sclcheck):
     """
     Tests SCL spec with prefixed name without condition in scl_prefix macro
     """
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -190,9 +190,9 @@ def test_name_with_prefix_without_condition(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs-conflicts-without-prefix'])
-def test_conflicts_without_prefix(package):
+def test_conflicts_without_prefix(package, sclcheck):
     """Tests SCL spec with nonprefixed conflicts"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -200,9 +200,9 @@ def test_conflicts_without_prefix(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs-provides-without-prefix'])
-def test_provides_without_prefix(package):
+def test_provides_without_prefix(package, sclcheck):
     """Tests SCL spec with nonprefixed provides"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -210,12 +210,12 @@ def test_provides_without_prefix(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs-norequire'])
-def test_main_package_without_scl_require(package):
+def test_main_package_without_scl_require(package, sclcheck):
     """
     Tests SCL spec where the main package doesn't require anything
     from collection
     """
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -223,12 +223,12 @@ def test_main_package_without_scl_require(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs-n-noprefix'])
-def test_n_supbackage_without_prefix(package):
+def test_n_supbackage_without_prefix(package, sclcheck):
     """
     Tests SCL spec where a subpackage uses -n and doesn't start with
     SCL prefix
     """
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -236,9 +236,9 @@ def test_n_supbackage_without_prefix(package):
 
 
 @pytest.mark.parametrize('package', ['spec/nodejs-setup-no-n'])
-def test_setup_without_n(package):
+def test_setup_without_n(package, sclcheck):
     """Tests SCL spec where setup doesn't use -n option"""
-    output, test = sclcheck()
+    output, test = sclcheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -246,29 +246,29 @@ def test_setup_without_n(package):
 
 
 @pytest.mark.parametrize('package', ['binary/nodejs110-nodejs-oauth'])
-def test_scl_name_screwed_up(tmpdir, package):
+def test_scl_name_screwed_up(tmpdir, package, sclcheck):
     """
     SCL check on SCL package that differs it's name from scl tree folder
     """
-    output, test = sclcheck()
+    output, test = sclcheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     assert 'scl-name-screwed-up' in out
 
 
 @pytest.mark.parametrize('package', ['binary/outside-nodejs010-nodejs-oauth'])
-def test_scl_forbidden_folders(tmpdir, package):
+def test_scl_forbidden_folders(tmpdir, package, sclcheck):
     """SCL check on SCL package that has files in forbidden folders"""
-    output, test = sclcheck()
+    output, test = sclcheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     assert 'file-outside-of-scl-tree' in out
 
 
 @pytest.mark.parametrize('package', ['binary/macros-nodejs010-nodejs-oauth'])
-def test_scl_macros_outside_of_build(tmpdir, package):
+def test_scl_macros_outside_of_build(tmpdir, package, sclcheck):
     """SCL check on SCL package that has files in forbidden folders"""
-    output, test = sclcheck()
+    output, test = sclcheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     assert 'scl-rpm-macros-outside-of-build' in out

--- a/test/test_sources.py
+++ b/test/test_sources.py
@@ -14,8 +14,8 @@ def sourcescheck():
 
 
 @pytest.mark.parametrize('package', ['source/wrongsrc'])
-def test_inconsistent_file_extension(tmpdir, package):
-    output, test = sourcescheck()
+def test_inconsistent_file_extension(tmpdir, package, sourcescheck):
+    output, test = sourcescheck
     test.check(get_tested_package(package, tmpdir))
     assert len(output.results) == 3
     out = output.print_results(output.results)

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -15,8 +15,8 @@ def speccheck():
     return output, test
 
 
-def test_check_include(tmpdir):
-    output, test = speccheck()
+def test_check_include(tmpdir, speccheck):
+    output, test = speccheck
     test.check_source(get_tested_package('source/CheckInclude', tmpdir))
     out = output.print_results(output.results)
     assert 'no-buildroot-tag' in out
@@ -24,8 +24,8 @@ def test_check_include(tmpdir):
 
 
 @pytest.mark.parametrize('package', ['spec/SpecCheck2', 'spec/SpecCheck3'])
-def test_patch_not_applied(package):
-    output, test = speccheck()
+def test_patch_not_applied(package, speccheck):
+    output, test = speccheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)
@@ -33,8 +33,8 @@ def test_patch_not_applied(package):
 
 
 @pytest.mark.parametrize('package', ['spec/SpecCheck'])
-def test_distribution_tags(package):
-    output, test = speccheck()
+def test_distribution_tags(package, speccheck):
+    output, test = speccheck
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg, pkg.name)
     out = output.print_results(output.results)

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -14,8 +14,8 @@ def tagscheck():
 
 
 @pytest.mark.parametrize('package', ['binary/unexpanded1'])
-def test_unexpanded_macros(tmpdir, package):
-    output, test = tagscheck()
+def test_unexpanded_macros(tmpdir, package, tagscheck):
+    output, test = tagscheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     assert 'unexpanded-macro Recommends' in out

--- a/test/test_zip.py
+++ b/test/test_zip.py
@@ -14,8 +14,8 @@ def zipcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/asm'])
-def test_jarfile(tmpdir, package):
-    output, test = zipcheck()
+def test_jarfile(tmpdir, package, zipcheck):
+    output, test = zipcheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     assert 'class-path-in-manifest' in out
@@ -23,8 +23,8 @@ def test_jarfile(tmpdir, package):
 
 
 @pytest.mark.parametrize('package', ['binary/ruby2.5-rubygem-rubyzip-testsuite'])
-def test_zip1(tmpdir, package):
-    output, test = zipcheck()
+def test_zip1(tmpdir, package, zipcheck):
+    output, test = zipcheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     # these are PW protected not broken so do not error about them
@@ -34,8 +34,8 @@ def test_zip1(tmpdir, package):
 
 
 @pytest.mark.parametrize('package', ['binary/texlive-codepage-doc'])
-def test_zip2(tmpdir, package):
-    output, test = zipcheck()
+def test_zip2(tmpdir, package, zipcheck):
+    output, test = zipcheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     assert 'W: unable-to-read-zip' in out


### PR DESCRIPTION
Fixtures should be used bit differently now.