### PR TITLE
Small cleanup, comments and .toml rename

### DIFF
--- a/rpmlint/checks/BuildDateCheck.py
+++ b/rpmlint/checks/BuildDateCheck.py
@@ -6,16 +6,19 @@ from rpmlint.checks.AbstractCheck import AbstractFilesCheck
 
 
 class BuildDateCheck(AbstractFilesCheck):
+    """
+    Check that the file doesn't contain the current date or time.
+
+    If so, it causes the package to rebuild when it's not needed.
+    """
     def __init__(self, config, output):
         super().__init__(config, output, r'.*')
         self.looksliketime = re.compile('(2[0-3]|[01]?[0-9]):([0-5]?[0-9]):([0-5]?[0-9])')
         self.istoday = re.compile(time.strftime('%b %e %Y'))
 
     def check_file(self, pkg, filename):
-        if filename.startswith('/usr/lib/debug') or pkg.isSource():
-            return
-
-        if not stat.S_ISREG(pkg.files()[filename].mode):
+        if filename.startswith('/usr/lib/debug') or pkg.isSource() or \
+                not stat.S_ISREG(pkg.files()[filename].mode):
             return
 
         grep_date = pkg.grep(self.istoday, filename)

--- a/rpmlint/descriptions/BuildDateCheck.toml
+++ b/rpmlint/descriptions/BuildDateCheck.toml
@@ -1,6 +1,8 @@
 file-contains-current-date="""
 Your file contains the current date, this may cause the package
-to rebuild in excess."""
+to rebuild in excess.
+"""
 file-contains-date-and-time="""
-Your file uses  __DATE__ and __TIME__ this causes the package to
-rebuild when not needed."""
+Your file uses __DATE__ and __TIME__ which causes the package to
+rebuild when not needed.
+"""

--- a/test/test_build_date.py
+++ b/test/test_build_date.py
@@ -23,3 +23,13 @@ def test_build_date_time(tmpdir, package, builddatecheck):
     out = output.print_results(output.results)
     assert 'E: file-contains-date-and-time /bin/with-datetime' in out
     assert 'E: file-contains-current-date /bin/with-date' in out
+
+
+@pytest.mark.parametrize('package', ['binary/bashisms'])
+def test_build_date_time_correct(tmpdir, package, builddatecheck):
+    output, test = builddatecheck
+    test.istoday = re.compile('Jan  1 2019')
+    test.check(get_tested_package(package, tmpdir))
+    out = output.print_results(output.results)
+    assert 'E: file-contains-date-and-time' not in out
+    assert 'E: file-contains-current-date' not in out


### PR DESCRIPTION
Rename CheckBuildDate.toml to BuildDateCheck.toml so it corresponds
with the check name. Also, add a test case that tests if it doesn't
print errors when it shouldn't.