### PR TITLE
remove /run from disalloweddirs

### DIFF
--- a/rpmlint/configdefaults.toml
+++ b/rpmlint/configdefaults.toml
@@ -196,12 +196,12 @@ InvalidRequires = [
     '^libsafe\.so\.',
 ]
 # List of directory prefixes that are not allowed in packages
+# In addition rpmlint will warn about non-ghost files in "/run/"
 DisallowedDirs = [
     "/home",
     "/mnt",
     "/opt",
     "/proc",
-    "/run",
     "/tmp",
     "/usr/local",
     "/usr/tmp",


### PR DESCRIPTION
FilesCheck is checking for /run explicitly and warns on non-ghost
files. ghost files in /run are okay and actually encouraged by
the TmpFilesCheck.py check.