### PR TITLE
Rename CheckForXinetd to XinetdDepCheck

### DIFF
--- a/rpmlint/checks/XinetdDepCheck.py
+++ b/rpmlint/checks/XinetdDepCheck.py
@@ -1,7 +1,7 @@
 from rpmlint.checks.AbstractCheck import AbstractCheck
 
 
-class CheckForXinetd(AbstractCheck):
+class XinetdDepCheck(AbstractCheck):
     def check(self, pkg):
         if pkg.is_source:
             return

--- a/test/test_xinetd.py
+++ b/test/test_xinetd.py
@@ -1,5 +1,5 @@
 import pytest
-from rpmlint.checks.CheckForXinetd import CheckForXinetd
+from rpmlint.checks.XinetdDepCheck import XinetdDepCheck
 from rpmlint.filter import Filter
 
 from Testing import CONFIG, get_tested_package
@@ -9,7 +9,7 @@ from Testing import CONFIG, get_tested_package
 def xinetdcheck():
     CONFIG.info = True
     output = Filter(CONFIG)
-    test = CheckForXinetd(CONFIG, output)
+    test = XinetdDepCheck(CONFIG, output)
     return output, test
 
 


### PR DESCRIPTION
This more accurately represents what the check contains
and follows the same naming convention as the rest of the
checks.

Fixes #399 