### PR TITLE
allow rpmdiff for installed packages

### DIFF
--- a/rpmlint/cli.py
+++ b/rpmlint/cli.py
@@ -58,13 +58,6 @@ def process_diff_args(argv):
         sys.exit(0)
 
     options = parser.parse_args(args=argv)
-    # the rpms must exist for us to do anything
-    if not options.old_package.exists():
-        print_warning(f"The file '{options.old_package}' does not exist")
-        exit(2)
-    if not options.new_package.exists():
-        print_warning(f"The file '{options.new_package}' does not exist")
-        exit(2)
 
     # convert options to dict
     options_dict = vars(options)

--- a/rpmlint/rpmdiff.py
+++ b/rpmlint/rpmdiff.py
@@ -141,7 +141,7 @@ class Rpmdiff(object):
                 return Pkg(name, tmpdir)
         except TypeError:
             pass
-        inst = getInstalledPkgs(name)
+        inst = getInstalledPkgs(str(name))
         if not inst:
             raise KeyError(f'No installed packages by name {name}')
         if len(inst) > 1:


### PR DESCRIPTION
See #764 

Minimal fix, I'm not a python expert.

The print_warning can perhaps also be removed.

Without this
```
$ rpmdiff php-kolab-net-ldap3 /home/rpmbuild/SPECS/remirepo/php/php-kolab-net-ldap3/noarch/php-kolab-net-ldap3-1.1.4-1.fc33.remi.noarch.rpm
The file 'php-kolab-net-ldap3' does not exist
```
Using this

```

$ rpmdiff php-kolab-net-ldap3 /home/rpmbuild/SPECS/remirepo/php/php-kolab-net-ldap3/noarch/php-kolab-net-ldap3-1.1.4-1.fc33.remi.noarch.rpm
The file 'php-kolab-net-ldap3' does not exist
removed     PROVIDES php-kolab-net-ldap3 = 1.1.4-1.fc35.remi
added       PROVIDES php-kolab-net-ldap3 = 1.1.4-1.fc33.remi
.....L....T /usr/share/doc/php-kolab-net-ldap3
.....L..... /usr/share/doc/php-kolab-net-ldap3/composer.json
.....L....T /usr/share/licenses/php-kolab-net-ldap3
.....L..... /usr/share/licenses/php-kolab-net-ldap3/LICENSE
.....L..... /usr/share/php/Net
.....L..... /usr/share/php/Net/LDAP3
.....L..... /usr/share/php/Net/LDAP3.php
.....L..... /usr/share/php/Net/LDAP3/Result.php

```