### PR TITLE
Generate information header prior running the rpmlint wrt issue #38

### DIFF
--- a/rpmlint/color.py
+++ b/rpmlint/color.py
@@ -1,0 +1,20 @@
+import sys
+
+if hasattr(sys.stderr, 'isatty') and sys.stderr.isatty():
+    class Color(object):
+        """
+        Colors used when doing printouts with rpmlint
+        """
+        Bold = '\x1b[1m'
+        Red = '\x1b[31m'
+        Yellow = '\x1b[33m'
+        Reset = '\x1b[0m'
+else:
+    class Color(object):
+        """
+        Colors used when doing printouts with rpmlint
+        """
+        Bold = ''
+        Red = ''
+        Yellow = ''
+        Reset = ''

--- a/rpmlint/filter.py
+++ b/rpmlint/filter.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import re
 import textwrap
 
-from rpmlint.helpers import print_warning
+from rpmlint.helpers import Color, print_warning
 import toml
 
 
@@ -72,6 +72,13 @@ class Filter(object):
         # as an error
         if self.strict:
             level = 'E'
+        # set coloring
+        if level == 'E':
+            lvl_color = Color.Red
+        elif level == 'W':
+            lvl_color = Color.Yellow
+        else:
+            lvl_color = Color.Bold
         # raise the counters
         self.score += badness
         self.printed_messages[level] += 1
@@ -83,7 +90,7 @@ class Filter(object):
         for detail in details:
             if detail:
                 detail_output += f' {detail}'
-        result = f'{filename}{arch}:{line} {level}: {reason}'
+        result = f'{Color.Bold}{filename}{arch}:{line}{Color.Reset} {lvl_color}{level}: {reason}{Color.Reset}'
         result += bad_output
         result += detail_output
         self.results.append(result)

--- a/rpmlint/filter.py
+++ b/rpmlint/filter.py
@@ -2,7 +2,8 @@ from pathlib import Path
 import re
 import textwrap
 
-from rpmlint.helpers import Color, print_warning
+from rpmlint.color import Color
+from rpmlint.helpers import print_warning
 import toml
 
 

--- a/rpmlint/helpers.py
+++ b/rpmlint/helpers.py
@@ -3,12 +3,7 @@
 from shutil import get_terminal_size
 import sys
 
-
-class Color:
-    Bold = '\x1b[1m'
-    Red = '\x1b[31m'
-    Yellow = '\x1b[33m'
-    Reset = '\x1b[0m'
+from rpmlint.color import Color
 
 
 def string_center(message, filler=' '):

--- a/rpmlint/helpers.py
+++ b/rpmlint/helpers.py
@@ -1,13 +1,36 @@
 # File containing various helper functions used across rpmlint
 
+from shutil import get_terminal_size
 import sys
+
+
+class Color:
+    Bold = '\x1b[1m'
+    Red = '\x1b[31m'
+    Yellow = '\x1b[33m'
+    Reset = '\x1b[0m'
+
+
+def string_center(message, filler=' '):
+    """
+    Create string centered of the terminal
+    """
+    cols, rows = get_terminal_size()
+    return (f' {message} ').center(cols, filler)
+
+
+def print_centered(message, filler=' '):
+    """
+    Print message in the center of a terminal
+    """
+    print(string_center(message, filler))
 
 
 def print_warning(message):
     """
     Print warning message to stderr.
     """
-    print(message, file=sys.stderr)
+    print(f'{Color.Red}{message}{Color.Reset}', file=sys.stderr)
 
 
 def byte_to_string(item):

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -5,6 +5,7 @@ from rpmlint.config import Config
 from rpmlint.filter import Filter
 from rpmlint.helpers import print_warning
 from rpmlint.pkg import FakePkg, getInstalledPkgs, Pkg
+from rpmlint.version import __version__
 
 
 class Lint(object):
@@ -51,6 +52,32 @@ class Lint(object):
         # if no exclusive option is passed then just loop over all the
         # arguments that are supposed to be either rpm or spec files
         self.validate_files(self.options['rpmfile'])
+
+        # first generate header with generic information about what is being
+        # tested and run
+        print(f'rpmlint: {__version__}')
+        configs = ', '.join(str(x) for x in self.config.conf_files)
+        print(f'configuration: {configs}')
+        if self.options['rpmlintrc']:
+            rpmlintrc = self.options['rpmlintrc']
+            print(f'rpmlintrc: {rpmlintrc}')
+        # display list of checks and list of files to test in verbose mode
+        if self.config.info:
+            checks = ', '.join(str(x) for x in self.config.configuration['Checks'])
+            print(f'checks: {checks}')
+            pkgs = ''
+            pkgs_installed = ', '.join(str(x) for x in self.options['installed'])
+            if pkgs_installed:
+                pkgs = pkgs_installed
+            pkgs_files = ', '.join(str(x) for x in self.options['rpmfile'])
+            if pkgs_files:
+                join = ''
+                if pkgs_installed:
+                    join = ', '
+                pkgs = pkgs + join + pkgs_files
+            print(f'packages: {pkgs}')
+        print('')
+        print('')
         print(self.output.print_results(self.output.results))
         print('{} packages and {} specfiles checked; {} errors, {} warnings'.format(self.packages_checked, self.specfiles_checked, self.output.printed_messages['E'], self.output.printed_messages['W']))
         if self.output.badness_threshold > 0 and self.output.score > self.output.badness_threshold:

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -1,9 +1,10 @@
 import importlib
 from tempfile import gettempdir
 
+from rpmlint.color import Color
 from rpmlint.config import Config
 from rpmlint.filter import Filter
-from rpmlint.helpers import Color, print_warning, string_center
+from rpmlint.helpers import print_warning, string_center
 from rpmlint.pkg import FakePkg, getInstalledPkgs, Pkg
 from rpmlint.version import __version__
 

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -64,7 +64,7 @@ class Lint(object):
             print(f'{Color.Red}{msg}{Color.Reset}')
             quit_color = Color.Red
             retcode = 66
-        if self.output.printed_messages['E'] > 0:
+        elif self.output.printed_messages['E'] > 0:
             quit_color = Color.Red
             retcode = 64
         msg = string_center('{} packages and {} specfiles checked; {} errors, {} warnings'.format(self.packages_checked, self.specfiles_checked, self.output.printed_messages['E'], self.output.printed_messages['W']), '=')

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -29,3 +29,15 @@ def test_bytetostr():
     result = helpers.byte_to_string(list_items)
     assert isinstance(result, list)
     assert result[0] == 'žížala'
+
+
+def test_centering(capsys):
+    """
+    Check wether centered print works
+    """
+
+    message = 'Hello there'
+    helpers.print_centered(message, '*')
+    out, err = capsys.readouterr()
+    assert f'** Hello there **' in out
+    assert not err

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -169,7 +169,6 @@ def test_run_installed_and_no_files(capsys):
     additional_options = {
         'rpmfile': [],
         'installed': ['python3-rpm'],
-        'verbose': True,
     }
     options = {**options_preset, **additional_options}
     linter = Lint(options)
@@ -177,6 +176,18 @@ def test_run_installed_and_no_files(capsys):
     out, err = capsys.readouterr()
     assert '1 packages and 0 specfiles checked' in out
     assert not err
+
+
+def test_header_information(capsys):
+    additional_options = {
+        'rpmfile': [],
+        'installed': ['python3-rpm'],
+    }
+    options = {**options_preset, **additional_options}
+    linter = Lint(options)
+    linter.run()
+    out, err = capsys.readouterr()
+    assert 'packages: 1' in out
 
 
 @pytest.mark.parametrize('packages', [list(Path('test').glob('*/*.rpm'))])

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -10,10 +10,10 @@ options_preset = {
     'verbose': False,
     'strict': False,
     'print_config': False,
-    'explain': False,
-    'rpmfile': False,
+    'explain': '',
+    'rpmfile': '',
     'rpmlintrc': False,
-    'installed': False,
+    'installed': '',
 }
 
 basic_tests = [

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -169,6 +169,7 @@ def test_run_installed_and_no_files(capsys):
     additional_options = {
         'rpmfile': [],
         'installed': ['python3-rpm'],
+        'verbose': True,
     }
     options = {**options_preset, **additional_options}
     linter = Lint(options)


### PR DESCRIPTION
It prints out version and configs/rpmlintrc everytime.
And in verbose mode it prints out the loaded checks and requested files.