### PR TITLE
Strip one filelist-forbidden-backup-file rule in Filters.

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -189,7 +189,7 @@ Filters = [
     ' postin-without-ghost-file-creation ',
 
 # Exceptions for filelist checks
-    'nfs-client\.\S+: \w: filelist-forbidden-backup-file /var/lib/nfs/sm.bak ',
+    'nfs-client\.\S+: \w: filelist-forbidden-backup-file /var/lib/nfs/sm.bak',
     'perl\.\S+: \w: filelist-forbidden-perl-dir ',
     'info\.\S+: \w: info-dir-file .*/usr/share/info/dir',
 


### PR DESCRIPTION
There's a bogus trailing space.