### PR TITLE
Make missing-call-to-setgroups-before-setuid only warning.

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -411,7 +411,8 @@ class BinariesCheck(AbstractCheck):
         gethostbyname = any(self.readelf_parser.symbol_table_info.get_functions_for_regex(self.gethostbyname_call_regex))
 
         if setgid and setuid and not setgroups:
-            self.output.add_info('E', pkg, 'missing-call-to-setgroups-before-setuid', path)
+            is_uid = stat.S_ISUID & pkg.files[path].mode
+            self.output.add_info('W' if is_uid else 'E', pkg, 'missing-call-to-setgroups-before-setuid', path)
 
         if mktemp:
             self.output.add_info('E', pkg, 'call-to-mktemp', path)

--- a/test/test_readelf_parser.py
+++ b/test/test_readelf_parser.py
@@ -5,6 +5,7 @@ import pytest
 from rpmlint.checks.BinariesCheck import BinariesCheck
 from rpmlint.filter import Filter
 from rpmlint.pkg import FakePkg, get_magic
+from rpmlint.pkgfile import PkgFile
 from rpmlint.readelfparser import ReadelfParser
 
 from Testing import CONFIG, get_tested_path, HAS_32BIT_GLIBC, IS_I686, IS_X86_64
@@ -223,9 +224,13 @@ def test_call_mktemp(binariescheck):
 def test_call_setgroups(binariescheck):
     output, test = binariescheck
 
-    run_elf_checks(test, FakePkg('fake'), get_full_path('call-setgroups'), '/bin/call-setgroups')
-    out = output.print_results(output.results)
-    assert 'E: missing-call-to-setgroups-before-setuid /bin/call-setgroups' in out
+    with FakePkg('fake') as pkg:
+        pkgfile = PkgFile('/bin/call-setgroups')
+        pkgfile.path = get_full_path('call-setgroups')
+        pkg.files[pkgfile.name] = pkgfile
+        run_elf_checks(test, pkg, pkgfile.path, pkgfile.name)
+        out = output.print_results(output.results)
+        assert 'E: missing-call-to-setgroups-before-setuid /bin/call-setgroups' in out
 
 
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')


### PR DESCRIPTION
If the application is setuid, emit warning, otherwise report
an error.

Fixes #772.