### PR TITLE
Add new LibraryDependencyCheck.

### DIFF
--- a/rpmlint/checks/AbstractCheck.py
+++ b/rpmlint/checks/AbstractCheck.py
@@ -25,6 +25,9 @@ class AbstractCheck(object):
     def check_spec(self, pkg):
         return
 
+    def after_checks(self):
+        return
+
 
 class AbstractFilesCheck(AbstractCheck):
     def __init__(self, config, output, file_regexp):

--- a/rpmlint/checks/LibraryDependencyCheck.py
+++ b/rpmlint/checks/LibraryDependencyCheck.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import stat
+
+from rpmlint.checks import FilesCheck
+from rpmlint.checks.AbstractCheck import AbstractCheck
+from rpmlint.pkg import FakePkg
+
+
+class LibraryDependencyCheck(AbstractCheck):
+    def __init__(self, config, output):
+        super().__init__(config, output)
+        self.package_requires = {}
+        self.package_so_symlinks = {}
+        self.package_so_files = {}
+        self.package_arch_mapping = {}
+
+    def check_binary(self, pkg):
+        if pkg.is_source:
+            return
+
+        is_devel = FilesCheck.devel_regex.search(pkg.name)
+        if is_devel:
+            self._process_devel_package(pkg, is_devel)
+        else:
+            self._process_nondevel_package(pkg)
+
+    def _process_devel_package(self, pkg, is_devel):
+        self.package_requires[pkg.name] = [req[0] for req in pkg.requires + pkg.prereq]
+        self.package_so_symlinks[pkg.name] = []
+        self.package_arch_mapping[pkg.name] = pkg.arch
+
+        for pkgfile in pkg.files.values():
+            if stat.S_ISLNK(pkgfile.mode) and pkgfile.name.endswith('.so'):
+                link = Path(pkgfile.name).parent / pkgfile.linkto
+                self.package_so_symlinks[pkg.name].append(str(link))
+
+    def _process_nondevel_package(self, pkg):
+        for pkgfile in pkg.files.values():
+            if FilesCheck.lib_regex.match(pkgfile.name):
+                self.package_so_files[pkgfile.name] = pkg.name
+
+    def after_checks(self):
+        for pkgname, so_symlinks in self.package_so_symlinks.items():
+            for link in so_symlinks:
+                with FakePkg(pkgname) as pkg:
+                    pkg.arch = self.package_arch_mapping[pkgname]
+                    if link not in self.package_so_files:
+                        self.output.add_info('E', pkg, 'no-library-dependency-for', link)
+                        break
+                    else:
+                        definition = self.package_so_files[link]
+                        if definition not in self.package_requires[pkgname]:
+                            self.output.add_info('E', pkg, 'no-library-dependency-on', definition)
+                            break

--- a/rpmlint/checks/TagsCheck.py
+++ b/rpmlint/checks/TagsCheck.py
@@ -359,7 +359,7 @@ class TagsCheck(AbstractCheck):
 
     def _check_multiple_tags(self, pkg, name, is_devel,
                              is_source, deps, epoch, version):
-        """Trigger checks no-name-tag check, no-dependency-on,
+        """Trigger checks no-name-tag check,
         no-version-dependency-on, missing-dependency-on,
         no-major-in-name, no-provides, no-pkg-config-provides
 
@@ -393,9 +393,7 @@ class TagsCheck(AbstractCheck):
                         if base_or_libs_re.match(d[0]):
                             dep = d
                             break
-                    if not dep:
-                        self.output.add_info('W', pkg, 'no-dependency-on', base_or_libs)
-                    elif version:
+                    if dep and version:
                         exp = (epoch, version, None)
                         sexp = Pkg.versionToString(exp)
                         if not dep[1]:

--- a/rpmlint/configdefaults.toml
+++ b/rpmlint/configdefaults.toml
@@ -14,6 +14,7 @@ Checks = [
     "FilesCheck",
     "IconSizesCheck",
     "I18NCheck",
+    "LibraryDependencyCheck",
     "LogrotateCheck",
     "MenuCheck",
     "MenuXDGCheck",

--- a/rpmlint/descriptions/LibraryDependencyCheck.toml
+++ b/rpmlint/descriptions/LibraryDependencyCheck.toml
@@ -1,0 +1,7 @@
+no-library-dependency-for="""
+The package misses dependency on a library package that provides the shared library.
+"""
+
+no-library-dependency-on="""
+The package misses dependency on a package which file it links to.
+"""

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -227,6 +227,10 @@ class Lint(object):
         for pkg in packages:
             self.validate_file(pkg, pkg == packages[-1])
 
+        # run post check function
+        for checker in self.checks.values():
+            checker.after_checks()
+
     def _expand_filelist(self, files):
         packages = []
         for pkg in files:

--- a/test/test_lib_dependency.py
+++ b/test/test_lib_dependency.py
@@ -1,0 +1,22 @@
+import pytest
+from rpmlint.checks.LibraryDependencyCheck import LibraryDependencyCheck
+from rpmlint.filter import Filter
+
+from Testing import CONFIG, get_tested_package
+
+
+@pytest.fixture(scope='function', autouse=True)
+def libdependencycheck():
+    CONFIG.info = True
+    output = Filter(CONFIG)
+    test = LibraryDependencyCheck(CONFIG, output)
+    return output, test
+
+
+@pytest.mark.parametrize('package', ['binary/shlib2-devel'])
+def test_shlib2_devel(tmpdir, package, libdependencycheck):
+    output, test = libdependencycheck
+    test.check(get_tested_package(package, tmpdir))
+    test.after_checks()
+    out = output.print_results(output.results)
+    assert 'E: no-library-dependency-for /usr/lib/libfoo.so.1' in out

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -40,6 +40,7 @@ basic_tests = [
     'FilesCheck',
     'IconSizesCheck',
     'I18NCheck',
+    'LibraryDependencyCheck',
     'LogrotateCheck',
     'MenuCheck',
     'MenuXDGCheck',

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -97,14 +97,6 @@ def test_forbidden_controlchar_found(tmpdir, package, tagscheck):
     assert 'E: forbidden-controlchar-found %changelog :' in out
 
 
-@pytest.mark.parametrize('package', ['binary/shlib2-devel'])
-def test_shlib2_devel(tmpdir, package, tagscheck):
-    output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
-    out = output.print_results(output.results)
-    assert 'W: no-dependency-on' in out
-
-
 @pytest.mark.parametrize('package', ['binary/unexpanded-macro-exp'])
 def test_check_unexpanded_macro(tmpdir, package, tagscheck):
     """Test if a package has an unexpanded macro in it's specfile."""


### PR DESCRIPTION
The check is a replacement for a weak `no-dependency-on` check.

The new check verifies that for a given `-devel` package, all symlink target packages are mentioned in `Requires:`.