### PR TITLE
Separate PkgConfigCheck to methods

### DIFF
--- a/rpmlint/checks/PkgConfigCheck.py
+++ b/rpmlint/checks/PkgConfigCheck.py
@@ -5,13 +5,16 @@ from rpmlint.checks.AbstractCheck import AbstractFilesCheck
 
 
 class PkgConfigCheck(AbstractFilesCheck):
+    """
+    Validate that .pc files are correct.
+    """
     suspicious_dir = re.compile(r'[=:](?:/usr/src/\w+/BUILD|/var/tmp|/tmp|/home)')
 
     def __init__(self, config, output):
         super().__init__(config, output, r'.*/pkgconfig/.*\.pc$')
 
     def check(self, pkg):
-        # check for references to /lib when in lib64 mode
+        # check for references to /lib when in lib64 mode and vice versa
         if pkg.arch in ('x86_64', 'ppc64', 's390x', 'aarch64'):
             self.wronglib_dir = re.compile(r'-L/usr/lib\b')
         else:
@@ -23,15 +26,40 @@ class PkgConfigCheck(AbstractFilesCheck):
         if pkg.isSource() or not stat.S_ISREG(pkg.files()[filename].mode):
             return
 
-        if pkg.grep(self.suspicious_dir, filename):
-            self.output.add_info('E', pkg, 'invalid-pkgconfig-file', filename)
-
         try:
             pc_file = open(pkg.dirName() + '/' + filename, 'r', encoding='utf-8')
-            for l in pc_file:
-                if l.startswith('Libs:') and self.wronglib_dir.search(l):
-                    self.output.add_info('E', pkg, 'pkgconfig-invalid-libs-dir', filename, l)
-                if '//' in l and '://' not in l:
-                    self.output.add_info('E', pkg, 'double-slash-in-pkgconfig-path', filename, l)
+            for line in pc_file:
+                self._check_invalid_pkgconfig_file(pkg, filename, line)
+                self._check_invalid_libs_dir(pkg, filename, line)
+                self._check_double_slash(pkg, filename, line)
         except Exception as e:
             self.output.add_info('E', pkg, 'pkgconfig-exception', filename, str(e))
+
+    def _check_invalid_pkgconfig_file(self, pkg, filename, line):
+        """
+        Check that .pc file is valid (it runs various checks).
+
+        E.g. it doesn't contain traces of $RPM_BUILD_ROOT or $RPM_BUILD_DIR,
+        unreplaced macros or invalid paths.
+        """
+        if self.suspicious_dir.search(line):
+            self.output.add_info('E', pkg, 'invalid-pkgconfig-file', filename)
+
+    def _check_invalid_libs_dir(self, pkg, filename, line):
+        """
+        Check that .pc file contains correct libs dir based on the build
+        target (32-bit, 64-bit).
+
+        That means:
+         -L/usr/lib or -L/lib for 32-bit,
+         -L/usr/lib64 or -L/lib64 for 64-bit
+        """
+        if line.startswith('Libs:') and self.wronglib_dir.search(line):
+            self.output.add_info('E', pkg, 'pkgconfig-invalid-libs-dir', filename, line)
+
+    def _check_double_slash(self, pkg, filename, line):
+        """
+        Check that .pc file doesn't contain a path with a double slash ('//')
+        """
+        if '//' in line and '://' not in line:
+            self.output.add_info('E', pkg, 'double-slash-in-pkgconfig-path', filename, line)

--- a/rpmlint/descriptions/PkgConfigCheck.toml
+++ b/rpmlint/descriptions/PkgConfigCheck.toml
@@ -2,15 +2,19 @@ invalid-pkgconfig-file="""
 Your .pc file appears to be invalid. Possible causes are:
 - it contains traces of $RPM_BUILD_ROOT or $RPM_BUILD_DIR.
 - it contains unreplaced macros (@have_foo@)
-- it references invalid paths (e.g. /home or /tmp)"""
+- it references invalid paths (e.g. /home or /tmp)
+"""
 pkgconfig-invalid-libs-dir="""
 Your .pc file contains -L/usr/lib or -L/lib and is
 built on a lib64 target, or contains references to -L/usr/lib64 or
--L/lib64 and is built for a lib target."""
+-L/lib64 and is built for a lib target.
+"""
 double-slash-in-pkgconfig-path="""
-This pkg-config file contains a path with double slash ('//') in it. This
+This pkg-config file contains a path with a double slash ('//') in it. This
 will break debugedit when stripping debug symbols during package building if
-these paths has been passed to gcc, and fail with the following error:
-canonicalization unexpectedly shrank by one character."""
+these paths have been passed to gcc, and fail with the following error:
+canonicalization unexpectedly shrank by one character.
+"""
 pkgconfig-exception="""
-An exception during parsing of .pc file has occurred."""
+An exception during parsing of .pc file has occurred.
+"""

--- a/test/test_pkgconfig.py
+++ b/test/test_pkgconfig.py
@@ -21,3 +21,13 @@ def test_pkg_config(tmpdir, package, pkgconfigcheck):
     assert 'E: invalid-pkgconfig-file /tmp/pkgconfig/xcb.pc' in out
     assert 'E: pkgconfig-invalid-libs-dir /tmp/pkgconfig/xcb.pc Libs: -L/usr/lib' in out
     assert 'E: double-slash-in-pkgconfig-path /tmp/pkgconfig/xcb.pc includedir=/usr/include//xyz' in out
+
+
+@pytest.mark.parametrize('package', ['binary/libreiserfscore-devel'])
+def test_pkg_config_correct(tmpdir, package, pkgconfigcheck):
+    output, test = pkgconfigcheck
+    test.check(get_tested_package(package, tmpdir))
+    out = output.print_results(output.results)
+    assert 'E: invalid-pkgconfig-file' not in out
+    assert 'E: pkgconfig-invalid-libs-dir' not in out
+    assert 'E: double-slash-in-pkgconfig-path' not in out


### PR DESCRIPTION
Separate the check_file() method to multiple methods, add comments and
clean up the code. Also use binary/libreiserfscore-devel-3.6.27-0.x86_64.rpm
package that contains a correct .pc file for testing that the check
doesn't print errors where it's not supposed to print.

(#225 #156)