### PR TITLE
add support for ZSTD compressed files

### DIFF
--- a/rpmlint/checks/SourceCheck.py
+++ b/rpmlint/checks/SourceCheck.py
@@ -13,6 +13,7 @@ class SourceCheck(AbstractCheck):
         'gz': 'gzip compressed',
         'tgz': 'gzip compressed',
         'bz2': 'bzip2 compressed',
+        'zst': 'ZSTD compressed',
     }
 
     def __init__(self, config, output):
@@ -59,7 +60,7 @@ class SourceCheck(AbstractCheck):
 
     def _check_compressed_source(self, fname, pkg):
         """
-        Check if the Source is compressed if CompressExtension configuration options is used (xz, gz, tgz or bz2).
+        Check if the Source is compressed if CompressExtension configuration options is used (gz, tgz, bz2, xz or zst).
         """
         if (self.source_regex.search(fname) and self.compress_ext and
                 not fname.endswith(self.compress_ext)):

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -63,7 +63,7 @@ RPM_SCRIPTLETS = ('pre', 'post', 'preun', 'postun', 'pretrans', 'posttrans',
 gzip_regex = re.compile(r'\.t?gz?$')
 bz2_regex = re.compile(r'\.t?bz2?$')
 xz_regex = re.compile(r'\.(t[xl]z|xz|lzma)$')
-
+zst_regex = re.compile(r'\.zst$')
 
 def catcmd(fname):
     """Get a 'cat' command that handles possibly compressed files."""
@@ -73,6 +73,8 @@ def catcmd(fname):
         cat = 'bzip2 -dcf'
     elif xz_regex.search(fname):
         cat = 'xz -dc'
+    elif zst_regex.search(fname):
+        cat = 'zstd -dc'
     return cat
 
 
@@ -85,6 +87,8 @@ def compression_algorithm(fname):
         return bz2
     elif xz_regex.search(fname):
         return lzma
+    elif zst_regex.search(fname):
+        return zstd
     else:
         return None
 


### PR DESCRIPTION
Handle CompressExtension with zst. These days distros are moving to Zstandard as default compression form RPM and other files.