### PR TITLE
Fix exception handling for BashismsCheck and BinariesCheck.

### DIFF
--- a/rpmlint/checks/AbstractCheck.py
+++ b/rpmlint/checks/AbstractCheck.py
@@ -43,6 +43,10 @@ class AbstractFilesCheck(AbstractCheck):
                 for filename in filenames:
                     futures.append(executor.submit(self.check_file, pkg, filename))
                 concurrent.futures.wait(futures)
+                for future in futures:
+                    err = future.exception()
+                    if err:
+                        raise err
         else:
             for filename in filenames:
                 self.check_file(pkg, filename)

--- a/rpmlint/checks/BashismsCheck.py
+++ b/rpmlint/checks/BashismsCheck.py
@@ -35,7 +35,9 @@ class BashismsCheck(AbstractFilesCheck):
                                env=ENGLISH_ENVIROMENT)
             if r.returncode == 2:
                 self.output.add_info('W', pkg, 'bin-sh-syntax-error', filename)
-        except (FileNotFoundError, UnicodeDecodeError):
+            elif r.returncode == 127:
+                raise FileNotFoundError(filename)
+        except UnicodeDecodeError:
             pass
 
         try:
@@ -44,5 +46,7 @@ class BashismsCheck(AbstractFilesCheck):
                                env=ENGLISH_ENVIROMENT)
             if r.returncode == 1:
                 self.output.add_info('W', pkg, 'potential-bashisms', filename)
-        except (FileNotFoundError, UnicodeDecodeError):
+            elif r.returncode == 2:
+                raise FileNotFoundError(filename)
+        except UnicodeDecodeError:
             pass

--- a/test/test_bashisms.py
+++ b/test/test_bashisms.py
@@ -20,3 +20,12 @@ def test_bashisms(tmpdir, package, bashismscheck):
     out = output.print_results(output.results)
     assert 'W: potential-bashisms /bin/script1' in out
     assert 'W: bin-sh-syntax-error /bin/script2' in out
+
+
+@pytest.mark.parametrize('package', ['binary/bashisms'])
+def test_bashisms_error(tmpdir, package, bashismscheck):
+    output, test = bashismscheck
+    package = get_tested_package(package, tmpdir)
+    package.dirname = 'I-do-not-exist-for-sure'
+    with pytest.raises(FileNotFoundError):
+        test.check(package)


### PR DESCRIPTION
I noticed that when ThreadPooll is used, exceptions are not propagated
properly. I fixed that and that requires some changes in BinariesCheck.