### PR TITLE
Handle when pybeam fails:

### DIFF
--- a/rpmlint/checks/ErlangCheck.py
+++ b/rpmlint/checks/ErlangCheck.py
@@ -14,11 +14,14 @@ class ErlangCheck(AbstractFilesCheck):
 
     def check_file(self, pkg, filename):
         beam = BeamFile(pkg.files[filename].path)
-        compile_state = byte_to_string(beam.compileinfo['source'].value)
-        if 'debug_info' not in beam.compileinfo['options']:
-            self.output.add_info('E', pkg, 'beam-compiled-without-debuginfo', filename)
-        # This can't be an error as builddir can be user specific and vary between users
-        # it could be error in OBS where all the builds are done by user abuild, not in
-        # general.
-        if not self.source_re.match(compile_state):
-            self.output.add_info('W', pkg, 'beam-was-not-recompiled', filename, compile_state)
+        try:
+            compile_state = byte_to_string(beam.compileinfo['source'].value)
+            if 'debug_info' not in beam.compileinfo['options']:
+                self.output.add_info('E', pkg, 'beam-compiled-without-debuginfo', filename)
+            # This can't be an error as builddir can be user specific and vary between users
+            # it could be error in OBS where all the builds are done by user abuild, not in
+            # general.
+            if not self.source_re.match(compile_state):
+                self.output.add_info('W', pkg, 'beam-was-not-recompiled', filename, compile_state)
+        except Exception:
+            self.output.add_info('E', pkg, 'pybeam-failed', filename)

--- a/rpmlint/descriptions/ErlangCheck.toml
+++ b/rpmlint/descriptions/ErlangCheck.toml
@@ -7,3 +7,6 @@ It seems that your beam file was not compiled by you, but was
 just copied in binary form to destination. Please, make sure
 that you really compile it from the sources.
 """
+pybeam-failed="""
+Invocation of the Python pybeam library failed.
+"""


### PR DESCRIPTION
(none): E: while reading /home/marxin/BIG/rpm/elixir/binaries/elixir-1.11.1-1.1.noarch.rpm: b'CInf'

Reported issue:
https://github.com/matwey/pybeam/issues/14