### PR TITLE
Partially revert pstats changes.

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -1,7 +1,7 @@
 import cProfile
 import importlib
 import operator
-from pstats import SortKey, Stats
+from pstats import Stats
 from tempfile import gettempdir
 import time
 
@@ -128,12 +128,12 @@ class Lint(object):
         N = 30
         print(f'\n{Color.Bold}cProfile report:{Color.Reset}')
         self.profile.disable()
-        stats = Stats(self.profile).strip_dirs()
-        stats.sort_stats(SortKey.CUMULATIVE).print_stats(N)
+        stats = Stats(self.profile)
+        stats.sort_stats('cumulative').print_stats(N)
         print('========================================================')
-        stats.sort_stats(SortKey.PCALLS).print_stats(N)
+        stats.sort_stats('ncalls').print_stats(N)
         print('========================================================')
-        stats.sort_stats(SortKey.TIME).print_stats(N)
+        stats.sort_stats('tottime').print_stats(N)
 
     def _load_installed_rpms(self, packages):
         existing_packages = []

--- a/test/dump_stats.py
+++ b/test/dump_stats.py
@@ -4,6 +4,6 @@ if __name__ == '__main__':
 
     p = pstats.Stats(sys.argv[1])
     N = 60
-    p.sort_stats(pstats.SortKey.CUMULATIVE).print_stats(N)
+    p.sort_stats('cumulative').print_stats(N)
     print('========================================================')
-    p.sort_stats(pstats.SortKey.PCALLS).print_stats(N)
+    p.sort_stats('ncalls').print_stats(N)


### PR DESCRIPTION
Do not use SortKey as it was added in Python 3.7.
And strip_dirs was accidental change.