### PR TITLE
Adjust GitHub Actions to use "main" branch instead of "master"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [ master, opensuse ]
+    branches: [ main, opensuse ]
   pull_request:
-    branches: [ master, opensuse ]
+    branches: [ main, opensuse ]
 
 jobs:
   build_and_test:


### PR DESCRIPTION
Now that the branch has been renamed, we (still) want GitHub Actions
to run on the mainline tree.