### PR TITLE
Fix text_section_regex regex.

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -50,7 +50,7 @@ class BinaryInfo(object):
 
     # [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
     # [ 1] .text             PROGBITS        0000000000000000 000040 000000 00  AX  0   0  1
-    text_section_regex = re.compile(r'.*\.text\s*\w+\s*\w*\s*\w*\w*\s*(\w*).*')
+    text_section_regex = re.compile(r'\s*\[[ 0-9]+\]\s*\.text\s*\w+\s*\w*\s*\w*\w*\s*(\w*).*.')
 
     def __init__(self, config, output, pkg, path, fname, is_ar, is_shlib):
         self.readelf_error = False


### PR DESCRIPTION
Do not match the regex with any of the following lines:

```
  [891] .rel.text         REL             00000000 08699c 006388 08   I 6184 890  4
   238: 00000070     8 OBJECT  LOCAL  DEFAULT  893 gob.textMarshalerInterfaceType
```

It caused an exception for `gcc7-go-32bit` rpm file.