### PR TITLE
Remove shared-library-not-executable for all shared libs.

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -498,9 +498,7 @@ class BinariesCheck(AbstractCheck):
 
     def _check_executable_shlib(self, pkg, pkgfile):
         if not (pkgfile.mode & stat.S_IEXEC) and self.readelf_parser.is_shlib:
-            interp = [h for h in self.readelf_parser.program_header_info.headers if h.name == 'INTERP']
-            if interp:
-                self.output.add_info('E', pkg, 'shared-library-not-executable', pkgfile.name)
+            self.output.add_info('E', pkg, 'shared-library-not-executable', pkgfile.name)
 
     def _check_optflags(self, pkg, pkgfile):
         if self.is_archive:


### PR DESCRIPTION
And not only for these that have set INTERP.
Fixes: #792.