### PR TITLE
Short errors for readelf-error.

### DIFF
--- a/rpmlint/readelfparser.py
+++ b/rpmlint/readelfparser.py
@@ -339,6 +339,7 @@ class ReadelfParser:
     in a structured format.
     """
 
+    NOT_ELF_ERROR = 'Error: Not an ELF file - it has the wrong magic bytes at the start'
     so_regex = re.compile(r'/lib(64)?/[^/]+\.so(\.[0-9]+)*$')
 
     def __init__(self, pkgfile_path, path):
@@ -359,4 +360,7 @@ class ReadelfParser:
                    self.symbol_table_info.parsing_failed_reason,
                    self.comment_section_info.parsing_failed_reason]
         reasons = [r for r in reasons if r]
+        for reason in reasons:
+            if self.NOT_ELF_ERROR in reason:
+                return self.NOT_ELF_ERROR
         return '\n'.join(reasons) if reasons else None

--- a/test/readelf/small_archive.a
+++ b/test/readelf/small_archive.a
@@ -1,0 +1,8 @@
+!<arch>
+limerick/       0           0     0     644     191       `
+There was a young man from Japan
+Whose limericks never would scan.
+When asked why that was,
+He replied "It's because
+I always try to cram as many words into the last line as I possibly can."
+

--- a/test/test_readelf_parser.py
+++ b/test/test_readelf_parser.py
@@ -167,6 +167,14 @@ def test_readelf_failure_in_package(binariescheck):
     assert 'readelf-failed /lib64/not-existing.so' in out
 
 
+def test_readelf_single_error_message(binariescheck):
+    output, test = binariescheck
+    run_elf_checks(test, FakePkg('fake'), get_full_path('small_archive.a'), '/lib64/small_archive.a')
+    out = output.print_results(output.results)
+    filtered = [line for line in out.splitlines() if 'Not an ELF file' in line]
+    assert len(filtered) == 1
+
+
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
 def test_no_soname(binariescheck):
     output, test = binariescheck


### PR DESCRIPTION
From:

```
dev86.x86_64: E: readelf-failed /usr/lib64/bcc/libdos.a readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
```

to:

```
dev86.x86_64: E: readelf-failed /usr/lib64/bcc/libdos.a readelf: Error: Not an ELF file - it has the wrong magic bytes at the start
```