### PR TITLE
Consider also rpmlintrc file.

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -159,7 +159,7 @@ class Lint(object):
         return existing_packages
 
     def _find_rpmlintrc_files(self, path):
-        rpmlintrcs = []
+        rpmlintrcs = list(path.glob('rpmlintrc'))
         rpmlintrcs += sorted(path.glob('*.rpmlintrc'))
         rpmlintrcs += sorted(path.glob('*-rpmlintrc'))
         return rpmlintrcs


### PR DESCRIPTION
For instance ocaml uses the file.

The file can be seen here:
https://build.opensuse.org/package/view_file/openSUSE:Factory:Staging:M/ocaml/rpmlintrc?expand=1