### PR TITLE
LddParser: do not run not needed parsing.

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -342,8 +342,7 @@ class BinariesCheck(AbstractCheck):
         # following issues are errors for shared libs and warnings for executables
         if not self.is_dynamically_linked:
             return
-        if (isinstance(pkg, InstalledPkg) or isinstance(pkg, FakePkg) and
-                not self.is_archive and not self.readelf_parser.is_debug):
+        if not self.is_archive and not self.readelf_parser.is_debug:
             info_type = 'E' if self.readelf_parser.is_shlib else 'W'
             for symbol in self.ldd_parser.undefined_symbols:
                 self.output.add_info(info_type, pkg, 'undefined-non-weak-symbol', path, symbol)
@@ -519,7 +518,8 @@ class BinariesCheck(AbstractCheck):
 
         if not self.is_archive:
             if self.is_dynamically_linked:
-                self.ldd_parser = LddParser(pkgfile_path, path)
+                is_installed_pkg = isinstance(pkg, InstalledPkg) or isinstance(pkg, FakePkg)
+                self.ldd_parser = LddParser(pkgfile_path, path, is_installed_pkg)
                 failed_reason = self.ldd_parser.parsing_failed_reason
                 if failed_reason:
                     self.output.add_info('E', pkg, 'ldd-failed', path, failed_reason)

--- a/rpmlint/lddparser.py
+++ b/rpmlint/lddparser.py
@@ -38,14 +38,15 @@ class LddParser:
     unused_regex = re.compile(r'^\s+(?P<lib>\S+)')
     undef_regex = re.compile(r'^undefined symbol:\s+(?P<symbol>[^, ]+)')
 
-    def __init__(self, pkgfile_path, path):
+    def __init__(self, pkgfile_path, path, is_installed_pkg):
         self.pkgfile_path = pkgfile_path
         self.dependencies = []
         self.unused_dependencies = []
         self.undefined_symbols = []
         self.parsing_failed_reason = None
-        self.parse_dependencies()
-        self.parse_undefined_symbols()
+        if is_installed_pkg:
+            self.parse_dependencies()
+            self.parse_undefined_symbols()
 
     def parse_dependencies(self):
         r = subprocess.run(['ldd', '-u', self.pkgfile_path], encoding='utf8',

--- a/test/test_ldd_parser.py
+++ b/test/test_ldd_parser.py
@@ -24,7 +24,7 @@ def get_full_path(path):
 def lddparser(path, system_path=None):
     if system_path is None:
         system_path = path
-    return LddParser(get_full_path(path), system_path)
+    return LddParser(get_full_path(path), system_path, True)
 
 
 def run_elf_checks(test, pkg, fullpath, path):


### PR DESCRIPTION
Do not parse dependencies and undefined symbols
for a not installed package.