### PR TITLE
Sort input .rpm files so that the output is stable.

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -224,6 +224,9 @@ class Lint(object):
         # check all elements if they are a folder or a file with proper suffix
         # and expand everything
         packages = self._expand_filelist(files)
+
+        # Sort the files so that the output is stable
+        packages = sorted(packages)
         for pkg in packages:
             self.validate_file(pkg, pkg == packages[-1])
 


### PR DESCRIPTION
Fixes: https://bugzilla.opensuse.org/show_bug.cgi?id=1193189