### PR TITLE
Correct fallout from stricter checking

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -722,6 +722,7 @@ note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#1049694"
 nodigests = [
     "/etc/dbus-1/system.d/tpm2-abrmd.conf",
+    "/usr/share/dbus-1/system.d/tpm2-abrmd.conf",
     "/usr/share/dbus-1/system-services/com.intel.tss2.Tabrmd.service",
 ]
 

--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -423,7 +423,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "fprintd"
+package = "wicked"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#783932"

--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -148,6 +148,15 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
+package = "plasma5-desktop"
+type = "dbus"
+note = "legacy: not audited"
+nodigests = [
+    "/usr/share/dbus-1/system-services/org.kde.kcontrol.kcmclock.service",
+    "/usr/share/dbus-1/system.d/org.kde.kcontrol.kcmclock.conf",
+]
+
+[[FileDigestGroup]]
 package = "plasma5-workspace"
 type = "dbus"
 note = "legacy: not audited"

--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -197,6 +197,7 @@ type = "dbus"
 note = "legacy: not audited"
 nodigests = [
     "/etc/dbus-1/system.d/nm-dispatcher.conf",
+    "/usr/share/dbus-1/system.d/nm-dispatcher.conf",
     "/usr/share/dbus-1/system-services/org.freedesktop.nm_dispatcher.service",
 ]
 
@@ -207,6 +208,7 @@ note = "imported from rpmlint1 DBUSServices.WhiteList"
 bug = "bsc#747780"
 nodigests = [
     "/etc/dbus-1/system.d/org.freedesktop.NetworkManager.conf",
+    "/usr/share/dbus-1/system.d/org.freedesktop.NetworkManager.conf",
 ]
 
 [[FileDigestGroup]]


### PR DESCRIPTION
These locations were already whitelisted in rpmlint1, but now that the package name is tied to the whitelist we need additional entries