### PR TITLE
Run file checks in parallel.

### DIFF
--- a/rpmlint/checks/BashismsCheck.py
+++ b/rpmlint/checks/BashismsCheck.py
@@ -8,6 +8,7 @@ from rpmlint.helpers import ENGLISH_ENVIROMENT
 class BashismsCheck(AbstractFilesCheck):
     def __init__(self, config, output):
         super().__init__(config, output, r'.*')
+        self.use_threads = True
 
     def check_file(self, pkg, filename):
         root = pkg.dirName()


### PR DESCRIPTION
That speeds up BashismsCheck for dialog rpm files from
15s to 1s.