### PR TITLE
Fix PieExecutables matching.

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -156,7 +156,7 @@ class BinariesCheck(AbstractCheck):
         executable.
         """
         if not self.is_shobj and not self.is_pie_exec:
-            if any(regex.search(bin_name) for regex in self.pie_exec_regex_list):
+            if any(regex.fullmatch(bin_name) for regex in self.pie_exec_regex_list):
                 self.output.add_info('E', pkg,
                                      'non-position-independent-executable',
                                      bin_name)

--- a/test/test_binaries.py
+++ b/test/test_binaries.py
@@ -180,7 +180,7 @@ def test_non_position_independent_sugg(tmpdir, package, binariescheck):
 # Force an error by setting PieExecutables option to the no-pie binary
 @pytest.mark.parametrize('package', ['binary/non-position-independent-exec'])
 def test_non_position_independent(tmpdir, package, binariescheck):
-    CONFIG.configuration['PieExecutables'] = ['sparta', 'hello']
+    CONFIG.configuration['PieExecutables'] = ['sparta', '.*hello']
     output = Filter(CONFIG)
     test = BinariesCheck(CONFIG, output)
     test.check(get_tested_package(package, tmpdir))


### PR DESCRIPTION
It's important matching entire regex for a given binary.
Not doing so, we end up with:
`non-position-independent-executable (Badness: 10000) /usr/bin/supertux2`

when `/usr/bin/su` lives in PieExecutables regexes.