### PR TITLE
SpecCheck: Revise rpm-buildroot-usage description and raise to error

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -211,7 +211,7 @@ class SpecCheck(AbstractCheck):
 
             if (current_section in Pkg.RPM_SCRIPTLETS + ('prep', 'build') and
                     contains_buildroot(line)):
-                self.output.add_info('W', pkg, 'rpm-buildroot-usage', '%' + current_section,
+                self.output.add_info('E', pkg, 'rpm-buildroot-usage', '%' + current_section,
                                      line[:-1].strip())
 
             if make_check_regex.search(line) and current_section not in \

--- a/rpmlint/descriptions/SpecCheck.toml
+++ b/rpmlint/descriptions/SpecCheck.toml
@@ -118,8 +118,9 @@ configurations, you can ignore this warning for the section(s) where your rpm
 takes care of it.
 """
 rpm-buildroot-usage="""
-$RPM_BUILD_ROOT should not be touched during %build or %prep stage, as it
-may break short circuit builds.
+$RPM_BUILD_ROOT or %{buildroot} must not be touched during %build or %prep
+stage, as it will break short circuit builds and will not persist to %install
+stage in a normal build, leading to unexpected package build behavior.
 """
 make-check-outside-check-section="""
 Make check or other automated regression test should be run in %check, as

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -149,7 +149,7 @@ def test_check_rpm_buildroot_usage_under_prep(package, speccheck):
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg)
     out = output.print_results(output.results)
-    assert 'W: rpm-buildroot-usage' in out
+    assert 'E: rpm-buildroot-usage' in out
 
 
 @pytest.mark.parametrize('package', ['spec/SpecCheckTemp'])
@@ -159,7 +159,7 @@ def test_check_rpm_buildroot_usage_under_build(package, speccheck):
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg)
     out = output.print_results(output.results)
-    assert 'W: rpm-buildroot-usage' in out
+    assert 'E: rpm-buildroot-usage' in out
 
 
 @pytest.mark.parametrize('package', ['spec/SpecCheck2'])
@@ -169,7 +169,7 @@ def test_check_rpm_buildroot_usage_not_applied(package, speccheck):
     pkg = get_tested_spec_package(package)
     test.check_spec(pkg)
     out = output.print_results(output.results)
-    assert 'W: rpm-buildroot-usage' not in out
+    assert 'E: rpm-buildroot-usage' not in out
 
 
 @pytest.mark.parametrize('package', ['spec/make-check-outside-check-section'])


### PR DESCRIPTION
This check now ensures package builds are coherent with RPM 4.16+
behavior across `%prep`, `%build`, and `%install` sections.

Additionally, it notes that using either `%{buildroot}` or `$RPM_BUILD_ROOT`
has the same effect.

Fixes #541 