### PR TITLE
Do not print empty specfile-errors.

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -626,7 +626,8 @@ class SpecCheck(AbstractCheck):
                  '--specfile', self._spec_file), stderr=subprocess.PIPE, encoding='utf8', env=ENGLISH_ENVIROMENT)
 
             for line in outcmd.stderr.splitlines():
-                if 'warning:' not in line:
+                line = line.strip()
+                if line and 'warning:' not in line:
                     self.output.add_info('E', pkg, 'specfile-error', line)
         except UnicodeDecodeError as e:
             self.output.add_info('E', pkg, 'specfile-error', str(e))


### PR DESCRIPTION
Empty lines comes from e.g.

```
warning: extra tokens at the end of %else directive in line 250:  %else	# suse_version

warning: extra tokens at the end of %endif directive in line 252:  %endif	# suse_version

warning: extra tokens at the end of %else directive in line 293:  %else	# suse_version

warning: extra tokens at the end of %endif directive in line 295:  %endif	# suse_version

warning: extra tokens at the end of %else directive in line 296:  %else	# default_qt
```