### PR TITLE
Language fixes

### DIFF
--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -1,4 +1,4 @@
-PAMModulesWhiteList = [
+PAMAuthorizedModules = [
     # pam_krb5
     "pam_krb5.so",
     "pam_krb5afs.so",

--- a/rpmlint/checks/PAMModulesCheck.py
+++ b/rpmlint/checks/PAMModulesCheck.py
@@ -11,7 +11,7 @@ class PAMModulesCheck(AbstractCheck):
         self.pam_authorized_modules = config.configuration['PAMAuthorizedModules']
         if not self.pam_authorized_modules:
             # compatibility: read the values from the original configuration option
-            self.pam_authorized_modules = config.configuration['PAMModulesWhiteList']
+            self.pam_authorized_modules = config.configuration.get('PAMModulesWhiteList', [])
 
     def check(self, pkg):
         if pkg.is_source:

--- a/rpmlint/checks/PAMModulesCheck.py
+++ b/rpmlint/checks/PAMModulesCheck.py
@@ -8,7 +8,10 @@ class PAMModulesCheck(AbstractCheck):
 
     def __init__(self, config, output):
         super().__init__(config, output)
-        self.pam_whitelist = config.configuration['PAMModulesWhiteList']
+        self.pam_authorized_modules = config.configuration['PAMAuthorizedModules']
+        if not self.pam_authorized_modules:
+            # compatibility: read the values from the original configuration option
+            self.pam_authorized_modules = config.configuration['PAMModulesWhiteList']
 
     def check(self, pkg):
         if pkg.is_source:
@@ -21,5 +24,5 @@ class PAMModulesCheck(AbstractCheck):
             m = self.pam_module_re.match(f)
             if m:
                 bn = m.groups()[0]
-                if bn not in self.pam_whitelist:
+                if bn not in self.pam_authorized_modules:
                     self.output.add_info('E', pkg, 'pam-unauthorized-module', bn)

--- a/rpmlint/configdefaults.toml
+++ b/rpmlint/configdefaults.toml
@@ -285,8 +285,8 @@ ValidLicenses = []
 # Default valid license exceptions
 ValidLicenseExceptions = []
 
-# Default white list for PAM modules
-PAMModulesWhiteList = []
+# Default list of authorized PAM modules
+PAMAuthorizedModules = []
 
 # Additional warnings on specific function calls
 [WarnOnFunction]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -51,7 +51,7 @@ def test_parsing():
         for SSL/TLS. That may cause the application not to use the system-wide set
         cryptographic policy and should be modified in accordance to:
         https://fedoraproject.org/wiki/Packaging:CryptoPolicies"""
-    call_blacklist = {
+    forbidden_functions = {
         'crypto-policy-non-compliance-openssl': {
             'f_name': 'SSL_CTX_set_cipher_list',
             'description': bad_crypto_warning,
@@ -69,7 +69,7 @@ def test_parsing():
     cfg = Config(TEST_CONFIG)
     assert cfg.configuration
     assert cfg.configuration['Distribution'] == 'Fedora Project'
-    assert cfg.configuration['WarnOnFunction'] == call_blacklist
+    assert cfg.configuration['WarnOnFunction'] == forbidden_functions
     # default value check
     assert cfg.configuration['UseDefaultRunlevels'] is True
 


### PR DESCRIPTION
This is related to https://www.redhat.com/en/blog/update-red-hats-conscious-language-efforts
I've renamed several variables which actually increase overall code readability and consistency.

Some words couldn't be replaced because they refer to locations and tools outside the project.