### PR TITLE
dbus-whitelisting: setroubleshoot fix packagename

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1082,7 +1082,7 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "setroubleshoot"
+package = "setroubleshoot-server"
 type = "dbus"
 bug = "bsc#1186344"
 nodigests = [


### PR DESCRIPTION
Turns out the D-Bus files are in a sub-package.