### PR TITLE
setuptools: Remove remaining import loop in the code

### DIFF
--- a/rpmlint/version.py
+++ b/rpmlint/version.py
@@ -1,1 +1,6 @@
-__version__ = '2.0.0'
+try:
+    from importlib.metadata import version as implib_metadata_version
+except ImportError:
+    from importlib_metadata import version as implib_metadata_version
+
+__version__ = implib_metadata_version('rpmlint')

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from rpmlint.version import __version__
 from setuptools import setup
 
 
@@ -10,7 +9,7 @@ setup(
     url='https://github.com/rpm-software-management/rpmlint',
     download_url='https://github.com/rpm-software-management/rpmlint',
 
-    version=__version__,
+    version='2.0.0',
 
     author='Frédéric Lepied',
     author_email='flepied@mandriva.com',
@@ -42,6 +41,7 @@ setup(
         'pyxdg',
         'rpm',
         'toml',
+        'importlib-metadata;python_version<"3.8"',
     ],
     tests_require=[
         'pytest',

--- a/test/Dockerfile-fedora31
+++ b/test/Dockerfile-fedora31
@@ -21,6 +21,7 @@ RUN dnf --nogpgcheck -y install \
         glibc \
         hunspell-en \
         hunspell-cs \
+        python3-importlib-metadata \
         python3-setuptools \
         python3-enchant \
         python3-magic \

--- a/test/Dockerfile-opensuselp15
+++ b/test/Dockerfile-opensuselp15
@@ -10,6 +10,7 @@ RUN zypper -n install \
         python3-pyenchant \
         python3-rpm \
         python3-base \
+        python3-importlib-metadata \
         python3-setuptools \
         python3-pybeam \
         python3-pytest \


### PR DESCRIPTION
This change eliminates the final import loop that made it difficult
to install rpmlint from PyPI, as now we have no implicit self dependencies
that turns all our runtime dependencies into build-time dependencies.