### PR TITLE
Allow spaces in .rpmlintrc files.

### DIFF
--- a/rpmlint/config.py
+++ b/rpmlint/config.py
@@ -19,8 +19,8 @@ class Config(object):
     existing one.
     """
 
-    re_filter = re.compile(r'\s*addFilter\([\"\'](.*)[\"\']\)')
-    re_badness = re.compile(r'\s*setBadness\([\'\"](.*)[\'\"],\s*[\'\"]?(\d+)[\'\"]?\)')
+    re_filter = re.compile(r'\s*addFilter\s*\([\"\'](.*)[\"\']\)')
+    re_badness = re.compile(r'\s*setBadness\s*\([\'\"](.*)[\'\"],\s*[\'\"]?(\d+)[\'\"]?\)')
     config_defaults = Path(__file__).parent / 'configdefaults.toml'
 
     def __init__(self, config=None):

--- a/test/configs/testing-rpmlintrc
+++ b/test/configs/testing-rpmlintrc
@@ -2,6 +2,7 @@
 from Config import *
 setBadness('suse-dbus-unauthorized-service', 0)
     setBadness('suse-other-error','20')
+setBadness      ('suse-other-error-123','200')
 # # Output filters
 addFilter("arch-independent-package-contains-binary-or-object ")
 addFilter('.*arch-independent-package-contains-binary-or-object.*/boot/vc/.*.elf')

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -132,5 +132,5 @@ def test_rpmlint_loading():
     """
     cfg = Config(TEST_CONFIG)
     cfg.load_rpmlintrc(TEST_RPMLINTRC)
-    assert len(cfg.configuration['Filters']) == 109
-    assert len(cfg.configuration['Scoring']) == 2
+    assert len(cfg.configuration['Filters']) == 110
+    assert len(cfg.configuration['Scoring']) == 3


### PR DESCRIPTION
Allow the following:
```
addFilter ("gcc.*devel-dependency libstdc")
```