### PR TITLE
Synchronization and Cleanup of Whitelists

### DIFF
--- a/configs/openSUSE/cron-whitelist.toml
+++ b/configs/openSUSE/cron-whitelist.toml
@@ -12,6 +12,19 @@ digests = [
 ]
 
 [[FileDigestGroup]]
+package = "cronie-anacron"
+type = "cron"
+note = "Minor change in some logic that checks whether the system runs on battery"
+bug = "bsc#1190521"
+digests = [
+    {
+        path = "/etc/cron.hourly/0anacron",
+        algorithm = "sha256",
+        hash = "6e8a152a16e84ddc10e8ab1c2ed2bad28adbfc3b0b1ced62518c4ab0ada87220"
+    },
+]
+
+[[FileDigestGroup]]
 package = "logdigest"
 type = "cron"
 note = "scours through log files to find 'interesting' information and mails it to root"

--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -17,7 +17,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "packagekit"
+package = "PackageKit"
 type = "dbus"
 note = "legacy: not audited"
 nodigests = [
@@ -26,7 +26,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "networkmanager-pptp"
+package = "NetworkManager-pptp"
 type = "dbus"
 note = "legacy: not audited"
 nodigests = [
@@ -192,7 +192,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "networkmanager"
+package = "NetworkManager"
 type = "dbus"
 note = "legacy: not audited"
 nodigests = [
@@ -201,7 +201,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "networkmanager"
+package = "NetworkManager"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#747780"
@@ -245,7 +245,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "networkmanager-openvpn"
+package = "NetworkManager-openvpn"
 type = "dbus"
 note = "legacy: not audited"
 nodigests = [
@@ -271,7 +271,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "networkmanager-vpnc"
+package = "NetworkManager-vpnc"
 type = "dbus"
 note = "legacy: not audited"
 nodigests = [
@@ -394,7 +394,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "networkmanager-iodine"
+package = "NetworkManager-iodine"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#781071"
@@ -403,7 +403,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "modemmanager"
+package = "ModemManager"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#798273"
@@ -735,7 +735,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "networkmanager-l2tp"
+package = "NetworkManager-l2tp"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#846337"

--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -934,7 +934,61 @@ nodigests = [
 package = "plasma5-disks"
 type = "dbus"
 note = "legacy: not audited"
+bug = "bsc#1176742"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.kde.kded.smart.service",
     "/usr/share/dbus-1/system.d/org.kde.kded.smart.conf",
+]
+
+[[FileDigestGroup]]
+package = "kdenetwork-filesharing"
+type = "dbus"
+note = "Samba configuration helper"
+bug = "bsc#1175633"
+nodigests = [
+    "org.kde.filesharing.samba.service",
+    "org.kde.filesharing.samba.conf",
+]
+
+[[FileDigestGroup]]
+package = "kdiskmark"
+type = "dbus"
+note = "HDD/SSD benchmark GUI"
+bug = "bsc#1182521"
+nodigests = [
+    "org.jonmagon.kdiskmark.service",
+    "org.jonmagon.kdiskmark.conf",
+]
+
+[[FileDigestGroup]]
+package = "systemd-experimental"
+type = "dbus"
+note = "systemd-homed helper service for providing portable home directory containers"
+bug = "bsc#1185285"
+nodigests = [
+    "org.freedesktop.home1.conf",
+    "org.freedesktop.home1.service",
+]
+
+[[FileDigestGroup]]
+package = "oddjob-gpupdate"
+type = "dbus"
+note = "helper that calls samba-gpupdate"
+bug = "bsc#1188680"
+nodigests = [
+    "oddjob-gpupdate.conf",
+]
+
+[[FileDigestGroup]]
+package = "deepin-api"
+type = "dbus"
+note = "an assorted mix of D-Bus interfaces for the Deepin desktop"
+bug = "bsc#1070943"
+nodigests = [
+    "com.deepin.api.Device.service",
+    "com.deepin.api.Device.conf",
+    "com.deepin.api.LocaleHelper.service",
+    "com.deepin.api.LocaleHelper.conf",
+    "com.deepin.api.SoundThemePlayer.service",
+    "com.deepin.api.SoundThemePlayer.conf"
 ]

--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -2,7 +2,7 @@
 package = "cups"
 type = "dbus"
 note = ""
-bug = "bnc#515977"
+bug = "bsc#515977"
 nodigests = [
     "/etc/dbus-1/system.d/cups.conf",
 ]
@@ -45,7 +45,7 @@ nodigests = [
 package = "udisks2"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#742751"
+bug = "bsc#742751"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.UDisks2.service",
     "/usr/share/dbus-1/system.d/org.freedesktop.UDisks2.conf",
@@ -63,7 +63,7 @@ nodigests = [
 package = "systemd"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#641924"
+bug = "bsc#641924"
 nodigests = [
     "/usr/share/dbus-1/services/org.freedesktop.systemd1.service",
     "/usr/share/dbus-1/system-services/org.freedesktop.systemd1.service",
@@ -95,7 +95,7 @@ nodigests = [
 package = "system-config-printer-applet"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#694640"
+bug = "bsc#694640"
 nodigests = [
     "/etc/dbus-1/system.d/com.redhat.NewPrinterNotification.conf",
 ]
@@ -104,7 +104,7 @@ nodigests = [
 package = "python3-cupshelpers"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#694640"
+bug = "bsc#694640"
 nodigests = [
     "/etc/dbus-1/system.d/com.redhat.PrinterDriversInstaller.conf",
 ]
@@ -131,7 +131,7 @@ nodigests = [
 package = "wpa_supplicant"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#681116"
+bug = "bsc#681116"
 nodigests = [
     "/usr/lib/systemd/system/dbus-fi.w1.wpa_supplicant1.service",
     "/usr/share/dbus-1/system-services/fi.w1.wpa_supplicant1.service",
@@ -204,7 +204,7 @@ nodigests = [
 package = "NetworkManager"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#747780"
+bug = "bsc#747780"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.NetworkManager.conf",
 ]
@@ -213,7 +213,7 @@ nodigests = [
 package = "bluez"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#768062"
+bug = "bsc#768062"
 nodigests = [
     "/etc/dbus-1/system.d/bluetooth.conf",
     "/usr/share/dbus-1/system-services/org.bluez.service",
@@ -282,7 +282,7 @@ nodigests = [
 package = "strongswan-nm"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#656222"
+bug = "bsc#656222"
 nodigests = [
     "/usr/share/dbus-1/system.d/nm-strongswan-service.conf",
 ]
@@ -291,7 +291,7 @@ nodigests = [
 package = "mumble-server"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#660784"
+bug = "bsc#660784"
 nodigests = [
     "/etc/dbus-1/system.d/mumble-server.conf",
     "/usr/lib/tmpfiles.d/mumble-server.conf",
@@ -301,7 +301,7 @@ nodigests = [
 package = "mumble-server"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#660784"
+bug = "bsc#660784"
 nodigests = [
     "/etc/dbus-1/system.d/mumble-server.conf",
     "/usr/lib/tmpfiles.d/mumble-server.conf",
@@ -311,7 +311,7 @@ nodigests = [
 package = "powerdevil5"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#672145"
+bug = "bsc#672145"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.kde.powerdevil.backlighthelper.service",
     "/usr/share/dbus-1/system.d/org.kde.powerdevil.backlighthelper.conf",
@@ -321,7 +321,7 @@ nodigests = [
 package = "urfkill"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#688328"
+bug = "bsc#688328"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.URfkill.service",
     "/etc/dbus-1/system.d/org.freedesktop.URfkill.conf",
@@ -331,7 +331,7 @@ nodigests = [
 package = "accountsservice"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#676638"
+bug = "bsc#676638"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.Accounts.service",
     "/etc/dbus-1/system.d/org.freedesktop.Accounts.conf",
@@ -341,7 +341,7 @@ nodigests = [
 package = "colord"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#698250"
+bug = "bsc#698250"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.ColorManager.service",
     "/usr/share/dbus-1/system.d/org.freedesktop.ColorManager.conf",
@@ -351,7 +351,7 @@ nodigests = [
 package = "lightdm"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#708205"
+bug = "bsc#708205"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.DisplayManager.conf",
 ]
@@ -369,7 +369,7 @@ nodigests = [
 package = "NetworkManager-openconnect"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#732915"
+bug = "bsc#732915"
 nodigests = [
     "/etc/dbus-1/system.d/nm-openconnect-service.conf",
 ]
@@ -378,7 +378,7 @@ nodigests = [
 package = "snapper"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#759391"
+bug = "bsc#759391"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.opensuse.Snapper.conf",
     "/usr/share/dbus-1/system-services/org.opensuse.Snapper.service",
@@ -388,7 +388,7 @@ nodigests = [
 package = "autofs"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#782691"
+bug = "bsc#782691"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.AutoMount.conf",
 ]
@@ -397,7 +397,7 @@ nodigests = [
 package = "NetworkManager-iodine"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#781071"
+bug = "bsc#781071"
 nodigests = [
     "/etc/dbus-1/system.d/nm-iodine-service.conf",
 ]
@@ -406,7 +406,7 @@ nodigests = [
 package = "ModemManager"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#798273"
+bug = "bsc#798273"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf",
     "/usr/share/dbus-1/system-services/org.freedesktop.ModemManager1.service",
@@ -416,7 +416,7 @@ nodigests = [
 package = "fprintd"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#792095"
+bug = "bsc#792095"
 nodigests = [
     "/usr/share/dbus-1/system-services/net.reactivated.Fprint.service",
     "/usr/share/dbus-1/system.d/net.reactivated.Fprint.conf",
@@ -426,7 +426,7 @@ nodigests = [
 package = "fprintd"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#783932"
+bug = "bsc#783932"
 nodigests = [
     "/etc/dbus-1/system.d/org.opensuse.Network.conf",
     "/etc/dbus-1/system.d/org.opensuse.Network.AUTO4.conf",
@@ -439,7 +439,7 @@ nodigests = [
 package = "systemd-container"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#828207"
+bug = "bsc#828207"
 nodigests = [
     "/usr/lib/systemd/system/dbus-org.freedesktop.machine1.service",
     "/usr/share/dbus-1/system-services/org.freedesktop.machine1.service",
@@ -450,7 +450,7 @@ nodigests = [
 package = "systemd-container"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#964935"
+bug = "bsc#964935"
 nodigests = [
     "/usr/lib/systemd/system/dbus-org.freedesktop.import1.service",
     "/usr/share/dbus-1/system-services/org.freedesktop.import1.service",
@@ -461,7 +461,7 @@ nodigests = [
 package = "geoclue2"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#838360"
+bug = "bsc#838360"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.GeoClue2.service",
     "/etc/dbus-1/system.d/org.freedesktop.GeoClue2.conf",
@@ -471,7 +471,7 @@ nodigests = [
 package = "geoclue2"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#862216"
+bug = "bsc#862216"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.GeoClue2.Agent.conf",
 ]
@@ -480,7 +480,7 @@ nodigests = [
 package = "mate-settings-daemon"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#831404"
+bug = "bsc#831404"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.mate.SettingsDaemon.DateTimeMechanism.service",
     "/usr/share/dbus-1/system.d/org.mate.SettingsDaemon.DateTimeMechanism.conf",
@@ -490,7 +490,7 @@ nodigests = [
 package = "tuned"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#787379, bnc#1007279"
+bug = "bsc#787379, bsc#1007279"
 nodigests = [
     "/etc/dbus-1/system.d/com.redhat.tuned.conf",
 ]
@@ -499,7 +499,7 @@ nodigests = [
 package = "kwalletmanager5"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#1033296"
+bug = "bsc#1033296"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.kde.kcontrol.kcmkwallet5.conf",
     "/usr/share/dbus-1/system-services/org.kde.kcontrol.kcmkwallet5.service",
@@ -509,7 +509,7 @@ nodigests = [
 package = "neard"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#837978"
+bug = "bsc#837978"
 nodigests = [
     "/etc/dbus-1/system.d/org.neard.conf"
 ]
@@ -518,7 +518,7 @@ nodigests = [
 package = "ofono"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#862354"
+bug = "bsc#862354"
 nodigests = [
     "/etc/dbus-1/system.d/ofono.conf",
 ]
@@ -527,7 +527,7 @@ nodigests = [
 package = "libKF5Auth5"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#864716"
+bug = "bsc#864716"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.kde.kf5auth.conf",
 ]
@@ -536,7 +536,7 @@ nodigests = [
 package = "firewalld"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#907625"
+bug = "bsc#907625"
 nodigests = [
     "/usr/share/dbus-1/system.d/FirewallD.conf",
 ]
@@ -545,7 +545,7 @@ nodigests = [
 package = "systemd-network"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#918799"
+bug = "bsc#918799"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.freedesktop.network1.conf",
     "/usr/share/dbus-1/system-services/org.freedesktop.network1.service",
@@ -555,7 +555,7 @@ nodigests = [
 package = "realmd"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#916766"
+bug = "bsc#916766"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.realmd.service",
     "/etc/dbus-1/system.d/org.freedesktop.realmd.conf",
@@ -565,7 +565,7 @@ nodigests = [
 package = "libteam-tools"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#941993"
+bug = "bsc#941993"
 nodigests = [
     "/etc/dbus-1/system.d/org.libteam.teamd.conf",
 ]
@@ -719,7 +719,7 @@ nodigests = [
 package = "tpm2.0-abrmd"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#1049694"
+bug = "bsc#1049694"
 nodigests = [
     "/etc/dbus-1/system.d/tpm2-abrmd.conf",
     "/usr/share/dbus-1/system-services/com.intel.tss2.Tabrmd.service",
@@ -787,7 +787,7 @@ nodigests = [
 package = "kalarm"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#1087714"
+bug = "bsc#1087714"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.kde.kalarm.rtcwake.conf",
     "/usr/share/dbus-1/system-services/org.kde.kalarm.rtcwake.service",
@@ -797,7 +797,7 @@ nodigests = [
 package = "NetworkManager-libreswan"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#1089340"
+bug = "bsc#1089340"
 nodigests = [
     "/etc/dbus-1/system.d/nm-libreswan-service.conf",
 ]
@@ -806,7 +806,7 @@ nodigests = [
 package = "ratbagd"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
-bug = "bnc#1076467"
+bug = "bsc#1076467"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.ratbag1.service",
     "/usr/share/dbus-1/system.d/org.freedesktop.ratbag1.conf",

--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -44,7 +44,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "udisks2"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#742751"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.UDisks2.service",
@@ -62,7 +62,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "systemd"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#641924"
 nodigests = [
     "/usr/share/dbus-1/services/org.freedesktop.systemd1.service",
@@ -94,7 +94,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "system-config-printer-applet"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#694640"
 nodigests = [
     "/etc/dbus-1/system.d/com.redhat.NewPrinterNotification.conf",
@@ -103,7 +103,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "python3-cupshelpers"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#694640"
 nodigests = [
     "/etc/dbus-1/system.d/com.redhat.PrinterDriversInstaller.conf",
@@ -130,7 +130,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "wpa_supplicant"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#681116"
 nodigests = [
     "/usr/lib/systemd/system/dbus-fi.w1.wpa_supplicant1.service",
@@ -203,7 +203,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "networkmanager"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#747780"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.NetworkManager.conf",
@@ -212,7 +212,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "bluez"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#768062"
 nodigests = [
     "/etc/dbus-1/system.d/bluetooth.conf",
@@ -281,7 +281,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "strongswan-nm"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#656222"
 nodigests = [
     "/usr/share/dbus-1/system.d/nm-strongswan-service.conf",
@@ -290,7 +290,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "mumble-server"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#660784"
 nodigests = [
     "/etc/dbus-1/system.d/mumble-server.conf",
@@ -300,7 +300,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "mumble-server"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#660784"
 nodigests = [
     "/etc/dbus-1/system.d/mumble-server.conf",
@@ -310,7 +310,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "powerdevil5"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#672145"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.kde.powerdevil.backlighthelper.service",
@@ -320,7 +320,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "urfkill"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#688328"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.URfkill.service",
@@ -330,7 +330,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "accountsservice"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#676638"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.Accounts.service",
@@ -340,7 +340,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "colord"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#698250"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.ColorManager.service",
@@ -350,7 +350,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "lightdm"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#708205"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.DisplayManager.conf",
@@ -359,7 +359,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "sddm"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "boo#897788"
 nodigests = [
     "/etc/dbus-1/system.d/sddm_org.freedesktop.DisplayManager.conf",
@@ -368,7 +368,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "NetworkManager-openconnect"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#732915"
 nodigests = [
     "/etc/dbus-1/system.d/nm-openconnect-service.conf",
@@ -377,7 +377,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "snapper"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#759391"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.opensuse.Snapper.conf",
@@ -387,7 +387,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "autofs"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#782691"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.AutoMount.conf",
@@ -396,7 +396,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "networkmanager-iodine"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#781071"
 nodigests = [
     "/etc/dbus-1/system.d/nm-iodine-service.conf",
@@ -405,7 +405,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "modemmanager"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#798273"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.ModemManager1.conf",
@@ -415,7 +415,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "fprintd"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#792095"
 nodigests = [
     "/usr/share/dbus-1/system-services/net.reactivated.Fprint.service",
@@ -425,7 +425,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "fprintd"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#783932"
 nodigests = [
     "/etc/dbus-1/system.d/org.opensuse.Network.conf",
@@ -438,7 +438,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "systemd-container"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#828207"
 nodigests = [
     "/usr/lib/systemd/system/dbus-org.freedesktop.machine1.service",
@@ -449,7 +449,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "systemd-container"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#964935"
 nodigests = [
     "/usr/lib/systemd/system/dbus-org.freedesktop.import1.service",
@@ -460,7 +460,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "geoclue2"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#838360"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.GeoClue2.service",
@@ -470,7 +470,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "geoclue2"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#862216"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.GeoClue2.Agent.conf",
@@ -479,7 +479,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "mate-settings-daemon"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#831404"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.mate.SettingsDaemon.DateTimeMechanism.service",
@@ -489,7 +489,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "tuned"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#787379, bnc#1007279"
 nodigests = [
     "/etc/dbus-1/system.d/com.redhat.tuned.conf",
@@ -498,7 +498,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "kwalletmanager5"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#1033296"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.kde.kcontrol.kcmkwallet5.conf",
@@ -508,7 +508,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "neard"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#837978"
 nodigests = [
     "/etc/dbus-1/system.d/org.neard.conf"
@@ -517,7 +517,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "ofono"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#862354"
 nodigests = [
     "/etc/dbus-1/system.d/ofono.conf",
@@ -526,7 +526,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "libKF5Auth5"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#864716"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.kde.kf5auth.conf",
@@ -535,7 +535,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "firewalld"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#907625"
 nodigests = [
     "/usr/share/dbus-1/system.d/FirewallD.conf",
@@ -544,7 +544,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "systemd-network"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#918799"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.freedesktop.network1.conf",
@@ -554,7 +554,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "realmd"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#916766"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.realmd.service",
@@ -564,7 +564,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "libteam-tools"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#941993"
 nodigests = [
     "/etc/dbus-1/system.d/org.libteam.teamd.conf",
@@ -573,7 +573,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "cinnamon-settings-daemon"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#951830"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.cinnamon.SettingsDaemon.DateTimeMechanism.conf",
@@ -583,7 +583,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "thermald"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#954771"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.thermald.conf",
@@ -593,7 +593,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "iio-sensor-proxy"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#939191"
 nodigests = [
     "/etc/dbus-1/system.d/net.hadess.SensorProxy.conf",
@@ -602,7 +602,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "tcmu-runner"
 type = "dbus"
-note = "legacy: not audited - TEMPORARY APPROVAL ONLY (meissner 20160519)"
+note = "imported from rpmlint1 DBUSServices.WhiteList - TEMPORARY APPROVAL ONLY (meissner 20160519)"
 bug = "bsc#978903"
 nodigests = [
     "/etc/dbus-1/system.d/tcmu-runner.conf",
@@ -612,7 +612,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "sysprof"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#996111"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.gnome.Sysprof2.service",
@@ -622,7 +622,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "sysprof"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1151418"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.gnome.Sysprof3.conf",
@@ -632,7 +632,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "flatpak"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#984817"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.Flatpak.SystemHelper.service",
@@ -642,7 +642,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "systemd-network"
 type = "dbus"
-note = "legacy: not audited; systemd resolver, but dont add automatically to nsswitch.conf!"
+note = "imported from rpmlint1 DBUSServices.WhiteList; systemd resolver, but dont add automatically to nsswitch.conf!"
 bug = "bsc#917781"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.freedesktop.resolve1.conf",
@@ -652,7 +652,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "powerdevil5"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1019748"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.kde.powerdevil.discretegpuhelper.conf",
@@ -662,7 +662,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "rebootmgr"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1019644"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.opensuse.RebootMgr.conf",
@@ -671,7 +671,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "blueman"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#987141"
 nodigests = [
     "/etc/dbus-1/system.d/org.blueman.Mechanism.conf",
@@ -681,7 +681,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "os-autoinst-openvswitch"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1032649"
 nodigests = [
     "/etc/dbus-1/system.d/org.opensuse.os_autoinst.switch.conf",
@@ -690,7 +690,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "backintime-qt"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1007723, bsc#1032717"
 nodigests = [
     "/etc/dbus-1/system.d/net.launchpad.backintime.serviceHelper.conf",
@@ -700,7 +700,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "switcheroo-control"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1034309"
 nodigests = [
     "/etc/dbus-1/system.d/net.hadess.SwitcherooControl.conf",
@@ -709,7 +709,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_dbus"
 type = "dbus"
-note = "legacy: not audited - Take care to never enable/integrate this by default (see bsc comments)"
+note = "imported from rpmlint1 DBUSServices.WhiteList - Take care to never enable/integrate this by default (see bsc comments)"
 bug = "bsc#1039709"
 nodigests = [
     "/etc/dbus-1/system.d/pam_dbus.conf"
@@ -718,7 +718,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "tpm2.0-abrmd"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#1049694"
 nodigests = [
     "/etc/dbus-1/system.d/tpm2-abrmd.conf",
@@ -728,7 +728,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "nfs-ganesha"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#997880"
 nodigests = [
     "/etc/dbus-1/system.d/org.ganesha.nfsd.conf",
@@ -737,7 +737,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "networkmanager-l2tp"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#846337"
 nodigests = [
     "/usr/share/dbus-1/system.d/nm-l2tp-service.conf",
@@ -746,7 +746,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "fwupd"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#932807"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.freedesktop.fwupd.conf",
@@ -756,7 +756,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "connman"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1057697"
 nodigests = [
     "/usr/share/dbus-1/system.d/connman.conf",
@@ -767,7 +767,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "kcm_sddm"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1065563"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.kde.kcontrol.kcmsddm.conf",
@@ -777,7 +777,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "usbauth"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1066877"
 nodigests = [
     "/etc/dbus-1/system.d/org.opensuse.usbauth.conf",
@@ -786,7 +786,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "kalarm"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#1087714"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.kde.kalarm.rtcwake.conf",
@@ -796,7 +796,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "NetworkManager-libreswan"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#1089340"
 nodigests = [
     "/etc/dbus-1/system.d/nm-libreswan-service.conf",
@@ -805,7 +805,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "ratbagd"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bnc#1076467"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.ratbag1.service",
@@ -815,7 +815,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "xpra"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1102836"
 nodigests = [
     "/etc/dbus-1/system.d/xpra.conf",
@@ -824,7 +824,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "iwd"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1108037"
 nodigests = [
     "/usr/share/dbus-1/system-services/net.connman.iwd.service",
@@ -834,7 +834,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "NetworkManager-fortisslvpn"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1109938"
 nodigests = [
     "/etc/dbus-1/system.d/nm-fortisslvpn-service.conf",
@@ -843,7 +843,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "systemd"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1111254"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.timesync1.service",
@@ -853,7 +853,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "keepalived"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1015141"
 nodigests = [
     "/etc/dbus-1/system.d/org.keepalived.Vrrp1.conf",
@@ -862,7 +862,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "bolt"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1119975"
 nodigests = [
     "/usr/share/dbus-1/system.d/org.freedesktop.bolt.conf",
@@ -872,7 +872,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "certmonger"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1129452"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.fedorahosted.certmonger.service",
@@ -882,7 +882,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "systemd-portable"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "boo#1145639"
 nodigests = [
     "/usr/lib/systemd/system/dbus-org.freedesktop.portable1.service",
@@ -893,7 +893,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "sssd-dbus"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1157663, bsc#1106600"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.freedesktop.sssd.infopipe.service",
@@ -903,7 +903,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "oddjob"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1169494"
 nodigests = [
     "/etc/dbus-1/system.d/oddjob.conf",
@@ -912,7 +912,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "libvirt-dbus"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1173093"
 nodigests = [
     "/usr/share/dbus-1/services/org.libvirt.service",
@@ -923,7 +923,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "powerdevil5"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1176474"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.kde.powerdevil.chargethresholdhelper.service",
@@ -933,7 +933,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "plasma5-disks"
 type = "dbus"
-note = "legacy: not audited"
+note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1176742"
 nodigests = [
     "/usr/share/dbus-1/system-services/org.kde.kded.smart.service",

--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -246,7 +246,7 @@ nodigests = [
 package = "pam_snapper"
 type = "pam"
 note = "imported from rpmlint1 PAMModules.WhiteList"
-bug = "bnc#815383"
+bug = "bsc#815383"
 nodigests = [
     "*/security/pam_snapper.so",
 ]

--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -128,7 +128,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1171564, bsc#1171563, bsc#1171562"
 nodigests = [
     "*/security/pam_access.so",
@@ -268,7 +268,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_snapper"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bnc#815383"
 nodigests = [
     "*/security/pam_snapper.so",
@@ -277,7 +277,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "gdm"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1004346"
 nodigests = [
     "*/security/pam_gdm.so",
@@ -286,7 +286,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "slurm-pam_slurm"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1007053, bsc#1116758"
 nodigests = [
     "*/security/pam_slurm.so",
@@ -296,7 +296,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_script"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1039848"
 nodigests = [
     "*/security/pam_script.so",
@@ -305,7 +305,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_yubico"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1087060"
 nodigests = [
     "*/security/pam_yubico.so",
@@ -314,7 +314,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_oath"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1089114"
 nodigests = [
     "*/security/pam_oath.so",
@@ -323,7 +323,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_p11"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1123916"
 nodigests = [
     "*/security/pam_p11.so",
@@ -332,7 +332,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_cifscreds"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1150527"
 nodigests = [
     "*/security/pam_cifscreds.so",
@@ -341,7 +341,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_pwquality"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1150520"
 nodigests = [
     "*/security/pam_pwquality.so",
@@ -350,7 +350,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_cgfs"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1150519"
 nodigests = [
     "*/security/pam_cgfs.so",
@@ -359,7 +359,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "google-authenticator-libpam"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1150524"
 nodigests = [
     "*/security/pam_google_authenticator.so",
@@ -368,7 +368,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_u2f"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1087061"
 nodigests = [
     "*/security/pam_u2f.so",
@@ -377,7 +377,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_kwallet"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#993806"
 nodigests = [
     "*/security/pam_kwallet5.so",
@@ -386,7 +386,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "pam_dbus"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1039709"
 nodigests = [
     "*/security/pam_dbus.so",
@@ -395,7 +395,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "google-guest-oslogin"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1146353"
 nodigests = [
     "*/security/pam_oslogin_admin.so",
@@ -405,7 +405,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "fprintd-pam"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#792095"
 nodigests = [
     "*/security/pam_fprintd.so",
@@ -414,7 +414,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "mariadb"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1163362"
 nodigests = [
     "*/security/pam_user_map.so",
@@ -423,7 +423,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "oddjob-mkhomedir"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1169494"
 nodigests = [
     "*/security/pam_oddjob_mkhomedir.so",
@@ -432,7 +432,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "cockpit-ws"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1169614"
 nodigests = [
     "*/security/pam_cockpit_cert.so",
@@ -442,7 +442,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "kanidm-unixd-clients"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1173387"
 nodigests = [
     "*/security/pam_kanidm.so",
@@ -451,7 +451,7 @@ nodigests = [
 [[FileDigestGroup]]
 package = "malcontent"
 type = "pam"
-note = "legacy: not audited"
+note = "imported from rpmlint1 PAMModules.WhiteList"
 bug = "bsc#1177974"
 nodigests = [
     "*/security/pam_malcontent.so",

--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -2,7 +2,6 @@
 package = "pam_krb5"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_krb5.so",
     "*/security/pam_krb5afs.so",
@@ -12,7 +11,6 @@ nodigests = [
 package = "ecryptfs-utils"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_ecryptfs.so",
 ]
@@ -21,7 +19,6 @@ nodigests = [
 package = "gnome-keyring-pam"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_gnome_keyring.so",
 ]
@@ -30,7 +27,6 @@ nodigests = [
 package = "samba-winbind"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_winbind.so",
 ]
@@ -39,7 +35,6 @@ nodigests = [
 package = "pam_ssh"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_ssh.so",
 ]
@@ -48,7 +43,6 @@ nodigests = [
 package = "pam_mount"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_mount.so",
 ]
@@ -57,7 +51,6 @@ nodigests = [
 package = "pam_ccreds"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_ccreds.so",
 ]
@@ -66,7 +59,6 @@ nodigests = [
 package = "pam_radius"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_radius_auth.so",
 ]
@@ -75,7 +67,6 @@ nodigests = [
 package = "pam_pkcs11"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_pkcs11.so",
 ]
@@ -84,7 +75,6 @@ nodigests = [
 package = "nss-pam-ldapd"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_ldap.so",
 ]
@@ -93,7 +83,6 @@ nodigests = [
 package = "pam_passwdqc"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_passwdqc.so",
 ]
@@ -102,7 +91,6 @@ nodigests = [
 package = "pam_userpass"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_userpass.so",
 ]
@@ -111,7 +99,6 @@ nodigests = [
 package = "pam_apparmor"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_apparmor.so",
 ]
@@ -120,7 +107,6 @@ nodigests = [
 package = "opie"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_opie.so",
 ]
@@ -179,7 +165,6 @@ nodigests = [
 package = "pam-deprecated"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_cracklib.so",
     "*/security/pam_tally2.so",
@@ -189,7 +174,6 @@ nodigests = [
 package = "pam_unix"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_unix.so",
     "*/security/pam_unix_acct.so",
@@ -202,7 +186,6 @@ nodigests = [
 package = "pam_unix-nis"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_unix.so",
     "*/security/pam_unix_acct.so",
@@ -215,7 +198,6 @@ nodigests = [
 package = "pam-extra"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_userdb.so",
 ]
@@ -224,7 +206,6 @@ nodigests = [
 package = "systemd"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_systemd.so",
 ]
@@ -233,7 +214,6 @@ nodigests = [
 package = "sssd"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_sss.so",
 ]
@@ -242,7 +222,6 @@ nodigests = [
 package = "pam_mktemp"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_mktemp.so",
 ]
@@ -251,7 +230,6 @@ nodigests = [
 package = "pam_csync"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_csync.so",
 ]
@@ -260,7 +238,6 @@ nodigests = [
 package = "pam_chroot"
 type = "pam"
 note = "legacy: not audited"
-bug = ""
 nodigests = [
     "*/security/pam_chroot.so",
 ]

--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -456,3 +456,21 @@ bug = "bsc#1177974"
 nodigests = [
     "*/security/pam_malcontent.so",
 ]
+
+[[FileDigestGroup]]
+package = "sssd"
+type = "pam"
+note = "sssd gssapi extension"
+bug = "bsc#1182509"
+nodigests = [
+    "*/security/pam_sss_gss.so",
+]
+
+[[FileDigestGroup]]
+package = "oddjob-gpupdate"
+type = "pam"
+note = "samba group-policy update helper"
+bug = "bsc#1188680"
+nodigests = [
+    "*/security/pam_oddjob_gpupdate.so",
+]

--- a/configs/openSUSE/polkit-rules-whitelist.toml
+++ b/configs/openSUSE/polkit-rules-whitelist.toml
@@ -18,7 +18,7 @@ note = "default rule shipped by polkit, allows uid 0 to do everything"
 bug = "bsc#1125314"
 digests = [
     {
-        path = "/etc/polkit-1/rules.d/50-default.rules",
+        path = "/usr/share/polkit-1/rules.d/50-default.rules",
         algorithm = "sha256",
         hash = "aea3041de2c15db8683620de8533206e50241c309eb27893605d5ead17e5e75f"
     },


### PR DESCRIPTION
This syncs the additions that have been made to rpmlint1's config file into the new whitelists kept in rpmlint2.

Furthermore some cleanup in whitelists is done.

@marxin: Since this only affects the whitelists we would like to review and merge this within the proactive security team to test the new workflow.