### PR TITLE
Add dependency on RPM Python bindings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
 
     install_requires=[
         'pyxdg',
+        'rpm',
         'toml',
     ],
     tests_require=[


### PR DESCRIPTION
RPMLint heavily leverages the RPM Python bindings in order to function properly. As those bindings are shipped with Python metadata, we can and should declare the dependency properly.