### PR TITLE
look for man pages in regular files, not just symlinks

### DIFF
--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -706,6 +706,11 @@ class FilesCheck(AbstractCheck):
                     if ln:
                         self.output.add_info('E', pkg, 'rpath-in-buildconfig', f, 'lines', ln)
 
+                # look for man pages
+                res = man_base_regex.search(f)
+                if res:
+                    man_basenames.add(res.group(1))
+
                 res = bin_regex.search(f)
                 if res:
                     if not mode_is_exec:


### PR DESCRIPTION
Currently, the code only looks for man pages in the stat.S_ISLNK(mode) conditional. This adds the same man page search to the regular file case. This is useful because most man pages are not symlinks and without this change, rpmlint reports missing man pages when they are present (unless they happen to be symlinks).

Reported here: https://bugzilla.redhat.com/show_bug.cgi?id=1980400