### PR TITLE
Require at least Python 3.8.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
         container:
           - 'registry.fedoraproject.org/fedora:latest'
           - 'registry.fedoraproject.org/fedora:rawhide'
-          - 'registry.opensuse.org/opensuse/leap-dnf:15.3'
           - 'registry.opensuse.org/opensuse/tumbleweed-dnf:latest'
         include:
           - container: 'registry.fedoraproject.org/fedora:latest'
@@ -63,7 +62,7 @@ jobs:
               python3-pyenchant
         if: ${{ contains(matrix.container, 'opensuse') && matrix.build-type == 'normal' }}
       - run: dnf --assumeyes install python3-flake8-comprehensions
-        if: ${{ contains(matrix.container, 'opensuse/tumbleweed') }}
+        if: ${{ contains(matrix.container, 'opensuse') }}
       - run: dnf --nogpgcheck --assumeyes install
               /usr/bin/cpio
               /usr/bin/bzip2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ https://github.com/rpm-software-management/rpmlint
 For installation on your machine you will need the following packages:
 
 Mandatory:
-- Python 3.6 or newer
+- Python 3.8 or newer
 - python3-setuptools, python3-toml, python3-pyxdg, python3-beam
 - rpm and its python bindings
 - binutils, cpio, gzip, bzip, xz and zstd

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,6 @@ setup(
         'Operating System :: POSIX',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Right now, we would like to use some xml.etree functionality that
is there since 3.8: #800.

Thus I'm suggesting using Python 3.8 that's out for quite some time.

What do you think @Conan-Kudo about this pull request?