### PR TITLE
Fix non-coherent-filename check in TagsCheck.py

### DIFF
--- a/rpmlint/checks/TagsCheck.py
+++ b/rpmlint/checks/TagsCheck.py
@@ -442,7 +442,7 @@ class TagsCheck(AbstractCheck):
             # as arch for source packages, do it ourselves
             expfmt = re.sub(r'(?i)%\{?ARCH\b\}?', pkg.arch, expfmt)
         expected = pkg.header.sprintf(expfmt).split('/')[-1]
-        basename = Path(pkg.filename).parent
+        basename = Path(pkg.filename).name
         if basename != expected:
             self.output.add_info('W', pkg, 'non-coherent-filename', basename, expected)
 


### PR DESCRIPTION
This commit contains,
- Fixed non-coherent-filename check,
    - Path(pkg.filename).parent -> Path(pkg.filename).name
    - Detailed explanation: https://gist.github.com/thisisshub/7423c6a71d75f191ef6b5cf363f5d231