### PR TITLE
Fix typo in Dockerfile for fedoradev.

### DIFF
--- a/test/Dockerfile-fedoradev
+++ b/test/Dockerfile-fedoradev
@@ -15,7 +15,7 @@ RUN dnf --nogpgcheck -y install \
         dash \
         devscripts-checkbashisms \
         glibc \
-        glibc.i386 \
+        glibc.i686 \
         hunspell-en \
         hunspell-cs \
         python3-setuptools \


### PR DESCRIPTION
Replace glibc.i386 by glibc.i686.