### PR TITLE
Catch more specfile-error errors.

### DIFF
--- a/test/Dockerfile-opensusetw
+++ b/test/Dockerfile-opensusetw
@@ -25,6 +25,7 @@ RUN zypper -n install \
         python3-pyxdg \
         python3-zstd \
         python3-toml \
+        rpm-build \
         sqlite3
 
 WORKDIR /usr/src/rpmlint

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -19,7 +19,8 @@ def test_check_include(tmpdir, speccheck):
     output, test = speccheck
     test.check_source(get_tested_package('source/CheckInclude', tmpdir))
     out = output.print_results(output.results)
-    assert '/tmp/' not in out
+    assert out.count('/tmp/') == 1
+    assert "specfile-error can't parse specfile" in out
     assert 'no-buildroot-tag' in out
     assert 'E: specfile-error error: query of specfile' not in out
 


### PR DESCRIPTION
It newly catches:

```
kernel-vanilla.spec: E: specfile-error error: Unable to open /tmp/rpmlint.kernel-vanilla-5.9.1-1.2.nosrc.rpm.mxml4l0o/kernel-spec-macros: No such file or directory
kernel-vanilla.spec: E: specfile-error error: query of specfile /tmp/rpmlint.kernel-vanilla-5.9.1-1.2.nosrc.rpm.mxml4l0o/kernel-vanilla.spec failed, can't parse
kernel-vanilla.spec: E: specfile-error can't parse specfile /tmp/rpmlint.kernel-vanilla-5.9.1-1.2.nosrc.rpm.mxml4l0o/kernel-vanilla.spec
```