### PR TITLE
Change cron dependency check to require crontabs

### DIFF
--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -563,8 +563,8 @@ class FilesCheck(AbstractCheck):
             if res and not ('logrotate' in deps) and pkg.name != 'logrotate':
                 self.output.add_info('E', pkg, 'missing-dependency-to-logrotate', 'for logrotate script', f)
             if f.startswith('/etc/cron.') \
-               and not ('cron' in deps) and pkg.name != 'cron':
-                self.output.add_info('E', pkg, 'missing-dependency-to-cron', 'for cron script', f)
+               and not ('crontabs' in deps) and pkg.name != 'crontabs':
+                self.output.add_info('E', pkg, 'missing-dependency-to-crontabs', 'for cron script', f)
             if f.startswith('/etc/xinet.d/') \
                and not ('xinetd' in deps) and pkg.name != 'xinetd':
                 self.output.add_info('E', pkg, 'missing-dependency-to-xinetd', 'for xinet.d script', f)

--- a/rpmlint/descriptions/FilesCheck.toml
+++ b/rpmlint/descriptions/FilesCheck.toml
@@ -297,11 +297,11 @@ consequences), or other compiler flags which result in rpmbuild's debuginfo
 extraction not working as expected. Verify that the binaries are not
 unexpectedly stripped and that the intended compiler flags are used.
 """
-missing-dependency-to-cron="""
+missing-dependency-to-crontabs="""
 This package installs a file in /etc/cron.*/ but
-doesn't require cron to be installed. as cron is not part of the essential packages,
-your package should explicitely require cron to make sure that your cron job is
-executed. If it is an optional feature of your package, recommend or suggest cron.
+doesn't require crontabs to be installed. As crontabs is not part of the essential packages,
+your package should explicitely require crontabs to make sure that your cron job is
+executed. If it is an optional feature of your package, recommend or suggest crontabs.
 """
 missing-dependency-to-logrotate="""
 This package installs a file in /etc/logrotate.d/ but


### PR DESCRIPTION
In most distributions, the correct thing to do for packaging
cron jobs is to require `crontabs`, which provides merely the
cron job directory tree skeleton.

Fixes #401.