### PR TITLE
Make output less verbose.

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -56,7 +56,8 @@ class Lint(object):
         # arguments that are supposed to be either rpm or spec files
         self.validate_files(self.options['rpmfile'])
         self._print_header()
-        print(self.output.print_results(self.output.results, self.config))
+        print(self.output.print_results(self.output.results, self.config),
+              end='')
         quit_color = Color.Bold
         if self.output.printed_messages['W'] > 0:
             quit_color = Color.Yellow
@@ -125,7 +126,6 @@ class Lint(object):
         no_pkgs = len(self.options['installed']) + len(self.options['rpmfile'])
         print(f'{Color.Bold}checks: {no_checks}, packages: {no_pkgs}{Color.Reset}')
         print('')
-        print('')
 
     def validate_installed_packages(self, packages):
         for pkg in packages:
@@ -165,7 +165,8 @@ class Lint(object):
     def validate_file(self, pname):
         try:
             if pname.suffix == '.rpm' or pname.suffix == '.spm':
-                with Pkg(pname, self.config.configuration['ExtractDir']) as pkg:
+                with Pkg(pname, self.config.configuration['ExtractDir'],
+                         verbose=self.config.info) as pkg:
                     self.run_checks(pkg)
             elif pname.suffix == '.spec':
                 with FakePkg(pname) as pkg:

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -383,10 +383,10 @@ class Pkg(AbstractPkg):
 
     _magic_from_compressed_re = re.compile(r'\([^)]+\s+compressed\s+data\b')
 
-    def __init__(self, filename, dirname, header=None, is_source=False, extracted=False):
+    def __init__(self, filename, dirname, header=None, is_source=False, extracted=False, verbose=False):
         self.filename = filename
         self.extracted = extracted
-        self.dirname = self.dir_name(dirname)
+        self.dirname = self.dir_name(dirname, verbose)
         self.current_linenum = None
 
         self._req_names = -1
@@ -459,11 +459,11 @@ class Pkg(AbstractPkg):
     def dirName(self):
         return self.dirname
 
-    def dir_name(self, dirname):
-        return self._extract(dirname)
+    def dir_name(self, dirname, verbose):
+        return self._extract(dirname, verbose)
 
     # extract rpm contents
-    def _extract(self, dirname):
+    def _extract(self, dirname, verbose):
         if not Path(dirname).is_dir():
             print_warning('Unable to access dir %s' % dirname)
         else:
@@ -477,7 +477,9 @@ class Pkg(AbstractPkg):
             command_str = \
                 'rpm2cpio %(f)s | cpio -id -D %(d)s ; chmod -R +rX %(d)s' % \
                 {'f': quote(str(self.filename)), 'd': quote(dirname)}
-            subprocess.run(command_str, shell=True, env=ENGLISH_ENVIROMENT)
+            stderr = None if verbose else subprocess.DEVNULL
+            subprocess.check_output(command_str, shell=True, env=ENGLISH_ENVIROMENT,
+                                    stderr=stderr)
             self.extracted = True
         return dirname
 


### PR DESCRIPTION
Decrease verbosity from:

```
3 blocks
============================================================================================================================ rpmlint session starts ============================================================================================================================
rpmlint: 2.0.0
configuration:
    /home/marxin/Programming/rpmlint/rpmlint/configdefaults.toml
checks: 26, packages: 1


...
audit-devel-32bit.x86_64: E: devel-dependency audit-devel

=========================================================================================================== 1 packages and 0 specfiles checked; 1 errors, 9 warnings ===========================================================================================================

```

to

```
============================================================================================================================ rpmlint session starts ============================================================================================================================
rpmlint: 2.0.0
configuration:
    /home/marxin/Programming/rpmlint/rpmlint/configdefaults.toml
checks: 26, packages: 1

...
audit-devel-32bit.x86_64: E: devel-dependency audit-devel
=========================================================================================================== 1 packages and 0 specfiles checked; 1 errors, 9 warnings ===========================================================================================================

```