### PR TITLE
Skip tests requiring optional deps

### DIFF
--- a/test/Testing.py
+++ b/test/Testing.py
@@ -22,6 +22,7 @@ IS_I686 = re.match(platform.machine(), 'i[3456]86')
 HAS_32BIT_GLIBC = glob.glob('/lib/ld-linux.so.*')
 HAS_CHECKBASHISMS = shutil.which('checkbashisms')
 HAS_DASH = shutil.which('dash')
+HAS_DESKTOP_FILE_UTILS = shutil.which('desktop-file-validate')
 
 
 def get_tested_path(path):

--- a/test/Testing.py
+++ b/test/Testing.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import platform
 import re
 import shutil
+import subprocess
 
 from rpmlint.config import Config
 from rpmlint.pkg import FakePkg, Pkg
@@ -24,6 +25,9 @@ HAS_CHECKBASHISMS = shutil.which('checkbashisms')
 HAS_DASH = shutil.which('dash')
 HAS_DESKTOP_FILE_UTILS = shutil.which('desktop-file-validate')
 HAS_APPSTREAM_GLIB = shutil.which('appstream-util')
+
+RPMDB_PATH = subprocess.run(['rpm', '--eval', '"%_dbpath"'], encoding='utf8').stdout
+HAS_RPMDB = RPMDB_PATH and Path(RPMDB_PATH).exists()
 
 
 def get_tested_path(path):

--- a/test/Testing.py
+++ b/test/Testing.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import platform
 import re
+import shutil
 
 from rpmlint.config import Config
 from rpmlint.pkg import FakePkg, Pkg
@@ -19,6 +20,8 @@ CONFIG = Config(TEST_CONFIG)
 IS_X86_64 = platform.machine() == 'x86_64'
 IS_I686 = re.match(platform.machine(), 'i[3456]86')
 HAS_32BIT_GLIBC = glob.glob('/lib/ld-linux.so.*')
+HAS_CHECKBASHISMS = shutil.which('checkbashisms')
+HAS_DASH = shutil.which('dash')
 
 
 def get_tested_path(path):

--- a/test/Testing.py
+++ b/test/Testing.py
@@ -23,6 +23,7 @@ HAS_32BIT_GLIBC = glob.glob('/lib/ld-linux.so.*')
 HAS_CHECKBASHISMS = shutil.which('checkbashisms')
 HAS_DASH = shutil.which('dash')
 HAS_DESKTOP_FILE_UTILS = shutil.which('desktop-file-validate')
+HAS_APPSTREAM_GLIB = shutil.which('appstream-util')
 
 
 def get_tested_path(path):

--- a/test/test_appdata.py
+++ b/test/test_appdata.py
@@ -4,7 +4,7 @@ import pytest
 from rpmlint.checks.AppDataCheck import AppDataCheck
 from rpmlint.filter import Filter
 
-from Testing import CONFIG, get_tested_package
+from Testing import CONFIG, get_tested_package, HAS_APPSTREAM_GLIB
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -15,6 +15,7 @@ def appdatacheck():
     return output, test
 
 
+@pytest.mark.skipif(not HAS_APPSTREAM_GLIB, reason='Optional dependency appstream-glib not installed')
 @pytest.mark.parametrize('package', ['binary/appdata'])
 def test_appdata_fail(tmpdir, package, appdatacheck):
     output, test = appdatacheck

--- a/test/test_bashisms.py
+++ b/test/test_bashisms.py
@@ -2,7 +2,7 @@ import pytest
 from rpmlint.checks.BashismsCheck import BashismsCheck
 from rpmlint.filter import Filter
 
-from Testing import CONFIG, get_tested_package
+from Testing import CONFIG, get_tested_package, HAS_CHECKBASHISMS, HAS_DASH
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -13,6 +13,8 @@ def bashismscheck():
     return output, test
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('package', ['binary/bashisms'])
 def test_bashisms(tmpdir, package, bashismscheck):
     output, test = bashismscheck
@@ -22,6 +24,8 @@ def test_bashisms(tmpdir, package, bashismscheck):
     assert 'W: bin-sh-syntax-error /bin/script2' in out
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('package', ['binary/bashisms'])
 def test_bashisms_error(tmpdir, package, bashismscheck):
     output, test = bashismscheck

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -5,6 +5,8 @@ from rpmlint.cli import process_lint_args
 from rpmlint.config import Config
 from rpmlint.lint import Lint
 
+from Testing import HAS_CHECKBASHISMS, HAS_DASH
+
 
 @pytest.mark.parametrize('test_arguments', [['-c', 'rpmlint/configs/thisdoesntexist.toml']])
 def test_parsing_non_existing_config_file(test_arguments):
@@ -21,6 +23,8 @@ def test_parsing_config_file(test_arguments):
     assert parsed['config'][0] == PosixPath('rpmlint/configdefaults.toml')
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('test_arguments', [['-c', 'configs/openSUSE']])
 def test_parsing_opensuse_conf(test_arguments):
     parsed = process_lint_args(test_arguments)
@@ -50,6 +54,8 @@ def test_parsing_opensuse_conf(test_arguments):
         assert score_key in checks
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('test_arguments', [['-c', 'configs/Fedora']])
 def test_parsing_fedora_conf(test_arguments):
     parsed = process_lint_args(test_arguments)

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 from rpmlint.lint import Lint
+from rpmlint.spellcheck import ENCHANT
 
 from Testing import HAS_CHECKBASHISMS, HAS_DASH, TEST_CONFIG, testpath
 
@@ -167,6 +168,7 @@ def test_explain_non_standard_dir_from_cfg(capsys):
     assert not err
 
 
+@pytest.mark.skipif(not ENCHANT, reason='Optional dependency pyenchant not install')
 @pytest.mark.parametrize('packages', [Path('test/binary/non-fhs-0-0.x86_64.rpm')])
 def test_descriptions_from_config(capsys, packages):
     """

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from rpmlint.lint import Lint
 
-from Testing import TEST_CONFIG, testpath
+from Testing import HAS_CHECKBASHISMS, HAS_DASH, TEST_CONFIG, testpath
 
 TEST_RPMLINTRC = testpath() / 'configs/testing2-rpmlintrc'
 
@@ -287,6 +287,8 @@ def test_header_information(capsys):
     assert 'packages: 1' in out
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('packages', [list(Path('test').glob('*/*.rpm'))])
 @pytest.mark.parametrize('configs', [list(Path('configs').glob('*/*.toml'))])
 @pytest.mark.no_cover
@@ -310,6 +312,8 @@ def test_run_full_rpm(capsys, packages, configs):
     assert not err_reduced
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('packages', [list(Path('test/spec').glob('*.spec'))])
 @pytest.mark.parametrize('configs', [list(Path('configs').glob('*/*.toml'))])
 @pytest.mark.no_cover
@@ -327,6 +331,8 @@ def test_run_full_specs(capsys, packages, configs):
     assert not err
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('packages', [Path('test/spec')])
 @pytest.mark.no_cover
 def test_run_full_directory(capsys, packages):
@@ -347,6 +353,8 @@ def test_run_full_directory(capsys, packages):
     assert not err
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 def test_run_empty(capsys):
     linter = Lint(options_preset)
     linter.run()
@@ -355,6 +363,8 @@ def test_run_empty(capsys):
     assert '0 packages and 0 specfiles checked; 0 errors, 0 warnings' in out
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('packages', [Path('test/rpmlintrc/single')])
 def test_run_rpmlintrc_single_dir(capsys, packages):
     additional_options = {
@@ -368,6 +378,8 @@ def test_run_rpmlintrc_single_dir(capsys, packages):
     assert 'rpmlintrc:' in out
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('packages', [Path('test/rpmlintrc/multiple')])
 def test_run_rpmlintrc_multiple(capsys, packages):
     additional_options = {
@@ -382,6 +394,8 @@ def test_run_rpmlintrc_multiple(capsys, packages):
     assert '0 badness' in out
 
 
+@pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
+@pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('packages', [Path('test/rpmlintrc/single/sample.spec')])
 def test_run_rpmlintrc_single_file(capsys, packages):
     additional_options = {

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -4,7 +4,9 @@ import pytest
 from rpmlint.lint import Lint
 from rpmlint.spellcheck import ENCHANT
 
-from Testing import HAS_CHECKBASHISMS, HAS_DASH, TEST_CONFIG, testpath
+from Testing import (
+    HAS_CHECKBASHISMS, HAS_DASH, HAS_RPMDB, TEST_CONFIG, testpath
+)
 
 TEST_RPMLINTRC = testpath() / 'configs/testing2-rpmlintrc'
 
@@ -212,6 +214,7 @@ def test_run_single(capsys, packages):
     assert not err
 
 
+@pytest.mark.skipif(not HAS_RPMDB, reason='No RPM database present')
 @pytest.mark.parametrize('packages', [Path('test/source/wrongsrc-0-0.src.rpm')])
 def test_run_installed(capsys, packages):
     # load up 1 normal path file and 2 installed packages
@@ -247,6 +250,7 @@ def test_run_strict(capsys, packages):
     assert not err
 
 
+@pytest.mark.skipif(not HAS_RPMDB, reason='No RPM database present')
 def test_run_installed_not_present(capsys):
     additional_options = {
         'rpmfile': [],
@@ -262,6 +266,7 @@ def test_run_installed_not_present(capsys):
     assert 'There are no files to process' in err
 
 
+@pytest.mark.skipif(not HAS_RPMDB, reason='No RPM database present')
 def test_run_installed_and_no_files(capsys):
     additional_options = {
         'rpmfile': [],
@@ -276,6 +281,7 @@ def test_run_installed_and_no_files(capsys):
     assert not err
 
 
+@pytest.mark.skipif(not HAS_RPMDB, reason='No RPM database present')
 def test_header_information(capsys):
     additional_options = {
         'rpmfile': [],

--- a/test/test_menuxdg.py
+++ b/test/test_menuxdg.py
@@ -2,7 +2,7 @@ import pytest
 from rpmlint.checks.MenuXDGCheck import MenuXDGCheck
 from rpmlint.filter import Filter
 
-from Testing import CONFIG, get_tested_package
+from Testing import CONFIG, get_tested_package, HAS_DESKTOP_FILE_UTILS
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -13,6 +13,7 @@ def menuxdgcheck():
     return output, test
 
 
+@pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/menuxdg1'])
 def test_raises_parse_error(tmpdir, package, menuxdgcheck):
     output, test = menuxdgcheck
@@ -24,6 +25,7 @@ def test_raises_parse_error(tmpdir, package, menuxdgcheck):
     assert 'check with desktop-file-validate' in out
 
 
+@pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/desktopfile-bad-binary'])
 def test_without_binary(tmpdir, package, menuxdgcheck):
     output, test = menuxdgcheck
@@ -32,6 +34,7 @@ def test_without_binary(tmpdir, package, menuxdgcheck):
     assert 'desktopfile-without-binary' in out
 
 
+@pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/desktopfile-bad-duplicate'])
 def test_duplicate(tmpdir, package, menuxdgcheck):
     output, test = menuxdgcheck
@@ -41,6 +44,7 @@ def test_duplicate(tmpdir, package, menuxdgcheck):
     assert 'invalid-desktopfile' in out
 
 
+@pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/desktopfile-bad-section'])
 def test_missing_header(tmpdir, package, menuxdgcheck):
     output, test = menuxdgcheck
@@ -50,6 +54,7 @@ def test_missing_header(tmpdir, package, menuxdgcheck):
     assert 'invalid-desktopfile' in out
 
 
+@pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/desktopfile-bad-unicode'])
 def test_bad_unicode(tmpdir, package, menuxdgcheck):
     output, test = menuxdgcheck
@@ -58,6 +63,7 @@ def test_bad_unicode(tmpdir, package, menuxdgcheck):
     assert 'non-utf8-desktopfile' in out
 
 
+@pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/desktopfile-good'])
 def test_good(tmpdir, package, menuxdgcheck):
     output, test = menuxdgcheck


### PR DESCRIPTION
As discussed in https://github.com/rpm-software-management/rpmlint/issues/657, add pytest predicates for tests that depend on optional dependencies. In this revision the executables needed are looked for but the variables used in the predicates are named after the package containing said executable.

This contribution together with my WIP `PKGBUILD` builds and tests this project without any test failures in my package testing image.

While doing this I discovered one additional dependency which I did not include in the list I shared in the issue: `desktop-file-utils`. I placed this among the optional dependencies, making the complete dependency list for Arch Linux:
```
depends=(
  'binutils'
  'bzip2'
  'cpio'
  'gzip'
  'python'
  'python-magic'
  'python-pybeam'
  'python-pyxdg'
  'python-toml'
  'python-zstd'
  'rpm-tools'
  'xz'
  'zstd'
)
makedepends=('python-setuptools')
checkdepends=(
  'python-pytest'
  'python-pytest-cov'
  'python-pytest-flake8'
  'python-pytest-xdist'
)
optdepends=(
  'appstream-glib: for AppData file validation'
  'checkbashisms: for checking bashisms'
  'dash: for checking bashisms'
  'desktop-file-utils: for checking desktop entries'
  'python-pyenchant: for spell checking'
)
```
If this is more suitable as a mandatory dependency, I'll make sure to change it and drop the commit skipping the related tests.

Finally, a small wish. If this gets merged it would be great if a new release could be made. That would releave me of having to publish this as a patch to the 2.0.0 version in order to update this package for the Arch Linux users.

Thanks!

Resolves https://github.com/rpm-software-management/rpmlint/issues/657.