### PR TITLE
 Modify no-changelogname-tag toml

### DIFF
--- a/rpmlint/descriptions/TagsCheck.toml
+++ b/rpmlint/descriptions/TagsCheck.toml
@@ -71,7 +71,8 @@ There is no Group tag in your package. You have to specify a valid group
 in your spec file using the Group tag.
 """
 no-changelogname-tag="""
- There is no %changelog tag in your spec file(or it's empty). To fix it, please insert a '%changelog' section in your spec file and add a entry change below it.
+There is no %changelog tag in your spec file(or it's empty). To fix it, 
+please insert a '%changelog' section in your spec file and add a entry change below it.
 """
 no-version-in-last-changelog="""
 The latest changelog entry doesn't contain a version. Please insert the

--- a/rpmlint/descriptions/TagsCheck.toml
+++ b/rpmlint/descriptions/TagsCheck.toml
@@ -71,8 +71,7 @@ There is no Group tag in your package. You have to specify a valid group
 in your spec file using the Group tag.
 """
 no-changelogname-tag="""
-There is no %changelog tag in your spec file. To insert it, just insert a
-'%changelog' in your spec file and rebuild it.
+ There is no %changelog tag in your spec file(or it's empty). To fix it, please insert a '%changelog' section in your spec file and add a entry change below it.
 """
 no-version-in-last-changelog="""
 The latest changelog entry doesn't contain a version. Please insert the


### PR DESCRIPTION
This commit contains,
- Modified no-changelogname-tag toml

- Reason:
    The check is triggered when either the %changelog is empty or
    %changelog tag is not present.

- Tested with:
    (error in stdout)
        - invalid-version-0pre-3.1.x86_64.rpm (no %changelog section)
        - invalid-dependency-0-0.x86_64.rpm (empty %changelog section)
    (error not in stdout)
        - hello-2.0-1.x86_64-signed.rpm (non-empty %changelog section)