### PR TITLE
Fix -r argument.

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -38,8 +38,6 @@ class Lint(object):
         else:
             self.profile = None
 
-        if options['rpmlintrc']:
-            options['rpmlintrc'] = [options['rpmlintrc']]
         self._load_rpmlintrc()
         if options['verbose']:
             self.config.info = options['verbose']

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -416,7 +416,7 @@ def test_run_rpmlintrc_multiple(capsys, packages):
 def test_run_rpmlintrc_single_file(capsys, packages):
     additional_options = {
         'rpmfile': [packages],
-        'rpmlintrc': TEST_RPMLINTRC
+        'rpmlintrc': [TEST_RPMLINTRC]
     }
     options = get_options(additional_options)
     linter = Lint(options)


### PR DESCRIPTION
options['rpmlintrc'] is already a list created in cli.py

Fixes #741.