### PR TITLE
Do not convert config to regex when -p is used.

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -46,8 +46,11 @@ class Lint(object):
             self.config.configuration['ExtractDir'] = gettempdir()
         # initialize output buffer
         self.output = Filter(self.config)
-        # preload the check list
-        self.load_checks()
+        # preload the check list if we not print config
+        # some of the config values are transformed e.g. to regular
+        # expressions
+        if not self.options['print_config']:
+            self.load_checks()
 
     def _run(self):
         start = time.monotonic()

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -74,6 +74,7 @@ def test_configoutput(capsys):
     out, err = capsys.readouterr()
     assert out
     assert 'Vendor = "Fedora Project"' in out
+    assert 're.compile' not in out
     assert not err
 
 


### PR DESCRIPTION
When we print config, do not initialize checks that may
modify configuration in place.