### PR TITLE
Rename ExecDocCheck to DocCheck

### DIFF
--- a/rpmlint/checks/DocCheck.py
+++ b/rpmlint/checks/DocCheck.py
@@ -4,22 +4,30 @@ import stat
 from rpmlint.checks.AbstractCheck import AbstractCheck
 
 
-class ExecDocCheck(AbstractCheck):
-    @staticmethod
-    def ignore_pkg(name):
-        if name.startswith('bundle-') or '-devel' in name or '-doc' in name:
-            return True
-        return False
+class DocCheck(AbstractCheck):
+    """
+    Checks for package documentation.
+    """
 
     def check(self, pkg):
         if pkg.isSource():
             return
 
         self._check_executable_docs(pkg)
-        if not self.ignore_pkg(pkg.name):
+        if not self._ignore_pkg(pkg.name):
             self._check_huge_docs(pkg)
 
+    @staticmethod
+    def _ignore_pkg(name):
+        if name.startswith('bundle-') or '-devel' in name or '-doc' in name:
+            return True
+        return False
+
     def _check_executable_docs(self, pkg):
+        """
+        Check if the documentation in the package is executable and print an
+        error if it is.
+        """
         files = pkg.files()
         for f in pkg.docFiles():
             mode = files[f].mode
@@ -35,6 +43,10 @@ class ExecDocCheck(AbstractCheck):
                     self.output.add_info('E', pkg, 'executable-docs', f)
 
     def _check_huge_docs(self, pkg):
+        """
+        Check the size of the documentation in the package and print a warning
+        if it's more than half of the size of the package.
+        """
         files = pkg.files()
         complete_size = 0
         for _, pkgfile in files.items():

--- a/rpmlint/configdefaults.toml
+++ b/rpmlint/configdefaults.toml
@@ -9,7 +9,7 @@ Checks = [
     "DistributionCheck",
     "DocFilesCheck",
     'DuplicatesCheck',
-    "ExecDocCheck",
+    "DocCheck",
     "FHSCheck",
     "FilesCheck",
     "IconSizesCheck",

--- a/rpmlint/descriptions/DocCheck.toml
+++ b/rpmlint/descriptions/DocCheck.toml
@@ -1,0 +1,7 @@
+executable-docs="""
+Documentation should not be executable.
+"""
+package-with-huge-docs="""
+More than half the size of your package is documentation.
+Consider splitting it into a -doc subpackage.
+"""

--- a/rpmlint/descriptions/ExecDocCheck.toml
+++ b/rpmlint/descriptions/ExecDocCheck.toml
@@ -1,8 +1,0 @@
-executable-docs="""
-Documentation should not be executable."""
-package-with-huge-docs="""
-More than half the size of your package is documentation.
-Consider splitting it into a -doc subpackage."""
-package-with-huge-translation="""
-More than half the size of your package is language-specific.
-Consider splitting it into a -lang subpackage."""

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -1,21 +1,21 @@
 import pytest
-from rpmlint.checks.ExecDocCheck import ExecDocCheck
+from rpmlint.checks.DocCheck import DocCheck
 from rpmlint.filter import Filter
 
 from Testing import CONFIG, get_tested_package
 
 
 @pytest.fixture(scope='function', autouse=True)
-def execdoccheck():
+def doccheck():
     CONFIG.info = True
     output = Filter(CONFIG)
-    test = ExecDocCheck(CONFIG, output)
+    test = DocCheck(CONFIG, output)
     return output, test
 
 
 @pytest.mark.parametrize('package', ['binary/mydoc'])
-def test_bashisms(tmpdir, package, execdoccheck):
-    output, test = execdoccheck
+def test_doccheck(tmpdir, package, doccheck):
+    output, test = doccheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     assert 'E: executable-docs /usr/share/doc/packages/mydoc/doc.html' in out

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -26,7 +26,7 @@ basic_tests = [
     'DistributionCheck',
     'DocFilesCheck',
     'DuplicatesCheck',
-    'ExecDocCheck',
+    'DocCheck',
     'FHSCheck',
     'FilesCheck',
     'IconSizesCheck',


### PR DESCRIPTION
Rename as it's no longer just a check that searches for the
executable documentation.

Add comments, rename test method (typo) and remove
"package-with-huge-translation" from .toml as it's not used anymore.