### PR TITLE
pybeam is mandatory module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For installation on your machine you will need the following packages:
 
 Mandatory:
 - Python 3.6 or newer
-- python3-setuptools, python3-toml, python3-pyxdg
+- python3-setuptools, python3-toml, python3-pyxdg, python3-beam
 - rpm and its python bindings
 - binutils, cpio, gzip, bzip, xz and zstd
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     keywords=['RPM', '.spec', 'validator'],
 
     install_requires=[
+        'pybeam',
         'pyxdg',
         'rpm',
         'toml',


### PR DESCRIPTION
addressing:
Traceback (most recent call last):
  File "/home/msuchy/projects/rpmlint/lint.py", line 5, in <module>
    lint()
  File "/home/msuchy/projects/rpmlint/rpmlint/cli.py", line 173, in lint
    lint = Lint(options)
  File "/home/msuchy/projects/rpmlint/rpmlint/lint.py", line 53, in __init__
    self.load_checks()
  File "/home/msuchy/projects/rpmlint/rpmlint/lint.py", line 291, in load_checks
    self.checks[check] = self.load_check(check)
  File "/home/msuchy/projects/rpmlint/rpmlint/lint.py", line 295, in load_check
    module = importlib.import_module(f'.{name}', package='rpmlint.checks')
  File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/msuchy/projects/rpmlint/rpmlint/checks/ErlangCheck.py", line 3, in <module>
    from pybeam import BeamFile
ModuleNotFoundError: No module named 'pybeam'