### PR TITLE
Add launch.json.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug",
+            "type": "python",
+            "request": "launch",
+            "program": "lint.py",
+            "console": "integratedTerminal",
+            "args": ["./test/binary/*.rpm"]
+        }
+    ]
+}


### PR DESCRIPTION
By default debug all .rpm files we have in test/binary folder.