### PR TITLE
Exit when a configuration file cannot be loaded.

### DIFF
--- a/rpmlint/config.py
+++ b/rpmlint/config.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import re
+import sys
 
 from rpmlint.helpers import print_warning
 import toml
@@ -133,14 +134,14 @@ class Config(object):
                 if path not in self.conf_files and path.exists():
                     self.conf_files.append(path)
 
-        try:
-            cfg = {}
-            for cf in sorted(self.conf_files, key=self._sort_config_files):
+        cfg = {}
+        for cf in sorted(self.conf_files, key=self._sort_config_files):
+            try:
                 toml_config = toml.load(cf)
                 self._merge_dictionaries(cfg, toml_config, self._is_override_config(cf))
-        except toml.decoder.TomlDecodeError as terr:
-            print_warning(f'(none): W: error parsing configuration files: {terr}')
-            cfg = None
+            except toml.decoder.TomlDecodeError as terr:
+                print_warning(f'(none): E: fatal error while parsing configuration file {cf}: {terr}')
+                sys.exit(4)
         self.configuration = cfg
 
     def load_rpmlintrc(self, rpmlintrc_file):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from rpmlint.config import Config
 
 from Testing import TEST_CONFIG, testpath
@@ -37,11 +38,10 @@ def test_custom_config(capsys):
 
 
 def test_broken_config(capsys):
-    cfg = Config(TEST_BROKEN)
-    out, err = capsys.readouterr()
-    assert 'error parsing configuration' in err
-    assert cfg.conf_files
-    assert len(cfg.conf_files) == 1
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        Config(TEST_BROKEN)
+    assert pytest_wrapped_e.type == SystemExit
+    assert pytest_wrapped_e.value.code == 4
 
 
 def test_parsing():


### PR DESCRIPTION
Newly updated error message is:
```
(none): E: fatal error while parsing configuration file configs/openSUSE/opensuse.toml: Unbalanced quotes (line 122 column 29 char 4640)
```