### PR TITLE
Fix parsing of 'Group' tag.

### DIFF
--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -465,6 +465,8 @@ class Pkg(AbstractPkg):
             or key in (x[0] for x in SCRIPT_TAGS) \
             or key in (x[1] for x in SCRIPT_TAGS):
                 val = byte_to_string(val)
+                if key == rpm.RPMTAG_GROUP and val == 'Unspecified':
+                    val = None
             return val
 
     # return the name of the directory where the package is extracted

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -160,6 +160,7 @@ def test_check_summary_warning(tmpdir, package, tagscheck):
     # Test if a package does not have an unexpanded
     # macro in it's specfile.
     assert 'W: unexpanded-macro' not in out
+    assert 'E: no-group-tag' in out
 
 
 @pytest.mark.parametrize('package', ['binary/no-url-tag'])


### PR DESCRIPTION
rpm emits the following value when the tag is not specified
in a spec file:
`headerPutString(pkg->header, RPMTAG_GROUP, "Unspecified");`

Fixes #611.