### PR TITLE
Skip tests requiring spellchecking dictionaries if not installed

### DIFF
--- a/test/Testing.py
+++ b/test/Testing.py
@@ -8,6 +8,7 @@ import subprocess
 
 from rpmlint.config import Config
 from rpmlint.pkg import FakePkg, Pkg
+import rpmlint.spellcheck
 
 
 def testpath():
@@ -28,6 +29,21 @@ HAS_APPSTREAM_GLIB = shutil.which('appstream-util')
 
 RPMDB_PATH = subprocess.run(['rpm', '--eval', '"%_dbpath"'], encoding='utf8').stdout
 HAS_RPMDB = RPMDB_PATH and Path(RPMDB_PATH).exists()
+
+
+def _has_dictionary(language):
+    if not rpmlint.spellcheck.ENCHANT:
+        return False
+    spell = rpmlint.spellcheck.Spellcheck()
+    spell._init_checker(language)
+    return (
+        language in spell._enchant_checkers and
+        spell._enchant_checkers[language] is not None
+    )
+
+
+HAS_ENGLISH_DICTIONARY = _has_dictionary('en_US')
+HAS_CZECH_DICTIONARY = _has_dictionary('cs_CZ')
 
 
 def get_tested_path(path):

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -5,7 +5,8 @@ from rpmlint.lint import Lint
 from rpmlint.spellcheck import ENCHANT
 
 from Testing import (
-    HAS_CHECKBASHISMS, HAS_DASH, HAS_RPMDB, TEST_CONFIG, testpath
+    HAS_CHECKBASHISMS, HAS_DASH, HAS_ENGLISH_DICTIONARY, HAS_RPMDB,
+    TEST_CONFIG, testpath
 )
 
 TEST_RPMLINTRC = testpath() / 'configs/testing2-rpmlintrc'
@@ -171,6 +172,7 @@ def test_explain_non_standard_dir_from_cfg(capsys):
 
 
 @pytest.mark.skipif(not ENCHANT, reason='Optional dependency pyenchant not install')
+@pytest.mark.skipif(not HAS_ENGLISH_DICTIONARY, reason='Missing English dictionary')
 @pytest.mark.parametrize('packages', [Path('test/binary/non-fhs-0-0.x86_64.rpm')])
 def test_descriptions_from_config(capsys, packages):
     """

--- a/test/test_spellchecking.py
+++ b/test/test_spellchecking.py
@@ -1,8 +1,11 @@
 import pytest
 import rpmlint.spellcheck
 
+from Testing import HAS_CZECH_DICTIONARY, HAS_ENGLISH_DICTIONARY
+
 
 @pytest.mark.skipif(not rpmlint.spellcheck.ENCHANT, reason='Missing enchant bindings')
+@pytest.mark.skipif(not HAS_ENGLISH_DICTIONARY, reason='Missing English dictionary')
 def test_spelldict(capsys):
     """
     Check we can init dictionary spellchecker
@@ -25,6 +28,8 @@ def test_spelldict(capsys):
 
 
 @pytest.mark.skipif(not rpmlint.spellcheck.ENCHANT, reason='Missing enchant bindings')
+@pytest.mark.skipif(not HAS_ENGLISH_DICTIONARY, reason='Missing English dictionary')
+@pytest.mark.skipif(not HAS_CZECH_DICTIONARY, reason='Missing Czech dictionary')
 def test_spellchecking():
     """
     Check if we can test the spelling
@@ -55,6 +60,7 @@ def test_spellchecking():
 
 
 @pytest.mark.skipif(not rpmlint.spellcheck.ENCHANT, reason='Missing enchant bindings')
+@pytest.mark.skipif(not HAS_ENGLISH_DICTIONARY, reason='Missing English dictionary')
 def test_pkgname_spellchecking():
     spell = rpmlint.spellcheck.Spellcheck()
 


### PR DESCRIPTION
I discovered a new problem while working on the my packaging. If a user has pyenchant installed but not the required dictionary/ies, some tests will fail. This MR resolves this by adding the pytest predicates HAS_ENGLISH_DICTIONARY and HAS_CZECH_DICTIONARY.