### PR TITLE
Fix backward compatibility with rpmlintrc files.

### DIFF
--- a/rpmlint/config.py
+++ b/rpmlint/config.py
@@ -21,7 +21,7 @@ class Config(object):
     existing one.
     """
 
-    re_filter = re.compile(r'^\s*addFilter\s*\(r?[\"\'](.*)[\"\']\)')
+    re_filter = re.compile(r'^\s*addFilter\s*\(\s?r?[\"\'](.*)[\"\']\s?\)')
     re_badness = re.compile(r'\s*setBadness\s*\([\'\"](.*)[\'\"],\s*[\'\"]?(\d+)[\'\"]?\)')
     config_defaults = Path(__file__).parent / 'configdefaults.toml'
 

--- a/test/configs/testing3-rpmlintrc
+++ b/test/configs/testing3-rpmlintrc
@@ -1,0 +1,4 @@
+# Backward compatibility should match spaces within paren
+addFilter('no-spaces-in-paren')
+addFilter( 'has-spaces-in-paren' )
+addFilter("doublequotes-instead-of-singlequotes")

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -7,6 +7,7 @@ from Testing import get_tested_package, testpath
 
 TEST_CONFIG_FILTERS = [testpath() / 'configs/testfilters.config']
 TEST_RPMLINTRC = testpath() / 'configs/testing-rpmlintrc'
+TEST3_RPMLINTRC = testpath() / 'configs/testing3-rpmlintrc'
 TEST_PACKAGE = Path('binary', 'ngircd')
 TEST_PACKAGE2 = Path('binary', 'tempfiled')
 TEST_DESCRIPTIONS = [testpath() / 'configs/descriptions.config']
@@ -39,6 +40,19 @@ def test_data_storing(tmpdir):
     assert len(result.results) == 2
     assert result.printed_messages['W'] == 1
     assert result.printed_messages['E'] == 1
+
+
+def test_data_storing_backward_compat(tmpdir):
+    """
+    Make sure we can load some filters from rpmlintrc that
+    worked with rpmlint v1.
+    """
+    cfg = Config(TEST_CONFIG_FILTERS)
+    cfg.load_rpmlintrc(TEST3_RPMLINTRC)
+    parsed_filters = cfg.rpmlintrc_filters
+    assert 'no-spaces-in-paren' in parsed_filters
+    assert 'has-spaces-in-paren' in parsed_filters
+    assert 'doublequotes-instead-of-singlequotes' in parsed_filters
 
 
 def test_description_storing(tmpdir):


### PR DESCRIPTION
While upgrading from rpmlint v1 to v2, we found that some of our `addFilter()`s were being ignored due to spaces between the parenthesis and the filter text.  I've updated the regex that matched these filters to allow spaces as well and added tests.