### PR TITLE
Fix failure when checking rust library files

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -626,10 +626,13 @@ class BinariesCheck(AbstractCheck):
             self.run_elf_checks(pkg, pkgfile.path, fname)
 
             # inspect binary file
-            is_shlib = self.readelf_parser.is_shlib
+            try:
+                is_shlib = self.readelf_parser.is_shlib
 
-            if is_shlib:
-                pkg_has_lib = True
+                if is_shlib:
+                    pkg_has_lib = True
+            except AttributeError:
+                pass
 
             # skip non-exec and non-SO
             # executables and shared objects only from here on


### PR DESCRIPTION
These are seen as archives in run_elf_checks which returns before
initializing readelf_parser.

Fixes error when checking rpms which contain rlib files:
(none): E: fatal error while reading some_file.rpm: 'BinariesCheck' object has no attribute 'readelf_parser'