### PR TITLE
Prevent duplicate files in lint input

### DIFF
--- a/rpmlint/cli.py
+++ b/rpmlint/cli.py
@@ -106,7 +106,7 @@ def process_lint_args(argv):
             print_warning(f"User specified rpmlintrc '{options.rpmlintrc}' does not exist")
             exit(2)
     # validate all the rpmlfile options to be either file or folder
-    f_path = []
+    f_path = set()
     invalid_path = False
     for item in options.rpmfile:
         p_path = Path()
@@ -122,14 +122,14 @@ def process_lint_args(argv):
             if not path.exists():
                 print_warning(f"The file or directory '{path}' does not exist")
                 invalid_path = True
-        f_path += p_path
+        f_path.update(p_path)
 
     if invalid_path:
         exit(2)
     # convert options to dict
     options_dict = vars(options)
     # use computed rpmfile
-    options_dict['rpmfile'] = f_path
+    options_dict['rpmfile'] = list(f_path)
     return options_dict
 
 


### PR DESCRIPTION
If the same file is passed in more than once as lint input,
certain checks misbehave.
At least error multiple-specfiles can be triggered
simply by passing in the same srpm twice.
Due to globbing, duplicates may be unknowingly passed in.
In order to avoid needless errors when that happens,
the rpmfile list in lint input is deduplicated
by collecting them in a set instead of a list.