### PR TITLE
Never print rpm2cpio stderr.

### DIFF
--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -489,7 +489,8 @@ class Pkg(AbstractPkg):
             command_str = \
                 'rpm2cpio %(f)s | cpio -id -D %(d)s ; chmod -R +rX %(d)s' % \
                 {'f': quote(str(self.filename)), 'd': quote(dirname)}
-            stderr = None if verbose else subprocess.DEVNULL
+            # SUSE-specific: never print stderr
+            stderr = subprocess.DEVNULL
             subprocess.check_output(command_str, shell=True, env=ENGLISH_ENVIROMENT,
                                     stderr=stderr)
             self.extracted = True


### PR DESCRIPTION
It removes the following lines:

2575 blocks
591 blocks
3825 blocks
9441 blocks
792 blocks

We want to use `--info`  argument, but we don't want these messages. Upstream likely yes.