### PR TITLE
Automatically load rpmlintrc files.

### DIFF
--- a/rpmlint/cli.py
+++ b/rpmlint/cli.py
@@ -103,6 +103,10 @@ def process_lint_args(argv):
         if not options.rpmlintrc.exists():
             print_warning(f"User specified rpmlintrc '{options.rpmlintrc}' does not exist")
             exit(2)
+        # make it a list
+        options.rpmlintrc = [options.rpmlintrc]
+    else:
+        options.rpmlintrc = []
     # validate all the rpmlfile options to be either file or folder
     f_path = []
     invalid_path = False

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -1,4 +1,5 @@
 import importlib
+from pathlib import Path
 from tempfile import gettempdir
 
 from rpmlint.color import Color
@@ -83,30 +84,34 @@ class Lint(object):
                 print_warning(f'(none): E: there is no installed rpm "{name}".')
         return existing_packages
 
+    def _find_rpmlintrc_files(self, path):
+        rpmlintrcs = []
+        rpmlintrcs += sorted(path.glob('*.rpmlintrc'))
+        rpmlintrcs += sorted(path.glob('*-rpmlintrc'))
+        return rpmlintrcs
+
     def _load_rpmlintrc(self):
         """
         Load rpmlintrc from argument or load up from folder
         """
-        if self.options['rpmlintrc']:
-            self.config.load_rpmlintrc(self.options['rpmlintrc'])
-        else:
-            # load only from the same folder specname.rpmlintrc or specname-rpmlintrc
-            # do this only in a case where there is one folder parameter or one file
-            # to avoid multiple folders handling
-            rpmlintrc = []
-            if not len(self.options['rpmfile']) == 1:
-                return
-            pkg = self.options['rpmfile'][0]
-            if pkg.is_file():
-                pkg = pkg.parent
-            rpmlintrc += sorted(pkg.glob('*.rpmlintrc'))
-            rpmlintrc += sorted(pkg.glob('*-rpmlintrc'))
-            if len(rpmlintrc) > 1:
-                # multiple rpmlintrcs are highly undesirable
-                print_warning('There are multiple items to be loaded for rpmlintrc, ignoring them: {}.'.format(' '.join(map(str, rpmlintrc))))
-            elif len(rpmlintrc) == 1:
-                self.options['rpmlintrc'] = rpmlintrc[0]
-                self.config.load_rpmlintrc(rpmlintrc[0])
+        if not self.options['rpmlintrc']:
+            # first load SUSE-specific locations
+            self.options['rpmlintrc'] += self._find_rpmlintrc_files(Path('/home/abuild/rpmbuild/SOURCES'))
+            self.options['rpmlintrc'] += self._find_rpmlintrc_files(Path('/usr/src/packages/SOURCES/'))
+            if not self.options['rpmlintrc'] and len(self.options['rpmfile']) == 1:
+                # load only from the same folder specname.rpmlintrc or specname-rpmlintrc
+                # do this only in a case where there is one folder parameter or one file
+                # to avoid multiple folders handling
+                pkg = self.options['rpmfile'][0]
+                if pkg.is_file():
+                    pkg = pkg.parent
+                self.options['rpmlintrc'] += self._find_rpmlintrc_files(pkg)
+
+        if len(self.options['rpmlintrc']) > 1:
+            # multiple rpmlintrcs are highly undesirable
+            print_warning('There are multiple items to be loaded: {}.'.format(' '.join(map(str, self.options['rpmlintrc']))))
+        for rcfile in self.options['rpmlintrc']:
+            self.config.load_rpmlintrc(rcfile)
 
     def _print_header(self):
         """
@@ -120,8 +125,9 @@ class Lint(object):
         for config in self.config.conf_files:
             print(f'    {config}')
         if self.options['rpmlintrc']:
-            rpmlintrc = self.options['rpmlintrc']
-            print(f'rpmlintrc: {rpmlintrc}')
+            print('rpmlintrc:')
+            for rcfile in self.options['rpmlintrc']:
+                print(f'    {rcfile}')
         no_checks = len(self.config.configuration['Checks'])
         no_pkgs = len(self.options['installed']) + len(self.options['rpmfile'])
         print(f'{Color.Bold}checks: {no_checks}, packages: {no_pkgs}{Color.Reset}')

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -1,3 +1,4 @@
+import copy
 from pathlib import Path
 
 import pytest
@@ -13,7 +14,7 @@ options_preset = {
     'print_config': False,
     'explain': '',
     'rpmfile': '',
-    'rpmlintrc': False,
+    'rpmlintrc': [],
     'installed': '',
 }
 
@@ -48,6 +49,11 @@ basic_tests = [
 ]
 
 
+def get_options(additional_options):
+    options = copy.deepcopy(options_preset)
+    return {**options, **additional_options}
+
+
 def _remove_except_zip(dictionary):
     """
     In order to not lie in coverage redux the test run on the
@@ -67,7 +73,7 @@ def test_configoutput(capsys):
     additional_options = {
         'print_config': True,
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -81,7 +87,7 @@ def test_explain_unknown(capsys):
     additional_options = {
         'explain': message,
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -94,7 +100,7 @@ def test_explain_known(capsys):
     additional_options = {
         'explain': message,
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -108,7 +114,7 @@ def test_explain_with_unknown(capsys):
     additional_options = {
         'explain': message,
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -129,7 +135,7 @@ def test_explain_no_binary_from_cfg(capsys):
         'config': [testpath() / 'configs/descriptions.config'],
         'explain': ['no-binary']
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -153,7 +159,7 @@ def test_explain_non_standard_dir_from_cfg(capsys):
         'config': [testpath() / 'configs/descriptions.config'],
         'explain': ['non-standard-dir-in-usr']
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -177,7 +183,7 @@ def test_descriptions_from_config(capsys, packages):
         'rpmfile': [packages]
     }
     options_preset['verbose'] = True
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -197,7 +203,7 @@ def test_run_single(capsys, packages):
     additional_options = {
         'rpmfile': [packages],
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.checks = _remove_except_zip(linter.checks)
     linter.run()
@@ -213,7 +219,7 @@ def test_run_installed(capsys, packages):
         'rpmfile': [packages],
         'installed': ['python3-rpm', 'rpm'],
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.checks = _remove_except_zip(linter.checks)
     linter.run()
@@ -231,7 +237,7 @@ def test_run_strict(capsys, packages):
         'rpmfile': [packages],
         'strict': True,
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.checks = _remove_except_zip(linter.checks)
     linter.run()
@@ -246,7 +252,7 @@ def test_run_installed_not_present(capsys):
         'rpmfile': [],
         'installed': ['non-existing-package'],
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.checks = _remove_except_zip(linter.checks)
     linter.run()
@@ -261,7 +267,7 @@ def test_run_installed_and_no_files(capsys):
         'rpmfile': [],
         'installed': ['python3-rpm'],
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.checks = _remove_except_zip(linter.checks)
     linter.run()
@@ -275,7 +281,7 @@ def test_header_information(capsys):
         'rpmfile': [],
         'installed': ['python3-rpm'],
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.checks = _remove_except_zip(linter.checks)
     linter.run()
@@ -292,7 +298,7 @@ def test_run_full_rpm(capsys, packages, configs):
         'rpmfile': packages,
     }
     options_preset['config'] = configs
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -315,7 +321,7 @@ def test_run_full_specs(capsys, packages, configs):
         'rpmfile': packages,
     }
     options_preset['config'] = configs
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -335,7 +341,7 @@ def test_run_full_directory(capsys, packages):
     additional_options = {
         'rpmfile': [packages],
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -356,7 +362,7 @@ def test_run_rpmlintrc_single_dir(capsys, packages):
     additional_options = {
         'rpmfile': [packages],
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
@@ -369,12 +375,12 @@ def test_run_rpmlintrc_multiple(capsys, packages):
     additional_options = {
         'rpmfile': [packages],
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()
-    assert 'rpmlintrc:' not in out
-    assert 'There are multiple items to be loaded for rpmlintrc' in err
+    assert 'rpmlintrc:' in out
+    assert 'There are multiple items to be loaded' in err
 
 
 @pytest.mark.parametrize('packages', [Path('test/rpmlintrc/single/sample.spec')])
@@ -382,7 +388,7 @@ def test_run_rpmlintrc_single_file(capsys, packages):
     additional_options = {
         'rpmfile': [packages],
     }
-    options = {**options_preset, **additional_options}
+    options = get_options(additional_options)
     linter = Lint(options)
     linter.run()
     out, err = capsys.readouterr()


### PR DESCRIPTION
Load them from /home/abuild/rpmbuild/SOURCES and allow loading
of multiple files (for now).

rpmlint-mini/rpmlint-mini.config contains:
```
    configs += glob.glob("/home/abuild/rpmbuild/SOURCES/*rpmlintrc")
    configs += glob.glob("/usr/src/packages/SOURCES/*rpmlintrc")
```
