### PR TITLE
Fix --rpmlintrc "user specified rpmlintrc" check

### DIFF
--- a/rpmlint/__init__.py
+++ b/rpmlint/__init__.py
@@ -102,7 +102,7 @@ def process_lint_args(argv):
             exit(2)
     # make sure rpmlintrc exists
     if options.rpmlintrc:
-        if options.rpmlintrc.exists():
+        if not options.rpmlintrc.exists():
             print_warning(f"User specified rpmlintrc '{options.rpmlintrc}' does not exist")
             exit(2)
     # validate all the rpmlfile options to be either file or folder


### PR DESCRIPTION
The warning should be issued if *not* Path.exists()