### PR TITLE
makefile-junk: make it only warning

### DIFF
--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -542,7 +542,7 @@ class FilesCheck(AbstractCheck):
             elif f == '/usr/info/dir' or f == '/usr/share/info/dir':
                 self.output.add_info('E', pkg, 'info-dir-file', f)
             elif makefile_regex.search(f) and not f.startswith('/usr/share/selinux'):
-                self.output.add_info('E', pkg, 'makefile-junk', f)
+                self.output.add_info('W', pkg, 'makefile-junk', f)
 
             res = logrotate_regex.search(f)
             if res:

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -86,9 +86,9 @@ def test_makefile_junk(tmpdir, package, filescheck):
     output, test = filescheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
-    assert 'E: makefile-junk /usr/share/CMakeLists.txt' in out
-    assert 'E: makefile-junk /usr/share/Makefile.am' in out
-    assert 'E: makefile-junk /usr/share/selinux' not in out
+    assert 'W: makefile-junk /usr/share/CMakeLists.txt' in out
+    assert 'W: makefile-junk /usr/share/Makefile.am' in out
+    assert 'W: makefile-junk /usr/share/selinux' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/python3-greenlet'])


### PR DESCRIPTION
Testing on ring0+1 in openSUSE:Factory (~3300) package
I see 6861 errors of the type.

Full list of errors:
[makefile-junk.txt](https://github.com/rpm-software-management/rpmlint/files/5473428/makefile-junk.txt)
