### PR TITLE
Speed up pkg.grep.

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -108,10 +108,10 @@ class BinariesCheck(AbstractCheck):
         If so then print a corresponding error with the matching line numbers.
         """
         if self.la_file_regex.search(fname):
-            lines = pkg.grep(self.invalid_dir_ref_regex, fname)
-            if lines:
+            line = pkg.grep(self.invalid_dir_ref_regex, fname)
+            if line:
                 self.output.add_info('E', pkg, 'invalid-la-file', fname,
-                                     '(line %s)' % ', '.join(lines))
+                                     f'(line {line})')
 
     def _check_binary_in_noarch(self, pkg, bin_name):
         """

--- a/rpmlint/checks/BuildDateCheck.py
+++ b/rpmlint/checks/BuildDateCheck.py
@@ -23,10 +23,9 @@ class BuildDateCheck(AbstractFilesCheck):
 
         grep_date = pkg.grep(self.istoday, filename)
 
-        if len(grep_date):
+        if grep_date:
             grep_time = pkg.grep(self.looksliketime, filename)
-
-            if len(grep_time):
+            if grep_time:
                 self.output.add_info('E', pkg, 'file-contains-date-and-time', filename)
             else:
                 self.output.add_info('E', pkg, 'file-contains-current-date', filename)

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -519,19 +519,17 @@ class Pkg(AbstractPkg):
             self.__tmpdir.cleanup()
 
     def grep(self, regex, filename):
-        """Grep regex from a file, return matching line numbers."""
-        ret = []
-        lineno = 0
+        """Grep regex from a file, return first matching line number (starting with 1)."""
         try:
             with open(Path(self.dirName() or '/', filename.lstrip('/'))) as in_file:
-                for line in in_file:
-                    lineno += 1
-                    if regex.search(line):
-                        ret.append(str(lineno))
-                        break
+                data = in_file.read()
+                match = regex.search(data)
+                if match:
+                    return data.count('\n', 0, match.start()) + 1
+                else:
+                    return None
         except Exception:
-            pass
-        return ret
+            return None
 
     def langtag(self, tag, lang):
         """Get value of tag in the given language."""


### PR DESCRIPTION
Use regex search of the entire file.
This speed up various checks on kernel-source.rpm from 47s to 35s.