### PR TITLE
Print traceback when a fatal error happens.

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -247,7 +247,10 @@ class Lint(object):
                     self.run_checks(pkg, is_last)
         except Exception as e:
             print_warning(f'(none): E: fatal error while reading {pname}: {e}')
-            sys.exit(3)
+            if self.config.info:
+                raise e
+            else:
+                sys.exit(3)
 
     def run_checks(self, pkg, is_last):
         spec_checks = isinstance(pkg, FakePkg)


### PR DESCRIPTION
I see it handy with --verbose printing traceback like:

```
...
(none): E: fatal error while reading /var/tmp/build-root/standard-x86_64/home/abuild/rpmbuild/RPMS/noarch/busybox-gzip-1.33.1-0.noarch.rpm: name 'asdadsf' is not defined
Traceback (most recent call last):
  File "./lint.py", line 5, in <module>
    lint()
  File "/home/marxin/Programming/rpmlint/rpmlint/cli.py", line 180, in lint
    sys.exit(lint.run())
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 102, in run
    return self._run()
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 74, in _run
    self.validate_files(self.options['rpmfile'])
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 230, in validate_files
    self.validate_file(pkg, pkg == packages[-1])
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 259, in validate_file
    raise e
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 252, in validate_file
    self.run_checks(pkg, is_last)
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 269, in run_checks
    fn(pkg)
  File "/home/marxin/Programming/rpmlint/rpmlint/checks/AbstractCheck.py", line 17, in check
    return self.check_binary(pkg)
  File "/home/marxin/Programming/rpmlint/rpmlint/checks/AbstractCheck.py", line 49, in check_binary
    raise err
  File "/usr/lib64/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/marxin/Programming/rpmlint/rpmlint/checks/BashismsCheck.py", line 31, in check_file
    self.check_bashisms(pkg, filepath, filename)
  File "/home/marxin/Programming/rpmlint/rpmlint/checks/BashismsCheck.py", line 42, in check_bashisms
    asdadsf
NameError: name 'asdadsf' is not defined

```