### PR TITLE
Add icingaweb2 group

### DIFF
--- a/configs/openSUSE/users-groups.toml
+++ b/configs/openSUSE/users-groups.toml
@@ -68,6 +68,7 @@ StandardGroups = [
     'icecream',
     'icinga',
     'icingacmd',
+    'icingaweb2',
     'ifdrwww',
     'intermezzo',
     'iouyap',


### PR DESCRIPTION
Add icingaweb2 to the list of allowed groups. This group is used by the package icingaweb2, which already made it into Tumbleweed beside the missing group:
 https://build.opensuse.org/package/live_build_log/openSUSE:Factory/icingaweb2/standard/x86_64