### PR TITLE
Fix the source distribution manifest to include all test data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,9 +3,4 @@ include COPYING
 include README.md
 recursive-include configs *.toml
 recursive-include rpmlint *.toml
-recursive-include test/binary *
-recursive-include test/configs *
-recursive-include test/pyc *
-recursive-include test/source *
-recursive-include test/spec *
-include test/Dockerfile*
+recursive-include test *


### PR DESCRIPTION
We actually need all this for the test suite, so let's just pull it all in.