### PR TITLE
Update openSUSE scoring:

### DIFF
--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -31,3 +31,6 @@ summary-not-capitalized = 20
 summary-too-long = 200
 pam-unauthorized-module = 10000
 wrong-script-interpreter = 490
+obsolete-insserv-requirement = 10000
+deprecated-init-script = 10000
+deprecated-boot-script = 10000


### PR DESCRIPTION
- Add badness for deprecated SysV Init Stuff as all packages should
  have been migrated.