### PR TITLE
Remove gpl2.0-only blurb as per issue #179

### DIFF
--- a/rpmlint/checks/DocFilesCheck.py
+++ b/rpmlint/checks/DocFilesCheck.py
@@ -1,18 +1,3 @@
-# Copyright (C) 2005 Enrico Scholz <enrico.scholz@informatik.tu-chemnitz.de>
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; version 2 of the License.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-
 import rpm
 from rpmlint.checks.AbstractCheck import AbstractCheck
 from rpmlint.helpers import byte_to_string


### PR DESCRIPTION
Authr acknowledged in the ticket that the file can use the general
license under which the package is distributed [GPL-2.0-or-later].