### PR TITLE
Ghost file exceptions

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -279,7 +279,7 @@ name = "licenses"
 path = "consolehelper$"
 name = "usermode-consoleonly"
 
-[[GhostFilesExceptions]]
+[GhostFilesExceptions]
 package = "polkit-default-privs"
 paths = [
     "/etc/polkit-1/rules.d/90-default-privs.rules",

--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -279,7 +279,7 @@ name = "licenses"
 path = "consolehelper$"
 name = "usermode-consoleonly"
 
-[GhostFilesExceptions]
+[[GhostFilesExceptions]]
 package = "polkit-default-privs"
 paths = [
     "/etc/polkit-1/rules.d/90-default-privs.rules",

--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -279,6 +279,12 @@ name = "licenses"
 path = "consolehelper$"
 name = "usermode-consoleonly"
 
+[[GhostFilesExceptions]]
+package = "polkit-default-privs"
+paths = [
+    "/etc/polkit-1/rules.d/90-default-privs.rules",
+]
+
 [FileDigestLocation]
 
 [FileDigestGroup]

--- a/rpmlint/checks/FileDigestCheck.py
+++ b/rpmlint/checks/FileDigestCheck.py
@@ -202,7 +202,7 @@ class FileDigestCheck(AbstractCheck):
             if not group:
                 continue
             elif pkgfile.name in pkg.ghost_files:
-                if not self._check_ghost_exceptions( pkg, pkgfile.name):
+                if not self._check_ghost_exceptions(pkg, pkgfile.name):
                     self.output.add_info('E', pkg, f'{group}-file-ghost', pkgfile.name)
             elif stat.S_ISLNK(pkgfile.mode) and not self.follow_symlinks_in_group[group]:
                 self.output.add_info('E', pkg, f'{group}-file-symlink', pkgfile.name)

--- a/rpmlint/checks/FileDigestCheck.py
+++ b/rpmlint/checks/FileDigestCheck.py
@@ -19,7 +19,7 @@ class FileDigestCheck(AbstractCheck):
             self.digest_configurations[group] = [Path(p) for p in values['Locations']]
             self.follow_symlinks_in_group[group] = values['FollowSymlinks']
             self.name_patterns_in_group[group] = values.get('NamePatterns')
-        self.ghost_file_exceptions = self.config.configuration['GhostFilesExceptions']
+        self.ghost_file_exceptions = self.config.configuration.get('GhostFilesExceptions', [])
 
         self.digest_groups = self.config.configuration.get('FileDigestGroup', [])
         for digest_group in self.digest_groups:


### PR DESCRIPTION
We need a way to whitelist %ghost'ed files that are present in whitelist targets. We currently see this in https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:L/polkit-default-privs/standard/x86_64