### PR TITLE
Add skipIf based on architecture.

### DIFF
--- a/test/Testing.py
+++ b/test/Testing.py
@@ -1,5 +1,8 @@
+import glob
 import os
 from pathlib import Path
+import platform
+import re
 
 from rpmlint.config import Config
 from rpmlint.pkg import FakePkg, Pkg
@@ -11,6 +14,11 @@ def testpath():
 
 TEST_CONFIG = [testpath() / 'configs/test.config']
 CONFIG = Config(TEST_CONFIG)
+
+# predicates used for pytest.mark.skipif decorators
+IS_X86_64 = platform.machine() == 'x86_64'
+IS_I686 = re.match(platform.machine(), 'i[3456]86') is not None
+HAS_32BIT_GLIBC = glob.glob('/lib/ld-linux.so.*') is not None
 
 
 def get_tested_path(path):

--- a/test/test_binaries.py
+++ b/test/test_binaries.py
@@ -2,7 +2,7 @@ import pytest
 from rpmlint.checks.BinariesCheck import BinariesCheck
 from rpmlint.filter import Filter
 
-from Testing import CONFIG, get_tested_package
+from Testing import CONFIG, get_tested_package, IS_X86_64
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -14,6 +14,7 @@ def binariescheck():
 
 
 @pytest.mark.parametrize('package', ['binary/crypto-policy'])
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_forbidden_c_calls(tmpdir, package, binariescheck):
     output, test = binariescheck
     test.check(get_tested_package(package, tmpdir))
@@ -84,6 +85,7 @@ def test_shlib_with_no_exec(tmpdir, package, binariescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/glibc'])
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_shlib_with_no_exec_glibc(tmpdir, package, binariescheck):
     output, test = binariescheck
     test.check(get_tested_package(package, tmpdir))
@@ -189,6 +191,7 @@ def test_non_position_independent(tmpdir, package, binariescheck):
 
 # libtest package
 @pytest.mark.parametrize('package', ['binary/libtest'])
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_library(tmpdir, package, binariescheck):
     output, test = binariescheck
     test.check(get_tested_package(package, tmpdir))
@@ -201,6 +204,7 @@ def test_library(tmpdir, package, binariescheck):
 
 # invalid-soname test package
 @pytest.mark.parametrize('package', ['binary/libtest1'])
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_shared_library1(tmpdir, package, binariescheck):
     output, test = binariescheck
     test.check(get_tested_package(package, tmpdir))
@@ -212,6 +216,7 @@ def test_shared_library1(tmpdir, package, binariescheck):
 
 # incoherent-version-in-name test package
 @pytest.mark.parametrize('package', ['binary/libtest2'])
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_shared_library2(tmpdir, package, binariescheck):
     output, test = binariescheck
     test.check(get_tested_package(package, tmpdir))
@@ -227,6 +232,7 @@ def test_shared_library2(tmpdir, package, binariescheck):
 
 # invalid-ldconfig-symlink test package
 @pytest.mark.parametrize('package', ['binary/libtest3'])
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_invalid_ldconfig_symlink(tmpdir, package, binariescheck):
     output, test = binariescheck
     test.check(get_tested_package(package, tmpdir))
@@ -241,6 +247,7 @@ def test_invalid_ldconfig_symlink(tmpdir, package, binariescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/multiple_errors'])
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_multiple_errors(tmpdir, package, binariescheck):
     output, test = binariescheck
     test.check(get_tested_package(package, tmpdir))

--- a/test/test_ldd_parser.py
+++ b/test/test_ldd_parser.py
@@ -6,7 +6,7 @@ from rpmlint.filter import Filter
 from rpmlint.lddparser import LddParser
 from rpmlint.pkg import FakePkg, get_magic
 
-from Testing import CONFIG, get_tested_path
+from Testing import CONFIG, get_tested_path, IS_X86_64
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -32,6 +32,7 @@ def run_elf_checks(test, pkg, fullpath, path):
     test.run_elf_checks(pkg, fullpath, path)
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_unused_dependency():
     ldd = lddparser('libtirpc.so.3.0.0')
     assert not ldd.parsing_failed_reason
@@ -39,6 +40,7 @@ def test_unused_dependency():
     assert 'liXXXsapi_krb5.so.2' in ldd.unused_dependencies
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_undefined_symbol():
     ldd = lddparser('libtirpc.so.3.0.0')
     assert not ldd.parsing_failed_reason
@@ -51,6 +53,7 @@ def test_ldd_parser_failure():
     assert 'not-existing-file: No such file or directory' in ldd.parsing_failed_reason
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_dependencies():
     ldd = lddparser('libtirpc.so.3.0.0')
     assert not ldd.parsing_failed_reason
@@ -58,6 +61,7 @@ def test_dependencies():
     assert any(d for d in ldd.dependencies if d.startswith('linux-vdso.so.1'))
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_unused_dependency_in_package(binariescheck):
     output, test = binariescheck
     run_elf_checks(test, FakePkg('fake'), get_full_path('libtirpc.so.3.0.0'), '/lib64/x.so')
@@ -67,6 +71,7 @@ def test_unused_dependency_in_package(binariescheck):
     assert 'E: unused-direct-shlib-dependency ' in out
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_unused_dependency_in_package_for_executable(binariescheck):
     output, test = binariescheck
     run_elf_checks(test, FakePkg('fake'), get_full_path('appletviewer'), '/usr/bin/appletviewer')
@@ -76,6 +81,7 @@ def test_unused_dependency_in_package_for_executable(binariescheck):
     assert 'W: unused-direct-shlib-dependency ' in out
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_opt_dependency(binariescheck):
     output, test = binariescheck
     run_elf_checks(test, FakePkg('fake'), get_full_path('opt-dependency'), '/bin/opt-dependency')
@@ -85,6 +91,7 @@ def test_opt_dependency(binariescheck):
     assert 'E: linked-against-opt-library /bin/opt-dependency /opt/libfoo.so' in out
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_usr_dependency(binariescheck):
     output, test = binariescheck
     run_elf_checks(test, FakePkg('fake'), get_full_path('usr-dependency'), '/bin/usr-dependency')

--- a/test/test_objdump_parser.py
+++ b/test/test_objdump_parser.py
@@ -6,7 +6,7 @@ from rpmlint.filter import Filter
 from rpmlint.objdumpparser import ObjdumpParser
 from rpmlint.pkg import FakePkg, get_magic
 
-from Testing import CONFIG, get_tested_path
+from Testing import CONFIG, get_tested_path, IS_X86_64
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -44,9 +44,11 @@ def test_basic():
     assert first['language'] == '32769\t(MIPS assembler)'
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_executable_stack_package(binariescheck):
     output, test = binariescheck
     run_elf_checks(test, FakePkg('fake'), get_full_path('executable-stack'), 'a.out')
     out = output.print_results(output.results)
+
     assert 'W: missing-mandatory-optflags a.out -fno-PIE -g -Ofast' in out
     assert 'E: forbidden-optflags a.out -frounding-math' in out

--- a/test/test_readelf_parser.py
+++ b/test/test_readelf_parser.py
@@ -7,7 +7,7 @@ from rpmlint.filter import Filter
 from rpmlint.pkg import FakePkg, get_magic
 from rpmlint.readelfparser import ReadelfParser
 
-from Testing import CONFIG, get_tested_path
+from Testing import CONFIG, get_tested_path, HAS_32BIT_GLIBC, IS_I686, IS_X86_64
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -148,6 +148,7 @@ def test_archive_with_debuginfo(binariescheck):
     assert 'E: static-library-without-debuginfo' not in output.print_results(output.results)
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_executable_stack(binariescheck):
     output, test = binariescheck
     run_elf_checks(test, FakePkg('fake'), get_full_path('executable-stack'), 'a.out')
@@ -166,6 +167,7 @@ def test_readelf_failure_in_package(binariescheck):
     assert 'readelf-failed /lib64/not-existing.so' in out
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_no_soname(binariescheck):
     output, test = binariescheck
     run_elf_checks(test, FakePkg('fake'), get_full_path('no-soname.so'), '/lib64/no-soname.so')
@@ -173,6 +175,7 @@ def test_no_soname(binariescheck):
     assert 'no-soname /lib64/no-soname.so' in out
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_invalid_soname(binariescheck):
     output, test = binariescheck
     run_elf_checks(test, FakePkg('fake'), get_full_path('invalid-soname.so'), '/lib64/invalid-soname.so')
@@ -181,6 +184,7 @@ def test_invalid_soname(binariescheck):
     assert 'E: shlib-with-non-pic-code /lib64/invalid-soname.so' not in out
 
 
+@pytest.mark.skipif(not IS_I686 and (not IS_X86_64 or not HAS_32BIT_GLIBC), reason='i686 glibc only')
 def test_non_pic_code_library(binariescheck):
     output, test = binariescheck
     run_elf_checks(test, FakePkg('fake'), get_full_path('non-pic-shared-m32.so'), '/usr/lib/non-pic-shared-m32.so')
@@ -188,6 +192,7 @@ def test_non_pic_code_library(binariescheck):
     assert 'E: shlib-with-non-pic-code' in out
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_no_ldconfig_symlink(binariescheck):
     output, test = binariescheck
 
@@ -197,6 +202,7 @@ def test_no_ldconfig_symlink(binariescheck):
     assert 'E: incoherent-version-in-name 1' in out
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_call_mktemp(binariescheck):
     output, test = binariescheck
 
@@ -205,6 +211,7 @@ def test_call_mktemp(binariescheck):
     assert 'E: call-to-mktemp /bin/call-mktemp' in out
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_call_setgroups(binariescheck):
     output, test = binariescheck
 
@@ -213,6 +220,7 @@ def test_call_setgroups(binariescheck):
     assert 'E: missing-call-to-setgroups-before-setuid /bin/call-setgroups' in out
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_call_gethostbyname(binariescheck):
     output, test = binariescheck
 
@@ -221,6 +229,7 @@ def test_call_gethostbyname(binariescheck):
     assert 'W: binary-or-shlib-calls-gethostbyname' in out
 
 
+@pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_missing_dependency(binariescheck):
     output, test = binariescheck
 


### PR DESCRIPTION
Many tests can run only on x86_64 due to ldd-failed, so that
I am adding skipIfs.

Tested on `x86_64`, `i686`, `ppc64le`, `ppc64`, `aarch64` and `armv7l`.