### PR TITLE
Support addFilter rules that start with r''

### DIFF
--- a/rpmlint/config.py
+++ b/rpmlint/config.py
@@ -20,7 +20,7 @@ class Config(object):
     existing one.
     """
 
-    re_filter = re.compile(r'\s*addFilter\s*\([\"\'](.*)[\"\']\)')
+    re_filter = re.compile(r'\s*addFilter\s*\(r?[\"\'](.*)[\"\']\)')
     re_badness = re.compile(r'\s*setBadness\s*\([\'\"](.*)[\'\"],\s*[\'\"]?(\d+)[\'\"]?\)')
     config_defaults = Path(__file__).parent / 'configdefaults.toml'
 

--- a/test/configs/testing-rpmlintrc
+++ b/test/configs/testing-rpmlintrc
@@ -4,7 +4,7 @@ setBadness('suse-dbus-unauthorized-service', 0)
     setBadness('suse-other-error','20')
 setBadness      ('suse-other-error-123','200')
 # # Output filters
-addFilter("arch-independent-package-contains-binary-or-object ")
+addFilter(r"arch-independent-package-contains-binary-or-object ")
 addFilter('.*arch-independent-package-contains-binary-or-object.*/boot/vc/.*.elf')
 addFilter("class-path-in-manifest")
 addFilter("deprecated-grep")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -132,5 +132,6 @@ def test_rpmlint_loading():
     """
     cfg = Config(TEST_CONFIG)
     cfg.load_rpmlintrc(TEST_RPMLINTRC)
+    assert 'arch-independent-package-contains-binary-or-object ' in cfg.configuration['Filters']
     assert len(cfg.configuration['Filters']) == 110
     assert len(cfg.configuration['Scoring']) == 3


### PR DESCRIPTION
Example:
`addFilter(r'arch-dependent-file-in-usr-share .* /usr/share/mysql-test/lib/My/SafeProcess/my_safe_process')`