### PR TITLE
Opensuse polkit descriptions and configuration

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -19,6 +19,7 @@ Checks = [
     "DBusServicesCheck",
     "FilelistCheck",
     "KMPPolicyCheck",
+    "PolkitCheck",
     "SystemdInstallCheck",
     "SUIDPermissionsCheck",
 ]

--- a/rpmlint/descriptions/PolkitCheck.toml
+++ b/rpmlint/descriptions/PolkitCheck.toml
@@ -25,17 +25,6 @@ via authentication. Use e.g. 'auth_admin' instead of 'no' and make
 sure to define 'allow_any'. This is an issue only if the privilege
 is not listed in /etc/polkit-default-privs.
 """
-polkit-unauthorized-rules="""
-A polkit rules file installed by this package is not whitelisted in the
-polkit-whitelisting package. If the package is intended for inclusion in any
-SUSE product please open a bug report to request review of the package by the
-security team. Please refer to {url} for more information.
-"""
-polkit-changed-rules="""
-A polkit rules file installed by this package changed in content. Please
-open a bug report to request follow-up review of the introduced changes by
-the security team. Please refer to {url} for more information.
-"""
 polkit-ghost-file="""
 This package installs a polkit rule or policy as %ghost file.
 This is not allowed as it is impossible to review. For more

--- a/rpmlint/descriptions/PolkitCheck.toml
+++ b/rpmlint/descriptions/PolkitCheck.toml
@@ -1,0 +1,43 @@
+polkit-unauthorized-file="""
+A custom polkit rule file is installed by this package. If the package is
+intended for inclusion in any SUSE product please open a bug report to request
+review of the package by the security team. Please refer to {url} for more
+information"""
+polkit-unauthorized-privilege="""
+The package allows unprivileged users to carry out privileged
+operations without authentication. This could cause security
+problems if not done carefully. If the package is intended for
+inclusion in any SUSE product please open a bug report to request
+review of the package by the security team. Please refer to {url}
+for more information.
+"""
+polkit-untracked-privilege="""
+The privilege is not listed in /etc/polkit-default-privs.*
+which makes it harder for admins to find. Furthermore polkit
+authorization checks can easily introduce security issues. If the
+package is intended for inclusion in any SUSE product please open
+a bug report to request review of the package by the security team.
+Please refer to {url} for more information.
+"""
+polkit-cant-acquire-privilege="""
+Usability can be improved by allowing users to acquire privileges
+via authentication. Use e.g. 'auth_admin' instead of 'no' and make
+sure to define 'allow_any'. This is an issue only if the privilege
+is not listed in /etc/polkit-default-privs.
+"""
+polkit-unauthorized-rules="""
+A polkit rules file installed by this package is not whitelisted in the
+polkit-whitelisting package. If the package is intended for inclusion in any
+SUSE product please open a bug report to request review of the package by the
+security team. Please refer to {url} for more information.
+"""
+polkit-changed-rules="""
+A polkit rules file installed by this package changed in content. Please
+open a bug report to request follow-up review of the introduced changes by
+the security team. Please refer to {url} for more information.
+"""
+polkit-ghost-file="""
+This package installs a polkit rule or policy as %ghost file.
+This is not allowed as it is impossible to review. For more
+information please refer to {url} for more information.
+"""


### PR DESCRIPTION
As discussed in #644 

This needs to be rebased on top of the `opensuse` branch after the changes from #646 have been merged into `main` and `opensuse` has been successfully rebased on top of `main`.