### PR TITLE
Restore error reporting for a threshold badness.

### DIFF
--- a/rpmlint/filter.py
+++ b/rpmlint/filter.py
@@ -94,6 +94,8 @@ class Filter(object):
                 level = 'E'
             elif level == 'E':
                 level = 'W'
+        else:
+            badness = 1
         # allow strict reporting where we override levels and treat everything
         # as an error
         if self.strict:
@@ -108,7 +110,7 @@ class Filter(object):
         # compile the message
         line = f'{package.current_linenum}:' if package.current_linenum else ''
         arch = f'.{package.arch}' if package.arch else ''
-        bad_output = f' (Badness: {badness})' if badness else ''
+        bad_output = f' (Badness: {badness})' if badness > 1 else ''
         detail_output = ''
         for detail in details:
             if detail:

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -69,7 +69,7 @@ class Lint(object):
         elif self.output.printed_messages['E'] > 0 and not self.config.permissive:
             quit_color = Color.Red
             retcode = 64
-        msg = string_center('{} packages and {} specfiles checked; {} errors, {} warnings'.format(self.packages_checked, self.specfiles_checked, self.output.printed_messages['E'], self.output.printed_messages['W']), '=')
+        msg = string_center('{} packages and {} specfiles checked; {} errors, {} warnings, {} badness'.format(self.packages_checked, self.specfiles_checked, self.output.printed_messages['E'], self.output.printed_messages['W'], self.output.score), '=')
         print(f'{quit_color}{msg}{Color.Reset}')
         return retcode
 


### PR DESCRIPTION
When a threshold is set, align the behaviour to what
rpmlint-1.x branch does.