### PR TITLE
Skip test requiring rpmdb

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ max_line_length = 79
 
 [Makefile]
 indent_style = tab
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, opensuse ]
+    branches: [main, opensuse]
   pull_request:
-    branches: [ main, opensuse ]
+    branches: [main, opensuse]
 
 jobs:
   CI:
@@ -13,20 +13,20 @@ jobs:
     strategy:
       matrix:
         build-type: ['normal']
-        docker:
+        container:
           - 'registry.fedoraproject.org/fedora:latest'
           - 'registry.fedoraproject.org/fedora:rawhide'
           - 'registry.opensuse.org/opensuse/leap-dnf:15.3'
           - 'registry.opensuse.org/opensuse/tumbleweed-dnf:latest'
         include:
-          - docker: 'registry.fedoraproject.org/fedora:latest'
+          - container: 'registry.fedoraproject.org/fedora:latest'
             build-type: 'no-optional-deps'
-          - docker: 'registry.opensuse.org/opensuse/tumbleweed-dnf:latest'
+          - container: 'registry.opensuse.org/opensuse/tumbleweed-dnf:latest'
             build-type: 'no-optional-deps'
       fail-fast: false
 
     container:
-      image: ${{ matrix.docker }}
+      image: ${{ matrix.container }}
       options: --security-opt seccomp=unconfined
 
     steps:
@@ -54,16 +54,16 @@ jobs:
               python3-pip
               rpm-build
               git
-        if: ${{ contains(matrix.docker, 'opensuse') }}
+        if: ${{ contains(matrix.container, 'opensuse') }}
       - run: dnf --assumeyes install
               checkbashisms dash
               desktop-file-utils
               appstream-glib
               myspell-en_US myspell-cs_CZ
               python3-pyenchant
-        if: ${{ contains(matrix.docker, 'opensuse') && matrix.build-type == 'normal' }}
+        if: ${{ contains(matrix.container, 'opensuse') && matrix.build-type == 'normal' }}
       - run: dnf --assumeyes install python3-flake8-comprehensions
-        if: ${{ contains(matrix.docker, 'opensuse/tumbleweed') }}
+        if: ${{ contains(matrix.container, 'opensuse/tumbleweed') }}
       - run: dnf --nogpgcheck --assumeyes install
               /usr/bin/cpio
               /usr/bin/bzip2
@@ -90,7 +90,7 @@ jobs:
               python3-pip
               rpm-build
               git
-        if: ${{ contains(matrix.docker, 'fedora') }}
+        if: ${{ contains(matrix.container, 'fedora') }}
       - run: dnf --nogpgcheck --assumeyes install
               /usr/bin/appstream-util
               /usr/bin/desktop-file-validate
@@ -99,7 +99,7 @@ jobs:
               hunspell-en
               hunspell-cs
               python3-enchant
-        if: ${{ contains(matrix.docker, 'fedora') && matrix.build-type == 'normal' }}
+        if: ${{ contains(matrix.container, 'fedora') && matrix.build-type == 'normal' }}
       - run: rm -rf $(rpm --eval '%_dbpath')
         if: matrix.build-type == 'no-optional-deps'
       - run: pip install coveralls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,17 @@ jobs:
 
     strategy:
       matrix:
+        build-type: ['normal']
         docker:
           - 'registry.fedoraproject.org/fedora:latest'
           - 'registry.fedoraproject.org/fedora:rawhide'
           - 'registry.opensuse.org/opensuse/leap-dnf:15.3'
           - 'registry.opensuse.org/opensuse/tumbleweed-dnf:latest'
+        include:
+          - docker: 'registry.fedoraproject.org/fedora:latest'
+            build-type: 'no-optional-deps'
+          - docker: 'registry.opensuse.org/opensuse/tumbleweed-dnf:latest'
+            build-type: 'no-optional-deps'
       fail-fast: false
 
     container:
@@ -25,13 +31,10 @@ jobs:
 
     steps:
       - run: dnf --assumeyes install
-              checkbashisms cpio dash gzip
+              cpio gzip
               bzip2 xz
-              binutils glibc glibc-32bit glibc-locale desktop-file-utils
-              appstream-glib
-              myspell-en_US myspell-cs_CZ
+              binutils glibc glibc-32bit glibc-locale
               python3-magic
-              python3-pyenchant
               python3-rpm
               python3-base
               python3-setuptools
@@ -52,26 +55,26 @@ jobs:
               rpm-build
               git
         if: ${{ contains(matrix.docker, 'opensuse') }}
+      - run: dnf --assumeyes install
+              checkbashisms dash
+              desktop-file-utils
+              appstream-glib
+              myspell-en_US myspell-cs_CZ
+              python3-pyenchant
+        if: ${{ contains(matrix.docker, 'opensuse') && matrix.build-type == 'normal' }}
       - run: dnf --assumeyes install python3-flake8-comprehensions
         if: ${{ contains(matrix.docker, 'opensuse/tumbleweed') }}
       - run: dnf --nogpgcheck --assumeyes install
-              /usr/bin/appstream-util
               /usr/bin/cpio
               /usr/bin/bzip2
-              /usr/bin/desktop-file-validate
               /usr/bin/python3
               /usr/bin/readelf
               /usr/bin/ldd
               /usr/bin/c++filt
               /usr/bin/xz
-              dash
-              devscripts-checkbashisms
               glibc
               glibc.i686
-              hunspell-en
-              hunspell-cs
               python3-setuptools
-              python3-enchant
               python3-magic
               python3-rpm
               python3-pybeam
@@ -88,6 +91,17 @@ jobs:
               rpm-build
               git
         if: ${{ contains(matrix.docker, 'fedora') }}
+      - run: dnf --nogpgcheck --assumeyes install
+              /usr/bin/appstream-util
+              /usr/bin/desktop-file-validate
+              dash
+              devscripts-checkbashisms
+              hunspell-en
+              hunspell-cs
+              python3-enchant
+        if: ${{ contains(matrix.docker, 'fedora') && matrix.build-type == 'normal' }}
+      - run: rm -rf $(rpm --eval '%_dbpath')
+        if: matrix.build-type == 'no-optional-deps'
       - run: pip install coveralls
       - uses: actions/checkout@v2
       - run: pytest

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -423,6 +423,7 @@ def test_run_rpmlintrc_single_file(capsys, packages):
     assert 'no-%build-section' not in out
 
 
+@pytest.mark.skipif(not HAS_RPMDB, reason='No RPM database present')
 def test_installed_package(capsys):
     additional_options = {
         'installed': ['bzip2'],


### PR DESCRIPTION
Hey again! :wave:

A test was added without the proper predicate in the 2.1.0 release which causes it to fail on Arch Linux.

The added CI job should make sure this does not happen anymore in the future.