### PR TITLE
Update wording for shlib-policy-name-error.

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -341,7 +341,8 @@ class BinariesCheck(AbstractCheck):
                 if res:
                     soversion = res.group(1) or res.group(2)
                     if soversion and soversion not in pkg.name:
-                        self.output.add_info('E', pkg, 'shlib-policy-name-error', soversion)
+                        self.output.add_info('E', pkg, 'shlib-policy-name-error',
+                                             f'SONAME: {soname}, expected package suffix: {soversion}')
 
         # check if the object code in the library is compiled with PIC
         if self.readelf_parser.dynamic_section_info['TEXTREL']:

--- a/test/test_readelf_parser.py
+++ b/test/test_readelf_parser.py
@@ -207,7 +207,7 @@ def test_no_ldconfig_symlink(binariescheck):
     run_elf_checks(test, FakePkg('fake'), get_full_path('libutil-2.29.so'), '/lib64/libutil-2.29.so')
     out = output.print_results(output.results)
     assert 'no-ldconfig-symlink /lib64/libutil-2.29.so' in out
-    assert 'E: shlib-policy-name-error 1' in out
+    assert 'E: shlib-policy-name-error SONAME: libutil.so.1, expected package suffix: 1' in out
 
 
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')


### PR DESCRIPTION
Old output:
`E: shlib-policy-name-error 1`

New one:
`E: shlib-policy-name-error SONAME: libutil.so.1, expected package suffix: 1`