### PR TITLE
Remove accidentaly by-default enabled lsbcheck

### DIFF
--- a/rpmlint/configdefaults.toml
+++ b/rpmlint/configdefaults.toml
@@ -9,7 +9,6 @@ Checks = [
     "FilesCheck",
     "InitScriptCheck",
     "I18NCheck",
-    "LSBCheck",
     "MenuCheck",
     "MenuXDGCheck",
     "NamingPolicyCheck",

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -26,7 +26,6 @@ basic_tests = [
     'FilesCheck',
     'InitScriptCheck',
     'I18NCheck',
-    'LSBCheck',
     'MenuCheck',
     'MenuXDGCheck',
     'NamingPolicyCheck',


### PR DESCRIPTION
It was not enabled before and I introduced it by accident when sorting
the tests alphabetically.