### PR TITLE
Add option to only return error when badness threshold is exceeded

### DIFF
--- a/rpmlint/__init__.py
+++ b/rpmlint/__init__.py
@@ -87,7 +87,9 @@ def process_lint_args(argv):
     parser.add_argument('-V', '--verbose', action='store_true', help='provide detailed explanations where available')
     parser.add_argument('-p', '--print-config', action='store_true', help='print the settings that are in effect when using the rpmlint')
     parser.add_argument('-i', '--installed', nargs='+', default='', help='installed packages to be validated by rpmlint')
-    parser.add_argument('-s', '--strict', action='store_true', help='treat all messages as errors')
+    lint_modes_parser = parser.add_mutually_exclusive_group()
+    lint_modes_parser.add_argument('-s', '--strict', action='store_true', help='treat all messages as errors')
+    lint_modes_parser.add_argument('-P', '--permissive', action='store_true', help='treat individual errors as non-fatal')
 
     # print help if there is no argument
     if len(argv) < 1:

--- a/rpmlint/config.py
+++ b/rpmlint/config.py
@@ -29,6 +29,8 @@ class Config(object):
         self.info = False
         # wether to treat all messages as errors or not
         self.strict = False
+        # whether to treat individual errors as non-fatal
+        self.permissive = False
         self.find_configs(config)
         self.load_config()
         # loading of the configuration failed fall back only to defaults

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -29,6 +29,8 @@ class Lint(object):
             self.config.info = options['verbose']
         if options['strict']:
             self.config.strict = options['strict']
+        if options['permissive']:
+            self.config.permissive = options['permissive']
         if not self.config.configuration['ExtractDir']:
             self.config.configuration['ExtractDir'] = gettempdir()
         # initialize output buffer
@@ -63,7 +65,7 @@ class Lint(object):
             print(f'{Color.Red}{msg}{Color.Reset}')
             quit_color = Color.Red
             retcode = 66
-        elif self.output.printed_messages['E'] > 0:
+        elif self.output.printed_messages['E'] > 0 and not self.config.permissive:
             quit_color = Color.Red
             retcode = 64
         msg = string_center('{} packages and {} specfiles checked; {} errors, {} warnings'.format(self.packages_checked, self.specfiles_checked, self.output.printed_messages['E'], self.output.printed_messages['W']), '=')

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -9,6 +9,7 @@ options_preset = {
     'config': TEST_CONFIG,
     'verbose': False,
     'strict': False,
+    'permissive': False,
     'print_config': False,
     'explain': '',
     'rpmfile': '',


### PR DESCRIPTION
When rpmlint is configured for mandatory tests in package builds, it is desirable to allow rpmlint to "pass" the build unless the the badness threshold has been exceeded, even with errors.

This option permits this behavior for this circumstance.