### PR TITLE
Fix LGTM warning about RE pattern.

### DIFF
--- a/rpmlint/checks/SharedLibraryPolicyCheck.py
+++ b/rpmlint/checks/SharedLibraryPolicyCheck.py
@@ -23,7 +23,7 @@ class SharedLibraryPolicyCheck(AbstractCheck):
         self.re_soname_strongly_versioned = re.compile(r'-[\d\.]+\.so$')
         # the pkgname is based on soname if ending with number; special option is flavor build
         self.re_soname_pkg = re.compile(r'^lib\S+(\d+(-(32|64)bit)?)$')
-        self.re_so_files = re.compile(r'\S+.so((.(\d+))+)?$')
+        self.re_so_files = re.compile(r'\S+.so((\.(\d+))*)$')
 
     def _check_missing_policy_lib(self, pkg):
         # check the pkg has any libname


### PR DESCRIPTION
`self.re_so_files = re.compile(r'\S+.so((.(\d+))+)?$')`
This part of the regular expression may cause exponential backtracking on strings starting with '!asoa' and containing many repetitions of '99'.