### PR TITLE
Remove fsf address verification

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -199,7 +199,6 @@ Filters = [
     '(?:dosutils|skelcd|installation-images|yast2-slide-show|instlux|skelcd-.*|patterns-.*)\.\S+: \w: filelist-forbidden-fhs23 /CD1',
 
 # Too noisy, and usually not something downstream packagers can fix
-    ' incorrect-fsf-address ',
     ' no-manual-page-for-binary ',
     ' static-library-without-debuginfo /usr/lib(?:64)?/ghc-[\d\.]+/',
 

--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -202,9 +202,6 @@ non_readable_regexs = (re.compile(r'^/var/log/'),
 
 man_base_regex = re.compile(r'^/usr(?:/share)?/man(?:/overrides)?/man[^/]+/(.+)\.[1-9n]')
 
-fsf_license_regex = re.compile(br'(GNU((\s+(Library|Lesser|Affero))?(\s+General)?\s+Public|\s+Free\s+Documentation)\s+Licen[cs]e|(GP|FD)L)', re.IGNORECASE)
-fsf_wrong_address_regex = re.compile(br'(675\s+Mass\s+Ave|59\s+Temple\s+Place|Franklin\s+Steet|02139|02111-1307)', re.IGNORECASE)
-
 scalable_icon_regex = re.compile(r'^/usr(?:/local)?/share/icons/.*/scalable/')
 tcl_regex = re.compile(r'^/usr/lib(64)?/([^/]+/)?pkgIndex\.tcl')
 
@@ -890,9 +887,6 @@ class FilesCheck(AbstractCheck):
                         # lots of unwanted noise.
                         if not is_utf8(pkgfile.path):
                             self.output.add_info('W', pkg, 'file-not-utf8', f)
-                    if fsf_license_regex.search(chunk) and \
-                            fsf_wrong_address_regex.search(chunk):
-                        self.output.add_info('E', pkg, 'incorrect-fsf-address', f)
 
                 elif is_doc and chunk and compr_regex.search(f):
                     ff = compr_regex.sub('', f)

--- a/rpmlint/descriptions/FilesCheck.toml
+++ b/rpmlint/descriptions/FilesCheck.toml
@@ -363,11 +363,6 @@ It can cause problems when dirs in $PATH are reordered.
 no-manual-page-for-binary="""
 Each executable in standard binary directories should have a man page.
 """
-incorrect-fsf-address="""
-The Free Software Foundation address in this file seems to be outdated or
-misspelled. Ask upstream to update the address, or if this is a license file,
-possibly the entire file with a new copy available from the FSF.
-"""
 gzipped-svg-icon="""
 Not all desktop environments that support SVG icons support them gzipped
 (.svgz). Install the icon as plain uncompressed SVG.

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -74,10 +74,9 @@ def test_pyc_mtime_from_chunk(version, mtime):
 def test_devel_files(tmpdir, package, filescheck):
     output, test = filescheck
     test.check(get_tested_package(package, tmpdir))
-    assert len(output.results) == 5
+    assert len(output.results) == 1
     out = output.print_results(output.results)
     assert 'devel-file-in-non-devel-package' not in out
-    assert 'incorrect-fsf-address' in out
     assert 'no-documentation' in out
 
 


### PR DESCRIPTION
This check is too noisy and it is something from upstream to fix.
Nothing much for distributions to handle.
When looking on openSUSE Tumbleweed few thousand packages have this
issue out of 14 thousand that are in distro (not all of them GPL of
course).