### PR TITLE
FileDigestCheck: implement support for file digest filtering

### DIFF
--- a/test/configs/digests_filtered.config
+++ b/test/configs/digests_filtered.config
@@ -1,0 +1,59 @@
+[FileDigestLocation.shellfilter]
+Digester = "shell"
+FollowSymlinks = false
+Locations = [
+    "/shell/",
+]
+
+[FileDigestLocation.xmlfilter]
+Digester = "xml"
+FollowSymlinks = false
+Locations = [
+    "/xml/",
+]
+
+[FileDigestLocation.defaultfilter]
+Digester = "default"
+FollowSymlinks = false
+Locations = [
+    "/default/",
+]
+
+[[FileDigestGroup]]
+package = "shellpkg"
+type = "shellfilter"
+note = "tests a package that has a shell script; use the 'shell' digester on it"
+bug = "bsc#1234"
+digests = [
+    {
+        path = "/shell/test.sh",
+        algorithm = "sha256",
+        hash = "44c0c33ec06bb5c82bc1d2cefe697db8d3ec20c5d4bc49c90988251fb57e0e19"
+    },
+]
+
+[[FileDigestGroup]]
+package = "xmlpkg"
+type = "xmlfilter"
+note = "tests a package that has an xml file; use the 'xml' digester on it"
+bug = "bsc#1234"
+digests = [
+    {
+        path = "/xml/test.xml",
+        algorithm = "sha256",
+	hash = "a6de3b9368a6029d793a8abe1e558579215cef4ee15952c409f991e1ecaf2df8"
+    },
+]
+
+[[FileDigestGroup]]
+package = "defaultpkg"
+type = "defaultfilter"
+note = "tests a package that an arbitrary file; use the 'default' digester on it"
+bug = "bsc#1234"
+digests = [
+    {
+        path = "/default/some.txt",
+        algorithm = "sha256",
+        hash = "826817e99969b8037801d1886cbee8b87df8aa45f99125e72eb8817920cd3e5d"
+    },
+]

--- a/test/data/shell_digest.sh
+++ b/test/data/shell_digest.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# let's iterate over 1 to 10
+for i in `seq 10`; do
+    echo "$i"
+done
+
+fun() {
+    # what fun?!
+    echo "have fun!"  
+}

--- a/test/data/xml_digest.xml
+++ b/test/data/xml_digest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?> <!--*-nxml-*-->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<!--
+  SPDX-License-Identifier: LGPL-2.1+
+
+  This file is part of elogind.
+
+  elogind is free software; you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License as published by
+  the Free Software Foundation; either version 2.1 of the License, or
+  (at your option) any later version.
+-->
+
+<busconfig>
+
+        <policy user="root">
+                <allow own="org.freedesktop.login1"/>
+                <allow send_destination="org.freedesktop.login1"/>  
+                <allow receive_sender="org.freedesktop.login1"/>
+        </policy>
+
+        <policy context="default">
+                <deny send_destination="org.freedesktop.login1"/>  
+
+                <allow send_destination="org.freedesktop.login1"
+                       send_interface="org.freedesktop.DBus.Introspectable"/>
+        </policy>
+
+</busconfig>

--- a/tools/get_whitelisting_digest.py
+++ b/tools/get_whitelisting_digest.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+import argparse
+import os
+import sys
+
+# make rpmlint modules available
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+import rpmlint.checks.FileDigestCheck as fdc  # noqa: E402
+
+parser = argparse.ArgumentParser(
+    description='This tool helps calculating whitelisting digests for the FileDigestCheck'
+)
+parser.add_argument('--filter', choices=list(fdc.DIGESTERS.keys()), required=True)
+parser.add_argument('--show-result',
+                    help='Instead of print the resulting digest, show the filtered file data',
+                    action='store_true')
+parser.add_argument('FILE')
+
+args = parser.parse_args()
+
+if args.filter == 'default' and args.show_result:
+    print('Cannot output result data for default digester (which is binary)', file=sys.stderr)
+    sys.exit(1)
+
+Digester = fdc.DIGESTERS.get(args.filter, fdc.DefaultDigester)
+
+digester = Digester(args.FILE, fdc.DEFAULT_DIGEST_ALG)
+
+if args.show_result:
+    for chunk in digester.parse_content():
+        print(chunk.decode('utf8'), end='')
+else:
+    print(digester.get_digest())


### PR DESCRIPTION
We want to become more robust against trivial changes in whitelisted
files. Currently we are not using file digests for things like D-Bus
service XML files, because a lot of non-functional changes might be
disrupting our processes.

With these filter we will be able to avoid this and become aware of more
sensitive upstream changes in the future.

This commit only contains the infrastucture, no production whitelists
use the feature yet, they will rely on the DefaultDigester until we
decide how to continue from here.