### PR TITLE
Add no-doc-for-lib.diff from SUSE rpmlint package (#292).

### DIFF
--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -439,7 +439,7 @@ class FilesCheck(AbstractCheck):
         debuginfo_srcs = False
         debuginfo_debugs = False
 
-        if not doc_files:
+        if not lib_package and not doc_files:
             self.output.add_info('W', pkg, 'no-documentation')
 
         if files:


### PR DESCRIPTION
Do not report no-documentation for library packages.