### PR TITLE
Skip Go .gox files.

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -561,10 +561,10 @@ class BinariesCheck(AbstractCheck):
             self._check_binary_in_usr_share(pkg, fname)
             self._check_binary_in_etc(pkg, fname)
 
-            # skip the rest of the tests for ocaml native, bytecode, .o and
-            # .static
+            # skip the rest of the tests for ocaml native, Lua bytecode,
+            # Go .gox, .o and .static
             if is_ocaml_native or is_lua_bytecode or fname.endswith('.o') or \
-                    fname.endswith('.static'):
+                    fname.endswith('.static') or fname.endswith('.gox'):
                 continue
 
             self._check_unstripped_binary(fname, pkg, pkgfile)


### PR DESCRIPTION
The files are ELFs, but:

```
ldd palette.gox
ldd: warning: you do not have execution permission for `palette.gox'
	not a dynamic executable
```