### PR TITLE
Use different Python package for ZStandard

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
               python3-flake8-import-order
               python3-flake8-quotes
               python3-pyxdg
-              python3-zstd
+              python3-zstandard
               python3-toml
               python3-pip
               rpm-build
@@ -86,7 +86,7 @@ jobs:
               python3-flake8-import-order
               python3-pyxdg
               python3-toml
-              python3-zstd
+              python3-zstandard
               python3-pip
               rpm-build
               git

--- a/.packit/rpmlint.spec
+++ b/.packit/rpmlint.spec
@@ -28,7 +28,7 @@ BuildRequires:  python3-pytest-xdist
 BuildRequires:  python3-pyxdg
 BuildRequires:  python3-rpm
 BuildRequires:  python3-toml
-BuildRequires:  python3-zstd
+BuildRequires:  python3-zstandard
 %else
 BuildRequires:  python3dist(setuptools)
 # For tests
@@ -42,7 +42,7 @@ BuildRequires:  python3dist(pytest-xdist)
 BuildRequires:  python3dist(pyxdg)
 BuildRequires:  python3dist(rpm)
 BuildRequires:  python3dist(toml)
-BuildRequires:  python3dist(zstd)
+BuildRequires:  python3dist(zstandard)
 %endif
 
 # Rest of the test dependencies

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -22,7 +22,7 @@ except ImportError:
 import rpm
 from rpmlint.helpers import byte_to_string, ENGLISH_ENVIROMENT, print_warning
 from rpmlint.pkgfile import PkgFile
-import zstd
+import zstandard as zstd
 
 
 DepInfo = namedtuple('DepInfo', ('name', 'flags', 'version'))

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'pyxdg',
         'rpm',
         'toml',
-        'zstd',
+        'zstandard',
         'importlib-metadata;python_version<"3.8"',
     ],
     tests_require=[


### PR DESCRIPTION
The Python package [zstd](https://github.com/sergey-dryabzhinsky/python-zstd) does not have an `open()` function which means the current implementation is broken. I suspect the intention was to use the package [zstandard](https://github.com/indygreg/python-zstandard) all along.

To test this, try building an RPM of the following SPEC and running rpmlint on it:

```spec
Name:       zstd-file
Version:    1
Release:    1
Summary:    RPM containing ZStandard compressed file
License:    FIXME
BuildRequires: zstd

%description
RPM containing ZStandard compressed file.

%build
cat > hello-world <<EOF
HELLO WORLD
EOF
zstd -f hello-world

%install
install -Dm 644 hello-world.zst %{buildroot}/usr/share/doc/zstd-file/hello-world.zst

%files
%doc %attr(0644, root, root) "/usr/share/doc/zstd-file/hello-world.zst"
```

This will produce an exception:

```sh
$ ./lint.py zstd-file-1-1.x86_64.rpm
(none): E: fatal error while reading zstd-file-1-1.x86_64.rpm: module 'zstd' has no attribute 'open'
```

With the dependency replaced this does not happen.