### PR TITLE
Implement filter exceptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,5 @@ The location of `rpmlintrc` can be set using `--rpmlintrc` option. Or you can ha
 `*-rpmlintrc` file in the current working directory.  The best practice is to store the name in `$PACKAGE_NAME.rpmlintrc`.
 
 `setBadness` overrides a default badness for a given check and `addFilter` ignores all errors
-that match the given regular expression.
+that match the given regular expression (one cannot filter out errors that are listed in `BlockedFilters`
+in a configuration file).

--- a/rpmlint/configdefaults.toml
+++ b/rpmlint/configdefaults.toml
@@ -29,6 +29,8 @@ Checks = [
 ]
 # Various output filters, list of regexp strings eg. "E: .* no-signature"
 Filters = []
+# List of errors that can't be filtered
+BlockedFilters = []
 # Treshold where we should error out, by default single error is enough
 BadnessThreshold = -1
 # When checking that various files that should be compressed are

--- a/rpmlint/filter.py
+++ b/rpmlint/filter.py
@@ -28,6 +28,8 @@ class Filter(object):
         self.strict = config.strict
         # list of filter regexes
         self.filters_regexes = [re.compile(f) for f in config.configuration['Filters']]
+        # list of blocked filters
+        self.blocked_filters = set(config.configuration['BlockedFilters'])
         # set of filters that are actually used in add_info
         self.used_filters = set()
         self.rpmlintrc_filters = config.rpmlintrc_filters
@@ -121,7 +123,7 @@ class Filter(object):
         # filter by the result message
         result_no_color = f'{filename}{arch}:{line} {level}: {rpmlint_issue}{detail_output}'
         # unused-rpmlintrc-filter warnings should be skipped
-        if rpmlint_issue != 'unused-rpmlintrc-filter':
+        if rpmlint_issue != 'unused-rpmlintrc-filter' and rpmlint_issue not in self.blocked_filters:
             for f in self.filters_regexes:
                 if f.search(result_no_color):
                     self.used_filters.add(f.pattern)

--- a/test/configs/testfilters.config
+++ b/test/configs/testfilters.config
@@ -10,7 +10,12 @@ Filters = [
     'no-regex',
     ' no-regex-with-leading-space',
     'ngircd.*: E: bad-error',
-    '^ngircd.*: E: test-color-error details of the error$'
+    '^ngircd.*: E: test-color-error details of the error$',
+    'fatal-error'
+]
+
+BlockedFilters = [
+    'fatal-error'
 ]
 
 [Scoring]

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -94,7 +94,7 @@ def test_filters():
     Load some filters and make sure we generate nice regexp
     """
     cfg = Config(TEST_CONFIG_FILTERS)
-    assert len(cfg.configuration['Filters']) == 11
+    assert len(cfg.configuration['Filters']) == 12
     assert cfg.configuration['Filters'][0] == '.*invalid-buildhost.*'
 
 

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -17,7 +17,7 @@ def test_filters_regexp():
     Load some filters and make sure we generate nice regexp
     """
     cfg = Config(TEST_CONFIG_FILTERS)
-    assert len(cfg.configuration['Filters']) == 11
+    assert len(cfg.configuration['Filters']) == 12
     assert cfg.configuration['Filters'][0] == '.*invalid-buildhost.*'
 
 
@@ -149,3 +149,14 @@ def test_filtered_output(tmpdir):
     result.add_info('E', pkg, 'bad-error', 'details of the error')
     result.add_info('E', pkg, 'test-color-error', 'details of the error')
     assert len(result.results) == 0
+
+
+def test_blocked_filters(tmpdir):
+    key = 'fatal-error'
+    cfg = Config(TEST_CONFIG_FILTERS)
+    result = Filter(cfg)
+    pkg = get_tested_package(TEST_PACKAGE, tmpdir)
+    assert len(result.results) == 0
+    assert key in cfg.configuration['Filters']
+    result.add_info('E', pkg, key, '')
+    assert len(result.results) == 1


### PR DESCRIPTION
The feature is handy for hardening checks that should not be filterable
by a rpmlintrc file.

Fixes #660.