### PR TITLE
Do not run ldd for statically linked binaries.

### DIFF
--- a/rpmlint/arparser.py
+++ b/rpmlint/arparser.py
@@ -1,0 +1,24 @@
+import subprocess
+
+from rpmlint.helpers import ENGLISH_ENVIROMENT
+
+
+class ArParser:
+    """
+    Class contains all information obtained by ar command.
+    """
+
+    def __init__(self, pkgfile_path):
+        self.pkgfile_path = pkgfile_path
+        self.objects = []
+        self.parsing_failed_reason = None
+        self.parse()
+
+    def parse(self):
+        r = subprocess.run(['ar', 't', self.pkgfile_path], encoding='utf8',
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=ENGLISH_ENVIROMENT)
+        if r.returncode != 0:
+            self.parsing_failed_reason = r.stderr
+            return
+
+        self.objects = r.stdout.splitlines()

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -365,6 +365,18 @@ def parse_deps(line):
     return prcos
 
 
+def get_magic(path):
+    # file() method evaluates every file twice with python2,
+    # use descriptor() method instead
+    try:
+        fd = os.open(path, os.O_RDONLY)
+        magic = byte_to_string(_magic.descriptor(fd))
+        os.close(fd)
+        return magic
+    except OSError:
+        return ''
+
+
 # classes representing package
 
 class AbstractPkg(object):
@@ -579,14 +591,7 @@ class Pkg(AbstractPkg):
                         pkgfile.magic = 'empty'
                 if (not pkgfile.magic and
                         not pkgfile.is_ghost and _magic):
-                    # file() method evaluates every file twice with python2,
-                    # use descriptor() method instead
-                    try:
-                        fd = os.open(pkgfile.path, os.O_RDONLY)
-                        pkgfile.magic = byte_to_string(_magic.descriptor(fd))
-                        os.close(fd)
-                    except OSError:
-                        pass
+                    pkgfile.magic = get_magic(pkgfile.path)
                 if pkgfile.magic is None:
                     pkgfile.magic = ''
                 elif Pkg._magic_from_compressed_re.search(pkgfile.magic):

--- a/test/test_ldd_parser.py
+++ b/test/test_ldd_parser.py
@@ -4,7 +4,7 @@ import pytest
 from rpmlint.checks.BinariesCheck import BinariesCheck
 from rpmlint.filter import Filter
 from rpmlint.lddparser import LddParser
-from rpmlint.pkg import FakePkg
+from rpmlint.pkg import FakePkg, get_magic
 
 from Testing import CONFIG, get_tested_path
 
@@ -25,6 +25,11 @@ def lddparser(path, system_path=None):
     if system_path is None:
         system_path = path
     return LddParser(get_full_path(path), system_path)
+
+
+def run_elf_checks(test, pkg, fullpath, path):
+    test._detect_attributes(get_magic(fullpath))
+    test.run_elf_checks(FakePkg('fake'), fullpath, path)
 
 
 def test_unused_dependency():
@@ -55,7 +60,7 @@ def test_dependencies():
 
 def test_unused_dependency_in_package(binariescheck):
     output, test = binariescheck
-    test.run_elf_checks(FakePkg('fake'), get_full_path('libtirpc.so.3.0.0'), '/lib64/x.so')
+    run_elf_checks(test, FakePkg('fake'), get_full_path('libtirpc.so.3.0.0'), '/lib64/x.so')
     assert not test.readelf_parser.parsing_failed_reason()
     assert not test.ldd_parser.parsing_failed_reason
     out = output.print_results(output.results)
@@ -64,7 +69,7 @@ def test_unused_dependency_in_package(binariescheck):
 
 def test_unused_dependency_in_package_for_executable(binariescheck):
     output, test = binariescheck
-    test.run_elf_checks(FakePkg('fake'), get_full_path('appletviewer'), '/usr/bin/appletviewer')
+    run_elf_checks(test, FakePkg('fake'), get_full_path('appletviewer'), '/usr/bin/appletviewer')
     assert not test.readelf_parser.parsing_failed_reason()
     assert not test.ldd_parser.parsing_failed_reason
     out = output.print_results(output.results)
@@ -73,7 +78,7 @@ def test_unused_dependency_in_package_for_executable(binariescheck):
 
 def test_opt_dependency(binariescheck):
     output, test = binariescheck
-    test.run_elf_checks(FakePkg('fake'), get_full_path('opt-dependency'), '/bin/opt-dependency')
+    run_elf_checks(test, FakePkg('fake'), get_full_path('opt-dependency'), '/bin/opt-dependency')
     assert not test.readelf_parser.parsing_failed_reason()
     assert not test.ldd_parser.parsing_failed_reason
     out = output.print_results(output.results)
@@ -82,7 +87,7 @@ def test_opt_dependency(binariescheck):
 
 def test_usr_dependency(binariescheck):
     output, test = binariescheck
-    test.run_elf_checks(FakePkg('fake'), get_full_path('usr-dependency'), '/bin/usr-dependency')
+    run_elf_checks(test, FakePkg('fake'), get_full_path('usr-dependency'), '/bin/usr-dependency')
     assert not test.readelf_parser.parsing_failed_reason()
     assert not test.ldd_parser.parsing_failed_reason
     out = output.print_results(output.results)

--- a/test/test_objdump_parser.py
+++ b/test/test_objdump_parser.py
@@ -4,7 +4,7 @@ import pytest
 from rpmlint.checks.BinariesCheck import BinariesCheck
 from rpmlint.filter import Filter
 from rpmlint.objdumpparser import ObjdumpParser
-from rpmlint.pkg import FakePkg
+from rpmlint.pkg import FakePkg, get_magic
 
 from Testing import CONFIG, get_tested_path
 
@@ -28,6 +28,11 @@ def objdumpparser(path, system_path=None):
     return ObjdumpParser(get_full_path(path), system_path)
 
 
+def run_elf_checks(test, pkg, fullpath, path):
+    test._detect_attributes(get_magic(fullpath))
+    test.run_elf_checks(FakePkg('fake'), fullpath, path)
+
+
 def test_basic():
     objdump = objdumpparser('executable-stack', '/lib64/executable-stack')
     assert not objdump.parsing_failed_reason
@@ -41,7 +46,7 @@ def test_basic():
 
 def test_executable_stack_package(binariescheck):
     output, test = binariescheck
-    test.run_elf_checks(FakePkg('fake'), get_full_path('executable-stack'), 'a.out')
+    run_elf_checks(test, FakePkg('fake'), get_full_path('executable-stack'), 'a.out')
     out = output.print_results(output.results)
     assert 'W: missing-mandatory-optflags a.out -fno-PIE -g -Ofast' in out
     assert 'E: forbidden-optflags a.out -frounding-math' in out


### PR DESCRIPTION
The patch makes refactoring of properties of an ELF file.
Moreover, I added ArParser in order to identify non-standard
archives. And we should not run ldd on a statically linked binaries.