### PR TITLE
Add new option --ignore-unused-rpmlintrc.

### DIFF
--- a/rpmlint/cli.py
+++ b/rpmlint/cli.py
@@ -82,6 +82,8 @@ def process_lint_args(argv):
     parser.add_argument('-i', '--installed', nargs='+', default='', help='installed packages to be validated by rpmlint')
     parser.add_argument('-t', '--time-report', action='store_true', help='print time report for run checks')
     parser.add_argument('-T', '--profile', action='store_true', help='print cProfile report')
+    parser.add_argument('--ignore-unused-rpmlintrc', action='store_true',
+                        help='Do not report "unused-rpmlintrc-filter" errors')
     lint_modes_parser = parser.add_mutually_exclusive_group()
     lint_modes_parser.add_argument('-s', '--strict', action='store_true', help='treat all messages as errors')
     lint_modes_parser.add_argument('-P', '--permissive', action='store_true', help='treat individual errors as non-fatal')

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -276,7 +276,8 @@ class Lint(object):
             for checker in self.checks.values():
                 checker.after_checks()
 
-            self.output.validate_filters(pkg)
+            if not self.options['ignore_unused_rpmlintrc']:
+                self.output.validate_filters(pkg)
 
         if spec_checks:
             self.specfiles_checked += 1

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -22,7 +22,8 @@ options_preset = {
     'rpmlintrc': False,
     'installed': '',
     'time_report': False,
-    'profile': False
+    'profile': False,
+    'ignore_unused_rpmlintrc': False
 }
 
 basic_tests = [


### PR DESCRIPTION
The option skips reporting of unused-rpmlintrc-filter errors.

Fixes: #794.