### PR TITLE
Fix filecaps bug for older rpm versions

### DIFF
--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -604,7 +604,7 @@ class Pkg(AbstractPkg):
                     # patched so it generates them.
                     pkgfile.magic = ''
                 if filecaps:
-                    pkgfile.filecaps = filecaps[idx]
+                    pkgfile.filecaps = byte_to_string(filecaps[idx])
                 ret[pkgfile.name] = pkgfile
         return ret
 


### PR DESCRIPTION
filecaps in rpm 4.14.1 are given as byte not str, fixes by casting to str