### PR TITLE
Fix parsing of DanglingSymlinkExceptions.

### DIFF
--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -342,6 +342,8 @@ class FilesCheck(AbstractCheck):
         self.use_debugsource = self.config.configuration['UseDebugSource']
         self.games_group_regex = re.compile(self.config.configuration['RpmGamesGroup'])
         self.dangling_exceptions = self.config.configuration['DanglingSymlinkExceptions']
+        for item in self.dangling_exceptions.values():
+            item['path'] = re.compile(item['path'])
         self.module_rpms_ok = self.config.configuration['KernelModuleRPMsOK']
         self.python_default_version = self.config.configuration['PythonDefaultVersion']
         self.perl_version_trick = self.config.configuration['PerlVersionTrick']

--- a/rpmlint/configdefaults.toml
+++ b/rpmlint/configdefaults.toml
@@ -325,8 +325,8 @@ binaries = ['/usr/bin/launch_x11_clanapp', 'clanlib', 'libclanlib0']
 regexp = '(?:/usr/bin/)?soundwrapper'
 binaries = false
 
-# Exception list for dangling symlink checks.  The first in each pair
-# is a regexp, and the second the package in which the target of the
+# Exception list for dangling symlink checks.  The first in each pair ("path")
+# is a regexp, and the second ("name") the package in which the target of the
 # dangling symlink is shipped
 [DanglingSymlinkExceptions]
 


### PR DESCRIPTION
Document better `DanglingSymlinkExceptions` in `configdefaults.toml`.