### PR TITLE
Ugly workaround for RPM 4.14 vs 4.15 python3 bindings incompatibility

### DIFF
--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -143,8 +143,17 @@ def is_utf8(fname):
 
 
 def is_utf8_bytestr(s):
+    """Returns True whether the given text is UTF-8.
+    Due to changes in rpm, needs to handle both bytes and unicode."""
     try:
-        s.decode('UTF-8')
+        if hasattr(s, 'decode'):
+            s.decode('utf-8')
+        elif hasattr(s, 'encode'):
+            s.encode('utf-8')
+        else:
+            unexpected = type(s).__name__
+            raise TypeError(
+                'Expected str/unicode/bytes, not {}'.format(unexpected))
     except UnicodeError:
         return False
     return True

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -11,7 +11,7 @@ def test_distribution_tags():
     textdiff = diff.textdiff()
     print(textdiff)
     # the count always reports one less
-    assert textdiff.count('\n') + 1 == 231
+    assert 231 <= len(textdiff.splitlines()) <= 233
 
     ignore.append('T')
     ignore.append('5')
@@ -19,6 +19,6 @@ def test_distribution_tags():
     diff = Rpmdiff(oldpkg, newpkg, ignore)
     textdiff = diff.textdiff()
     print('----\n' + textdiff)
-    assert textdiff.count('\n') + 1 == 36
+    assert 36 <= len(textdiff.splitlines()) <= 38
 
     assert 'added       /usr/share/mc/syntax/yaml.syntax' in textdiff

--- a/test/test_diff.py
+++ b/test/test_diff.py
@@ -9,6 +9,7 @@ def test_distribution_tags():
     ignore = list()
     diff = Rpmdiff(oldpkg, newpkg, ignore)
     textdiff = diff.textdiff()
+    print(textdiff)
     # the count always reports one less
     assert textdiff.count('\n') + 1 == 231
 
@@ -17,6 +18,7 @@ def test_distribution_tags():
     ignore.append('S')
     diff = Rpmdiff(oldpkg, newpkg, ignore)
     textdiff = diff.textdiff()
+    print('----\n' + textdiff)
     assert textdiff.count('\n') + 1 == 36
 
     assert 'added       /usr/share/mc/syntax/yaml.syntax' in textdiff


### PR DESCRIPTION
Fixes https://github.com/rpm-software-management/rpmlint/issues/202