### PR TITLE
Fix skipif predicates.

### DIFF
--- a/test/Testing.py
+++ b/test/Testing.py
@@ -17,8 +17,8 @@ CONFIG = Config(TEST_CONFIG)
 
 # predicates used for pytest.mark.skipif decorators
 IS_X86_64 = platform.machine() == 'x86_64'
-IS_I686 = re.match(platform.machine(), 'i[3456]86') is not None
-HAS_32BIT_GLIBC = glob.glob('/lib/ld-linux.so.*') is not None
+IS_I686 = re.match(platform.machine(), 'i[3456]86')
+HAS_32BIT_GLIBC = glob.glob('/lib/ld-linux.so.*')
 
 
 def get_tested_path(path):


### PR DESCRIPTION
I made a mistake in `HAS_32BIT_GLIBC ` as empty `glob` gives `[]`, and `[] is not None` is `True` which is not desired.
Addresses issue seen in #381.