### PR TITLE
Use proper folder _sourcedir for spec files.

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -141,6 +141,7 @@ class SpecCheck(AbstractCheck):
     def check_spec(self, pkg):
         """Find specfile in specified path and run spec file related checks."""
         self._spec_file = pkg.name
+        self._spec_file_dir = str(Path(self._spec_file).parent)
         spec_only = isinstance(pkg, Pkg.FakePkg)
         spec_lines = readlines(self._spec_file)
         patches = {}
@@ -622,7 +623,7 @@ class SpecCheck(AbstractCheck):
         # capture and print them nicely, so we do it once each way :P
         try:
             outcmd = subprocess.run(
-                ('rpm', '-q', '--qf=', '-D', '_sourcedir %s' % Path(self._spec_file).parent,
+                ('rpm', '-q', '--qf=', '-D', '_sourcedir %s' % self._spec_file_dir,
                  '--specfile', self._spec_file), stderr=subprocess.PIPE, encoding='utf8', env=ENGLISH_ENVIROMENT)
 
             for line in outcmd.stderr.splitlines():
@@ -637,7 +638,7 @@ class SpecCheck(AbstractCheck):
         # grab sources and patches from parsed spec object to get
         # them with macros expanded for URL checking
         spec_obj = None
-        rpm.addMacro('_sourcedir', pkg.dirName())
+        rpm.addMacro('_sourcedir', self._spec_file_dir)
         try:
             transaction_set = rpm.TransactionSet()
             spec_obj = transaction_set.parseSpec(str(self._spec_file))

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -19,8 +19,7 @@ def test_check_include(tmpdir, speccheck):
     output, test = speccheck
     test.check_source(get_tested_package('source/CheckInclude', tmpdir))
     out = output.print_results(output.results)
-    assert out.count('/tmp/') == 1
-    assert "specfile-error can't parse specfile" in out
+    assert "specfile-error can't parse specfile" not in out
     assert 'no-buildroot-tag' in out
     assert 'E: specfile-error error: query of specfile' not in out
 


### PR DESCRIPTION
Fixes #632.