### PR TITLE
Add --profile argument to trace using cProfile.

### DIFF
--- a/rpmlint/cli.py
+++ b/rpmlint/cli.py
@@ -88,6 +88,7 @@ def process_lint_args(argv):
     parser.add_argument('-p', '--print-config', action='store_true', help='print the settings that are in effect when using the rpmlint')
     parser.add_argument('-i', '--installed', nargs='+', default='', help='installed packages to be validated by rpmlint')
     parser.add_argument('-t', '--time-report', action='store_true', help='print time report for run checks')
+    parser.add_argument('-T', '--profile', action='store_true', help='print cProfile report')
     lint_modes_parser = parser.add_mutually_exclusive_group()
     lint_modes_parser.add_argument('-s', '--strict', action='store_true', help='treat all messages as errors')
     lint_modes_parser.add_argument('-P', '--permissive', action='store_true', help='treat individual errors as non-fatal')

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -15,7 +15,8 @@ options_preset = {
     'rpmfile': '',
     'rpmlintrc': False,
     'installed': '',
-    'time_report': False
+    'time_report': False,
+    'profile': False
 }
 
 basic_tests = [


### PR DESCRIPTION
It's useful for debugging and it prints now:

```
cProfile report:
         1467359 function calls (1427341 primitive calls) in 15.673 seconds

   Ordered by: cumulative time
   List reduced from 1573 to 30 due to restriction <30>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   15.346   15.346 /home/marxin/Programming/rpmlint/rpmlint/lint.py:51(run)
        1    0.000    0.000   15.346   15.346 /home/marxin/Programming/rpmlint/rpmlint/lint.py:179(validate_files)
        5    0.000    0.000   15.346    3.069 /home/marxin/Programming/rpmlint/rpmlint/lint.py:210(validate_file)
        5    0.001    0.000   15.258    3.052 /home/marxin/Programming/rpmlint/rpmlint/lint.py:222(run_checks)
      384    0.009    0.000   15.125    0.039 /usr/lib64/python3.8/subprocess.py:448(run)
       80    0.000    0.000   15.070    0.188 /home/marxin/Programming/rpmlint/rpmlint/checks/AbstractCheck.py:11(check)
       35    0.003    0.000   14.977    0.428 /home/marxin/Programming/rpmlint/rpmlint/checks/AbstractCheck.py:31(check_binary)
      269    0.004    0.000   14.939    0.056 /home/marxin/Programming/rpmlint/rpmlint/checks/BashismsCheck.py:12(check_file)
      179    0.005    0.000   14.935    0.083 /home/marxin/Programming/rpmlint/rpmlint/checks/BashismsCheck.py:24(check_bashisms)
      384    0.003    0.000   14.276    0.037 /usr/lib64/python3.8/subprocess.py:980(communicate)
      785    0.003    0.000   14.132    0.018 /usr/lib64/python3.8/subprocess.py:1074(wait)
      785    0.003    0.000   14.129    0.018 /usr/lib64/python3.8/subprocess.py:1772(_wait)
      385    0.001    0.000   14.125    0.037 /usr/lib64/python3.8/subprocess.py:1759(_try_wait)
      385   14.124    0.037   14.124    0.037 {built-in method posix.waitpid}
      385    0.012    0.000    0.838    0.002 /usr/lib64/python3.8/subprocess.py:732(__init__)
      385    0.100    0.000    0.818    0.002 /usr/lib64/python3.8/subprocess.py:1550(_execute_child)
      385    0.280    0.001    0.280    0.001 {built-in method _posixsubprocess.fork_exec}
        1    0.000    0.000    0.271    0.271 /home/marxin/Programming/rpmlint/rpmlint/lint.py:253(load_checks)
       30    0.000    0.000    0.271    0.009 /home/marxin/Programming/rpmlint/rpmlint/lint.py:264(load_check)
      441    0.260    0.001    0.260    0.001 {built-in method posix.read}
   121/33    0.001    0.000    0.249    0.008 <frozen importlib._bootstrap>:986(_find_and_load)
   121/33    0.000    0.000    0.248    0.008 <frozen importlib._bootstrap>:956(_find_and_load_unlocked)
       30    0.000    0.000    0.247    0.008 /usr/lib64/python3.8/importlib/__init__.py:109(import_module)
    31/30    0.000    0.000    0.247    0.008 <frozen importlib._bootstrap>:1002(_gcd_import)
   114/33    0.000    0.000    0.246    0.007 <frozen importlib._bootstrap>:650(_load_unlocked)
   102/32    0.000    0.000    0.245    0.008 <frozen importlib._bootstrap_external>:777(exec_module)
     1238    0.004    0.000    0.245    0.000 /usr/lib64/python3.8/re.py:289(_compile)
   139/36    0.000    0.000    0.243    0.007 <frozen importlib._bootstrap>:211(_call_with_frames_removed)
      539    0.000    0.000    0.241    0.000 /usr/lib64/python3.8/re.py:250(compile)
   115/32    0.001    0.000    0.239    0.007 {built-in method builtins.exec}


========================================================
         1467359 function calls (1427341 primitive calls) in 15.673 seconds

   Ordered by: call count
   List reduced from 1573 to 30 due to restriction <30>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   256928    0.032    0.000    0.034    0.000 {built-in method builtins.isinstance}
   213941    0.017    0.000    0.017    0.000 {method 'append' of 'list' objects}
128127/117755    0.012    0.000    0.014    0.000 {built-in method builtins.len}
   121221    0.012    0.000    0.012    0.000 {built-in method builtins.ord}
    88837    0.019    0.000    0.029    0.000 /usr/lib64/python3.8/sre_parse.py:164(__getitem__)
    66595    0.008    0.000    0.008    0.000 {built-in method posix.fspath}
    60591    0.015    0.000    0.015    0.000 {method 'encode' of 'str' objects}
    60254    0.042    0.000    0.072    0.000 /usr/lib64/python3.8/os.py:800(fsencode)
    50049    0.018    0.000    0.018    0.000 /usr/lib64/python3.8/sre_parse.py:233(__next)
    39894    0.011    0.000    0.025    0.000 /usr/lib64/python3.8/sre_parse.py:254(get)
    38292    0.008    0.000    0.011    0.000 /usr/lib64/python3.8/sre_parse.py:172(append)
    30356    0.031    0.000    0.031    0.000 {method 'search' of 're.Pattern' objects}
    29070    0.013    0.000    0.013    0.000 {built-in method builtins.min}
    12514    0.003    0.000    0.004    0.000 /usr/lib64/python3.8/sre_parse.py:160(__len__)
    12131    0.004    0.000    0.007    0.000 /usr/lib64/python3.8/sre_parse.py:249(match)
    11577    0.002    0.000    0.002    0.000 {method 'startswith' of 'str' objects}
10324/810    0.016    0.000    0.031    0.000 /usr/lib64/python3.8/sre_parse.py:174(getwidth)
    10322    0.004    0.000    0.004    0.000 /usr/lib64/python3.8/sre_parse.py:111(__init__)
10023/505    0.033    0.000    0.061    0.000 /usr/lib64/python3.8/sre_compile.py:71(_compile)
 9450/679    0.053    0.000    0.160    0.000 /usr/lib64/python3.8/sre_parse.py:493(_parse)
     8528    0.002    0.000    0.002    0.000 {built-in method builtins.max}
     7399    0.000    0.000    0.000    0.000 {method 'isspace' of 'str' objects}
     7382    0.000    0.000    0.000    0.000 {method 'isalnum' of 'str' objects}
     5387    0.001    0.000    0.001    0.000 {built-in method sys.intern}
     4470    0.002    0.000    0.003    0.000 /usr/lib64/python3.8/posixpath.py:41(_get_sep)
     3890    0.001    0.000    0.001    0.000 {method 'split' of 'str' objects}
     3697    0.010    0.000    0.015    0.000 /usr/lib64/python3.8/posixpath.py:71(join)
     3411    0.005    0.000    0.022    0.000 /usr/lib64/python3.8/subprocess.py:1632(<genexpr>)
     3091    0.001    0.000    0.001    0.000 {method 'endswith' of 'str' objects}
     3086    0.001    0.000    0.001    0.000 {method 'group' of 're.Match' objects}
```