### PR TITLE
systemd-mini also ships pam_systemd.so. Now with the whitelist tied to

### DIFF
--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -211,6 +211,14 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
+package = "systemd-mini"
+type = "pam"
+note = "legacy: not audited"
+nodigests = [
+    "*/security/pam_systemd.so",
+]
+
+[[FileDigestGroup]]
 package = "systemd-experimental"
 type = "pam"
 note = "Imported as part of the rpmlint2 migration"


### PR DESCRIPTION
binary packages it needs its own entry