### PR TITLE
Fix opensuse config

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -239,6 +239,14 @@ name = "licenses"
 path = "consolehelper$"
 name = "usermode-consoleonly"
 
+[FileDigestLocation]
+
+[FileDigestGroup]
+
+[DeviceFilesWhitelist]
+
+[WorldWritableWhitelist]
+
 [Descriptions]
 non-standard-uid = '''A file in this package is owned by an unregistered user id.
 To register the user, please make a pull request to the rpmlint config file


### PR DESCRIPTION
As @mgerstner pointed out, I messed up the PR #652
This moves the missing configs to the opensuse.toml. This works now, I tested it.

@marxin 