### PR TITLE
pam module whitelist: adjust package name for pam_winbind (bsc#1194573)

### DIFF
--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -33,9 +33,10 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "samba-winbind"
+package = "samba-winbind-libs"
 type = "pam"
-note = "legacy: not audited"
+bug  = "bsc#1194573"
+note = "performs authentication against a Windows domain server"
 nodigests = [
     "*/security/pam_winbind.so",
 ]


### PR DESCRIPTION
I made a quick review of the current sources for the PAM module and
nothing terrible caught my attention.