### PR TITLE
Keep having self.options['rpmlintrc'] an array.

### DIFF
--- a/rpmlint/cli.py
+++ b/rpmlint/cli.py
@@ -83,7 +83,7 @@ def process_lint_args(argv):
     parser.add_argument('-V', '--version', action='version', version=__version__, help='show package version and exit')
     parser.add_argument('-c', '--config', type=_validate_conf_location, help='load up additional configuration data from specified path (file or directory with *.toml files)')
     parser.add_argument('-e', '--explain', nargs='+', default='', help='provide detailed explanation for one specific message id')
-    parser.add_argument('-r', '--rpmlintrc', type=Path, help='load up specified rpmlintrc file')
+    parser.add_argument('-r', '--rpmlintrc', type=_is_file_path, help='load up specified rpmlintrc file')
     parser.add_argument('-v', '--verbose', '--info', action='store_true', help='provide detailed explanations where available')
     parser.add_argument('-p', '--print-config', action='store_true', help='print the settings that are in effect when using the rpmlint')
     parser.add_argument('-i', '--installed', nargs='+', default='', help='installed packages to be validated by rpmlint')
@@ -162,6 +162,13 @@ def _validate_conf_location(string):
         config_paths.append(path)
 
     return config_paths
+
+
+def _is_file_path(path):
+    p = Path(path)
+    if not p.is_file():
+        raise argparse.ArgumentTypeError(f'{path} is not a valid file path')
+    return p
 
 
 def lint():

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -35,6 +35,9 @@ class Lint(object):
             self.profile.enable()
         else:
             self.profile = None
+
+        if options['rpmlintrc']:
+            options['rpmlintrc'] = [options['rpmlintrc']]
         self._load_rpmlintrc()
         if options['verbose']:
             self.config.info = options['verbose']
@@ -161,11 +164,11 @@ class Lint(object):
         Load rpmlintrc from argument or load up from folder
         """
         if self.options['rpmlintrc']:
-            rcfile = self.options['rpmlintrc']
-            if rcfile.is_file():
+            # Right now, we allow loading of just a single file, but the 'opensuse'
+            # branch contains auto-loading mechanism that can eventually load
+            # multiple files.
+            for rcfile in self.options['rpmlintrc']:
                 self.config.load_rpmlintrc(rcfile)
-            else:
-                print_warning(f'(none): E: the specified rpmlintrc value "{rcfile}" is not a file and was not loaded.')
         else:
             # load only from the same folder specname.rpmlintrc or specname-rpmlintrc
             # do this only in a case where there is one folder parameter or one file


### PR DESCRIPTION
The array is used in opensuse branch where auto-loading mechanism
can load multiple files.

Fixes #704.