### PR TITLE
Separate to two try blocks

### DIFF
--- a/rpmlint/checks/BashismsCheck.py
+++ b/rpmlint/checks/BashismsCheck.py
@@ -21,7 +21,10 @@ class BashismsCheck(AbstractFilesCheck):
             r = subprocess.run(['dash', '-n', fullpath])
             if r.returncode == 2:
                 self.output.add_info('W', pkg, 'bin-sh-syntax-error', filename)
+        except (FileNotFoundError, UnicodeDecodeError):
+            pass
 
+        try:
             r = subprocess.run(['checkbashisms', fullpath])
             if r.returncode == 1:
                 self.output.add_info('W', pkg, 'potential-bashisms', filename)


### PR DESCRIPTION
If we have just one block we would always need both checkbashism
and dash.
This way we are fine with just the one needed for the warning to
be around