### PR TITLE
BashismsCheck: do not print to stderr.

### DIFF
--- a/rpmlint/checks/BashismsCheck.py
+++ b/rpmlint/checks/BashismsCheck.py
@@ -29,14 +29,18 @@ class BashismsCheck(AbstractFilesCheck):
         potential bash issues.
         """
         try:
-            r = subprocess.run(['dash', '-n', filepath], env=ENGLISH_ENVIROMENT)
+            r = subprocess.run(['dash', '-n', filepath],
+                               stderr=subprocess.DEVNULL,
+                               env=ENGLISH_ENVIROMENT)
             if r.returncode == 2:
                 self.output.add_info('W', pkg, 'bin-sh-syntax-error', filename)
         except (FileNotFoundError, UnicodeDecodeError):
             pass
 
         try:
-            r = subprocess.run(['checkbashisms', filepath], env=ENGLISH_ENVIROMENT)
+            r = subprocess.run(['checkbashisms', filepath],
+                               stderr=subprocess.DEVNULL,
+                               env=ENGLISH_ENVIROMENT)
             if r.returncode == 1:
                 self.output.add_info('W', pkg, 'potential-bashisms', filename)
         except (FileNotFoundError, UnicodeDecodeError):


### PR DESCRIPTION
Silent the following output:

```
possible bashism in /tmp/rpmlint.aaa_base-extras-84.87+git20200918.331aa2f-1.1.x86_64.rpm.p8pucbpt/usr/lib/base-scripts/backup-sysconfig line 44 (type):
        if type -p tar &>/dev/null ; then
possible bashism in /tmp/rpmlint.aaa_base-extras-84.87+git20200918.331aa2f-1.1.x86_64.rpm.p8pucbpt/usr/lib/base-scripts/backup-sysconfig line 44 (should be >word 2>&1):
        if type -p tar &>/dev/null ; then
```