### PR TITLE
Fix filtering for errors with a badness.

### DIFF
--- a/rpmlint/filter.py
+++ b/rpmlint/filter.py
@@ -119,7 +119,7 @@ class Filter(object):
         result = f'{Color.Bold}{filename}{arch}:{line}{Color.Reset} {lvl_color}{level}: {rpmlint_issue}{Color.Reset}{bad_output}{detail_output}'
 
         # filter by the result message
-        result_no_color = f'{filename}{arch}:{line} {level}: {rpmlint_issue}{bad_output}{detail_output}'
+        result_no_color = f'{filename}{arch}:{line} {level}: {rpmlint_issue}{detail_output}'
         if self.filters_re and self.filters_re.search(result_no_color):
             return
 

--- a/test/configs/testfilters.config
+++ b/test/configs/testfilters.config
@@ -12,3 +12,6 @@ Filters = [
     'ngircd.*: E: bad-error',
     '^ngircd.*: E: test-color-error details of the error$'
 ]
+
+[Scoring]
+test-color-error = 12345


### PR DESCRIPTION
Filtering does not consider '(Badness: 12345)' part:
`nfs-client\.\S+: \w: filelist-forbidden-backup-file /var/lib/nfs/sm.bak`

Should match:
`nfs-client.x86_64: E: filelist-forbidden-backup-file (Badness: 10000) /var/lib/nfs/sm.bak`