### PR TITLE
Fix parsing of ValidSrcPerms.

### DIFF
--- a/rpmlint/checks/SourceCheck.py
+++ b/rpmlint/checks/SourceCheck.py
@@ -19,7 +19,7 @@ class SourceCheck(AbstractCheck):
     def __init__(self, config, output):
         super().__init__(config, output)
         self.compress_ext = config.configuration['CompressExtension']
-        self.valid_src_perms = config.configuration['ValidSrcPerms']
+        self.valid_src_perms = [int(value, 8) for value in config.configuration['ValidSrcPerms']]
         self.spec_file = None
 
         source_details_dict = {

--- a/test/test_sources.py
+++ b/test/test_sources.py
@@ -19,13 +19,13 @@ def test_extension_and_permissions(tmpdir, package, sourcescheck):
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
 
-    assert len(output.results) == 3
+    assert len(output.results) == 1
 
     assert 'inconsistent-file-extension' in out
     assert 'name extension indicates a different compression format' in out
 
-    assert 'strange-permission' in out
-    assert 'a file should have' in out
+    assert 'strange-permission' not in out
+    assert 'a file should have' not in out
 
 
 @pytest.mark.parametrize('package', ['source/not-compressed-multi-spec'])


### PR DESCRIPTION
Properly parse octal literals.

Fixes #536.