### PR TITLE
Add Opensuse dbus and pam whitelisting checks

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -16,6 +16,7 @@ Checks = [
 
     # Checks present at opensuse branch only
     "BrandingPolicyCheck",
+    "DBusServicesCheck",
     "FilelistCheck",
     "KMPPolicyCheck",
     "SystemdInstallCheck",

--- a/rpmlint/checks/DBusServicesCheck.py
+++ b/rpmlint/checks/DBusServicesCheck.py
@@ -21,9 +21,9 @@ class DBusServicesCheck(AbstractCheck):
                 if f.startswith(p):
 
                     if f in pkg.ghost_files:
-                        self.output.add_info('E', pkg, 'dbus-ghost-service', f)
+                        self.output.add_info('E', pkg, 'suse-dbus-ghost-service', f)
                         continue
 
                     bn = f[len(p):]
                     if bn not in self.services_whitelist:
-                        self.output.add_info('E', pkg, 'dbus-unauthorized-service', f)
+                        self.output.add_info('E', pkg, 'suse-dbus-unauthorized-service', f)

--- a/rpmlint/checks/DBusServicesCheck.py
+++ b/rpmlint/checks/DBusServicesCheck.py
@@ -2,7 +2,7 @@ from rpmlint.checks.AbstractCheck import AbstractCheck
 
 
 class DBusServicesCheck(AbstractCheck):
-    _dbus_system_paths = [
+    dbus_system_paths = [
         '/usr/share/dbus-1/system-services/',
         '/usr/share/dbus-1/system.d/',
         '/etc/dbus-1/system.d/'
@@ -17,9 +17,8 @@ class DBusServicesCheck(AbstractCheck):
             return
 
         for f in pkg.files:
-            for p in self._dbus_system_paths:
+            for p in self.dbus_system_paths:
                 if f.startswith(p):
-
                     if f in pkg.ghost_files:
                         self.output.add_info('E', pkg, 'suse-dbus-ghost-service', f)
                         continue

--- a/rpmlint/checks/DBusServicesCheck.py
+++ b/rpmlint/checks/DBusServicesCheck.py
@@ -1,0 +1,29 @@
+from rpmlint.checks.AbstractCheck import AbstractCheck
+
+
+class DBusServicesCheck(AbstractCheck):
+    _dbus_system_paths = [
+        '/usr/share/dbus-1/system-services/',
+        '/usr/share/dbus-1/system.d/',
+        '/etc/dbus-1/system.d/'
+    ]
+
+    def __init__(self, config, output):
+        super().__init__(config, output)
+        self.services_whitelist = config.configuration['DBUSServices']['WhiteList']
+
+    def check(self, pkg):
+        if pkg.is_source:
+            return
+
+        for f in pkg.files:
+            for p in self._dbus_system_paths:
+                if f.startswith(p):
+
+                    if f in pkg.ghost_files:
+                        self.output.add_info('E', pkg, 'dbus-ghost-service', f)
+                        continue
+
+                    bn = f[len(p):]
+                    if bn not in self.services_whitelist:
+                        self.output.add_info('E', pkg, 'dbus-unauthorized-service', f)

--- a/rpmlint/checks/PAMModulesCheck.py
+++ b/rpmlint/checks/PAMModulesCheck.py
@@ -15,11 +15,12 @@ class PAMModulesCheck(AbstractCheck):
             return
 
         for f in pkg.files:
-            if f in pkg.ghost_files:
-                continue
-
             m = self.pam_module_re.match(f)
             if m:
+                if f in pkg.ghost_files:
+                    self.output.add_info('E', pkg, 'pam-ghost-module', f)
+                    continue
+
                 bn = m.groups()[0]
                 if bn not in self.pam_authorized_modules:
                     self.output.add_info('E', pkg, 'pam-unauthorized-module', bn)

--- a/rpmlint/descriptions/DBusServicesCheck.toml
+++ b/rpmlint/descriptions/DBusServicesCheck.toml
@@ -1,8 +1,8 @@
 AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
 
-dbus-ghost-service="""
+suse-dbus-ghost-service="""
 This package installs a DBUS system service marked as %ghost. This is not allowed, since it is impossible to review. Please refer to #AUDIT_BUG_URL# for more information.
 """
-dbus-unauthorized-service="""
+suse-dbus-unauthorized-service="""
 The package installs a DBUS system service file. If the package is intended for inclusion in any SUSE product please open a bug report to request review of the package by the security team. Please refer to #AUDIT_BUG_URL# for more information.
 """

--- a/rpmlint/descriptions/DBusServicesCheck.toml
+++ b/rpmlint/descriptions/DBusServicesCheck.toml
@@ -1,0 +1,8 @@
+AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
+
+dbus-ghost-service="""
+This package installs a DBUS system service marked as %ghost. This is not allowed, since it is impossible to review. Please refer to #AUDIT_BUG_URL# for more information.
+"""
+dbus-unauthorized-service="""
+The package installs a DBUS system service file. If the package is intended for inclusion in any SUSE product please open a bug report to request review of the package by the security team. Please refer to #AUDIT_BUG_URL# for more information.
+"""

--- a/rpmlint/descriptions/DBusServicesCheck.toml
+++ b/rpmlint/descriptions/DBusServicesCheck.toml
@@ -1,5 +1,3 @@
-AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
-
 suse-dbus-ghost-service="""
 This package installs a DBUS system service marked as %ghost. This is not allowed, since it is impossible to review. Please refer to #AUDIT_BUG_URL# for more information.
 """

--- a/rpmlint/descriptions/FileDigestCheck.toml
+++ b/rpmlint/descriptions/FileDigestCheck.toml
@@ -1,4 +1,3 @@
-AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
 SUFFIX = "requires a review and whitelisting by the SUSE security team. Before submitting for any product or openSUSE:Factory please open an AUDIT bug according to the guidelines in #AUDIT_BUG_URL#."
 
 cron-file-digest-unauthorized="Packaging cron jobs #SUFFIX#"

--- a/rpmlint/descriptions/FileMetadataCheck.toml
+++ b/rpmlint/descriptions/FileMetadataCheck.toml
@@ -1,4 +1,3 @@
-AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
 SUFFIX = "requires a review and whitelisting by the SUSE security team. Before submitting this for any product or openSUSE:Factory please open an AUDIT bug according to the guidelines in #AUDIT_BUG_URL#."
 
 device-unauthorized-file="Packaging device files #SUFFIX#"

--- a/rpmlint/descriptions/PAMModulesCheck.toml
+++ b/rpmlint/descriptions/PAMModulesCheck.toml
@@ -1,5 +1,3 @@
-AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
-
 pam-unauthorized-module="""
 The package installs a PAM module. If the package is intended for inclusion in any SUSE product please open a bug report to request review of the package by the security team. Please refer to #AUDIT_BUG_URL# for more information.
 """

--- a/rpmlint/descriptions/PAMModulesCheck.toml
+++ b/rpmlint/descriptions/PAMModulesCheck.toml
@@ -1,5 +1,8 @@
+AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
+
 pam-unauthorized-module="""
-The package installs a PAM module. If the package
-is intended for inclusion the PAM module name must
-be included in the white list.
+The package installs a PAM module. If the package is intended for inclusion in any SUSE product please open a bug report to request review of the package by the security team. Please refer to #AUDIT_BUG_URL# for more information.
+"""
+pam-ghost-module="""
+The package installs a PAM module as %ghost file. This is not allowed, since it is impossible to review. Please refer to #AUDIT_BUG_URL# for more information.
 """

--- a/rpmlint/descriptions/Variables.toml
+++ b/rpmlint/descriptions/Variables.toml
@@ -1,0 +1,1 @@
+AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -124,7 +124,12 @@ Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
 eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
 in culpa qui officia deserunt mollit anim id est laborum.
 
-ngircd.x86_64: E: suse-dbus-unauthorized-service\n"""
+ngircd.x86_64: E: suse-dbus-unauthorized-service
+The package installs a DBUS system service file. If the package is intended
+for inclusion in any SUSE product please open a bug report to request review
+of the package by the security team. Please refer to
+https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs for
+more information.\n\n"""
     cfg = Config(TEST_CONFIG_FILTERS)
     result = Filter(cfg)
     pkg = get_tested_package(TEST_PACKAGE, tmpdir)
@@ -138,7 +143,7 @@ ngircd.x86_64: E: suse-dbus-unauthorized-service\n"""
     result.error_details.update({'suse-other-error': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'})
     assert len(result.print_results(result.results).splitlines()) == 4
     result.info = True
-    assert len(result.print_results(result.results).splitlines()) == 11
+    assert len(result.print_results(result.results).splitlines()) == 17
     assert result.print_results(result.results) == expected_output
 
 


### PR DESCRIPTION
Adds dbus services whitelisting and ghost file checks in `DBusServicesCheck`.
Adds check for pam ghost files in `PAMModulesCheck`.