### PR TITLE
fix loading of rpmlintrc from cmdline

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -161,8 +161,11 @@ class Lint(object):
         Load rpmlintrc from argument or load up from folder
         """
         if self.options['rpmlintrc']:
-            for rcfile in self.options['rpmlintrc']:
+            rcfile = self.options['rpmlintrc']
+            if rcfile.is_file():
                 self.config.load_rpmlintrc(rcfile)
+            else:
+                print_warning(f'(none): E: the specified rpmlintrc value "{rcfile}" is not a file and was not loaded.')
         else:
             # load only from the same folder specname.rpmlintrc or specname-rpmlintrc
             # do this only in a case where there is one folder parameter or one file

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -410,7 +410,7 @@ def test_run_rpmlintrc_multiple(capsys, packages):
 def test_run_rpmlintrc_single_file(capsys, packages):
     additional_options = {
         'rpmfile': [packages],
-        'rpmlintrc': [TEST_RPMLINTRC]
+        'rpmlintrc': TEST_RPMLINTRC
     }
     options = {**options_preset, **additional_options}
     linter = Lint(options)


### PR DESCRIPTION
Signed-off-by: Tom spot Callaway <spot@fedoraproject.org>

As reported in [Fedora Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2000018), rpmlint errors out if you try to pass an rpmlintrc file value.

```
$ touch /tmp/empty
$ /usr/bin/rpmlint -r /tmp/empty x86_64/miniz-2.2.0-1.fc36.x86_64.rpm 
Traceback (most recent call last):
  File "/usr/bin/rpmlint", line 33, in <module>
    sys.exit(load_entry_point('rpmlint==2.1.0', 'console_scripts', 'rpmlint')())
  File "/usr/lib/python3.10/site-packages/rpmlint/cli.py", line 173, in lint
    lint = Lint(options)
  File "/usr/lib/python3.10/site-packages/rpmlint/lint.py", line 38, in __init__
    self._load_rpmlintrc()
  File "/usr/lib/python3.10/site-packages/rpmlint/lint.py", line 164, in _load_rpmlintrc
    for rcfile in self.options['rpmlintrc']:
TypeError: 'PosixPath' object is not iterable
```
Looking at the code, the rpmlintrc option value is assigned as a Path (PosixPath) which is indeed, not iterable. (If the Path object is a dir, you can pass .iterdir to it and get an iterable list of the contents, but that is not applicable here). Given that there is no obvious way in the code currently to pass more than one rpmlintrc option (it permits multiple invocations of -r, but only keeps the last one), it seemed simpler to align with that and assume that the result of self.options['rpmlintrc'], if it exists, is indeed a Path object and treat it accordingly. I did add a simple check to confirm that the rpmlintrc Path object is a file before trying to load it, and tossing a E print_warning if not. This does, however, in practice, result in output like this:

```
[spot@localhost perl-Text-Template]$ rpmlint -r /tmp noarch/perl-Text-Template-1.60-1.fc36.noarch.rpm 
(none): E: the specified rpmlintrc value "/tmp" is not a file and was not loaded.
=============================================================================== rpmlint session starts ===============================================================================
rpmlint: 2.1.0
configuration:
    /usr/lib/python3.9/site-packages/rpmlint/configdefaults.toml
    /etc/xdg/rpmlint/fedora.toml
    /etc/xdg/rpmlint/licenses.toml
    /etc/xdg/rpmlint/scoring.toml
    /etc/xdg/rpmlint/users-groups.toml
    /etc/xdg/rpmlint/warn-on-functions.toml
rpmlintrc: /tmp
checks: 31, packages: 1

================================================ 1 packages and 0 specfiles checked; 0 errors, 0 warnings, 0 badness; has taken 0.0 s ================================================
```

This is a little confusing because the output lists /tmp as the rpmlintrc value, despite being told by the error that it is not loaded, but changing _print_header to only output the rpmlintrc value if it was valid seemed like a step beyond what I wanted to do to resolve this issue. After all, the user did pass that, should the tool confirm that, even if it is not a file and was not loaded? I defer that design decision to you, dear upstream. :)

