### PR TITLE
Use UTF8 in LC_ALL.

### DIFF
--- a/rpmlint/checks/MenuXDGCheck.py
+++ b/rpmlint/checks/MenuXDGCheck.py
@@ -44,19 +44,22 @@ class MenuXDGCheck(AbstractFilesCheck):
     def check_file(self, pkg, filename):
         root = pkg.dirName()
         f = root + filename
-        command = subprocess.run(('desktop-file-validate', f), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=ENGLISH_ENVIROMENT)
-        text = command.stdout.decode()
-        if command.returncode:
-            error_printed = False
-            for line in text.splitlines():
-                if 'error: ' in line:
-                    self.output.add_info('E', pkg, 'invalid-desktopfile', filename,
-                                         line.split('error: ')[1])
-                    error_printed = True
-            if not error_printed:
-                self.output.add_info('E', pkg, 'invalid-desktopfile', filename)
+        try:
+            command = subprocess.run(('desktop-file-validate', f), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=ENGLISH_ENVIROMENT)
+            text = command.stdout.decode()
+            if command.returncode:
+                error_printed = False
+                for line in text.splitlines():
+                    if 'error: ' in line:
+                        self.output.add_info('E', pkg, 'invalid-desktopfile', filename,
+                                             line.split('error: ')[1])
+                        error_printed = True
+                if not error_printed:
+                    self.output.add_info('E', pkg, 'invalid-desktopfile', filename)
 
-        self.parse_desktop_file(pkg, root, f, filename)
+            self.parse_desktop_file(pkg, root, f, filename)
+        except UnicodeDecodeError as e:
+            self.output.add_info('E', pkg, 'non-utf8-desktopfile', filename, f'Unicode error: {e}')
 
     def _handle_parser_error(self, pkg, filename, e):
         """
@@ -77,7 +80,7 @@ class MenuXDGCheck(AbstractFilesCheck):
 
     def _has_binary(self, pkg, root, cfp, filename):
         """
-        Check whether there is a binarry assigned to the desktop file.
+        Check whether there is a binary assigned to the desktop file.
 
         Needs configparser instance, it is assumed to be called in parse_desktop_file.
         """

--- a/rpmlint/helpers.py
+++ b/rpmlint/helpers.py
@@ -7,7 +7,7 @@ import sys
 from rpmlint.color import Color
 
 
-ENGLISH_ENVIROMENT = dict(os.environ, LC_ALL='en_US')
+ENGLISH_ENVIROMENT = dict(os.environ, LC_ALL='en_US.UTF-8')
 
 
 def string_center(message, filler=' '):

--- a/test/test_menuxdg.py
+++ b/test/test_menuxdg.py
@@ -55,7 +55,6 @@ def test_bad_unicode(tmpdir, package, menuxdgcheck):
     output, test = menuxdgcheck
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
-    assert 'invalid-desktopfile' in out
     assert 'non-utf8-desktopfile' in out
 
 


### PR DESCRIPTION
It is needed in order to get proper encoded utf8 errors
for e.g. desktop-file-validate.