### PR TITLE
Fix missing-dependency-on check.

### DIFF
--- a/rpmlint/checks/TagsCheck.py
+++ b/rpmlint/checks/TagsCheck.py
@@ -396,7 +396,6 @@ class TagsCheck(AbstractCheck):
                     if not dep:
                         self.output.add_info('W', pkg, 'no-dependency-on', base_or_libs)
                     elif version:
-                        epoch = str(epoch)
                         exp = (epoch, version, None)
                         sexp = Pkg.versionToString(exp)
                         if not dep[1]:


### PR DESCRIPTION
It fixes issue seen here:
https://bugzilla.suse.com/show_bug.cgi?id=1190387

pam-devel.x86_64: W: missing-dependency-on pam*/pam-libs/libpam* = 1.5.2

The 2 compared values are:

(None, '1.5.2', None)
('None', '1.5.2', None)

which is wrong.