### PR TITLE
Allow multiple spaces between paren

### DIFF
--- a/rpmlint/config.py
+++ b/rpmlint/config.py
@@ -21,7 +21,7 @@ class Config(object):
     existing one.
     """
 
-    re_filter = re.compile(r'^\s*addFilter\s*\(\s?r?[\"\'](.*)[\"\']\s?\)')
+    re_filter = re.compile(r'^\s*addFilter\s*\(\s*r?[\"\'](.*)[\"\']\s*\)')
     re_badness = re.compile(r'\s*setBadness\s*\([\'\"](.*)[\'\"],\s*[\'\"]?(\d+)[\'\"]?\)')
     config_defaults = Path(__file__).parent / 'configdefaults.toml'
 

--- a/test/configs/testing3-rpmlintrc
+++ b/test/configs/testing3-rpmlintrc
@@ -1,4 +1,5 @@
 # Backward compatibility should match spaces within paren
 addFilter('no-spaces-in-paren')
 addFilter( 'has-spaces-in-paren' )
+addFilter(  'multiple-spaces-in-paren'  )
 addFilter("doublequotes-instead-of-singlequotes")

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -52,6 +52,7 @@ def test_data_storing_backward_compat(tmpdir):
     parsed_filters = cfg.rpmlintrc_filters
     assert 'no-spaces-in-paren' in parsed_filters
     assert 'has-spaces-in-paren' in parsed_filters
+    assert 'multiple-spaces-in-paren' in parsed_filters
     assert 'doublequotes-instead-of-singlequotes' in parsed_filters
 
 


### PR DESCRIPTION
Allow for additional spaces between the parenthesis in the backward compatible `addFilter()` regex.