### PR TITLE
dbus-services: add oddjob-mkhomedir which got lost during migration

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1014,6 +1014,15 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
+package = "oddjob-mkhomedir"
+type = "dbus"
+note = "oddjob example that creates user's home directories upon first login"
+bug = "bsc#1169494"
+nodigests = [
+    "/etc/dbus-1/system.d/oddjob-mkhomedir.conf",
+]
+
+[[FileDigestGroup]]
 package = "deepin-api"
 type = "dbus"
 note = "an assorted mix of D-Bus interfaces for the Deepin desktop"


### PR DESCRIPTION
Packager complains that his Factory build got broken again. Turns out we
lost this piece of oddjob when syncing the additions from rpmlint 1
(bsc#1169494).