### PR TITLE
Add missing re.compile.

### DIFF
--- a/rpmlint/checks/AlternativesCheck.py
+++ b/rpmlint/checks/AlternativesCheck.py
@@ -104,7 +104,7 @@ class AlternativesCheck(AbstractCheck):
         binaries = list(self.install_binaries.values())
         # we remove from the binaries list in the loop, copy it
         for binary in binaries.copy():
-            re_remove = re.compile(r'--remove\s+{}\b'.format(binary))
+            re_remove = re.compile(r'--remove\s+{}\b'.format(re.escape(binary)))
             for line in script:
                 if re_remove.search(line) and binary in binaries:
                     binaries.remove(binary)


### PR DESCRIPTION
Fixes:

```
./lint.py toluapp-5.3-1.0.93-0.x86_64.rpm -v
(none): E: fatal error while reading toluapp-5.3-1.0.93-0.x86_64.rpm: multiple repeat at position 17
Traceback (most recent call last):
  File "./lint.py", line 5, in <module>
    lint()
  File "/home/marxin/Programming/rpmlint/rpmlint/cli.py", line 181, in lint
    sys.exit(lint.run())
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 103, in run
    return self._run()
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 75, in _run
    self.validate_files(self.options['rpmfile'])
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 228, in validate_files
    self.validate_file(pkg, pkg == packages[-1])
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 261, in validate_file
    raise e
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 254, in validate_file
    self.run_checks(pkg, is_last)
  File "/home/marxin/Programming/rpmlint/rpmlint/lint.py", line 272, in run_checks
    fn(pkg)
  File "/home/marxin/Programming/rpmlint/rpmlint/checks/AlternativesCheck.py", line 58, in check
    self._check_postun_phase(pkg, self.postun)
  File "/home/marxin/Programming/rpmlint/rpmlint/checks/AlternativesCheck.py", line 107, in _check_postun_phase
    re_remove = re.compile(r'--remove\s+{}\b'.format(binary))
  File "/usr/lib64/python3.8/re.py", line 252, in compile
    return _compile(pattern, flags)
  File "/usr/lib64/python3.8/re.py", line 304, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/usr/lib64/python3.8/sre_compile.py", line 764, in compile
    p = sre_parse.parse(p, flags)
  File "/usr/lib64/python3.8/sre_parse.py", line 948, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "/usr/lib64/python3.8/sre_parse.py", line 443, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
  File "/usr/lib64/python3.8/sre_parse.py", line 671, in _parse
    raise source.error("multiple repeat",
re.error: multiple repeat at position 17
```