### PR TITLE
Add CONFIG_DISABLE_AUTOLOADING env in order to skip config auto-loading.

### DIFF
--- a/rpmlint/config.py
+++ b/rpmlint/config.py
@@ -72,7 +72,7 @@ class Config(object):
         self.conf_files.append(self.config_defaults)
 
         # Skip auto-loading when running under PYTEST
-        if not os.environ.get('PYTEST_XDIST_TESTRUNUID'):
+        if not os.environ.get('PYTEST_XDIST_TESTRUNUID') and not os.environ.get('CONFIG_DISABLE_AUTOLOADING'):
             # Then load up config directories on system
             for directory in reversed(xdg_config_dirs):
                 confdir = Path(directory) / 'rpmlint'


### PR DESCRIPTION
When one develops rpmlint on a system with install configuration, these
configs are automatically loaded. Which makes debugging harder.