### PR TITLE
Digest filter configuration per entry

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1141,11 +1141,13 @@ digests = [
     {
         path = "/usr/share/dbus-1/system.d/org.nvmexpress.stac.conf",
         algorithm = "sha256",
+        digester = "xml",
         hash = "96eeef5353252bc721a4724255ed9d3f3cd7d2ffd425c5c06d67e1ea3f05fb36"
     },
     {
         path = "/usr/share/dbus-1/system.d/org.nvmexpress.staf.conf",
         algorithm = "sha256",
+        digester = "xml",
         hash = "e991c8b4e4b0b1459d16ee33863e6b5425f0b9a9afd3e2fb6e040ab545651a3d"
     }
 ]

--- a/configs/openSUSE/security.toml
+++ b/configs/openSUSE/security.toml
@@ -11,7 +11,6 @@ Locations = [
 ]
 
 [FileDigestLocation.dbus]
-Digester = "xml"
 FollowSymlinks = false
 Locations = [
     "/usr/share/dbus-1/system-services/",

--- a/rpmlint/checks/FileDigestCheck.py
+++ b/rpmlint/checks/FileDigestCheck.py
@@ -110,10 +110,9 @@ class XmlDigester(DefaultDigester):
         yield ET.canonicalize(from_file=self.path, strip_text=True).encode()
 
 
-# These values can be used in the FileDigest configuration for the "Digester"
-# key. A digester is always the same for one type of FileDigest whitelistings
-# and thus not tied to individual whitelisting entries but to the type of a
-# FileDigestGroup.
+# These values can be used in the individual "digests" entries of a
+# whitelisting entry for a given digest group. For example:
+# { path = "/some/path.xml", algorithm = "sha256", digester = "xml", hash = "..." }
 DIGESTERS = {
     'default': DefaultDigester,
     'shell': ShellDigester,
@@ -129,16 +128,10 @@ class FileDigestCheck(AbstractCheck):
         self.digest_configuration_trie = {}
         self.follow_symlinks_in_group = {}
         self.name_patterns_in_group = {}
-        self.digester_for_group = {}
         for group, values in self.config.configuration['FileDigestLocation'].items():
             self.digest_configurations[group] = [Path(p) for p in values['Locations']]
             self.follow_symlinks_in_group[group] = values['FollowSymlinks']
             self.name_patterns_in_group[group] = values.get('NamePatterns')
-            digester_name = values.get('Digester', 'default')
-            digester = DIGESTERS.get(digester_name, None)
-            if not digester:
-                raise Exception(f'Invalid digester {digester_name} encountered for group {group}')
-            self.digester_for_group[group] = digester
 
         self._setup_digest_location_trie()
         self.ghost_file_exceptions = self.config.configuration.get('GhostFilesExceptions', [])
@@ -148,6 +141,13 @@ class FileDigestCheck(AbstractCheck):
         for digest_group in self.digest_groups:
             self._normalize_digest_group(digest_group)
             self._verify_digest_group(digest_group)
+
+    def _get_digester(self, entry):
+        name = entry.get('digester', 'default')
+        try:
+            return DIGESTERS[name]
+        except KeyError:
+            raise Exception(f'Invalid digester {name} encountered for path {entry["path"]}')
 
     def _setup_digest_location_trie(self):
         # Build trie of Locations that are present in FileDigestLocation
@@ -205,8 +205,9 @@ class FileDigestCheck(AbstractCheck):
         if dg_type not in self.digest_configurations:
             raise KeyError(f'FileDigestGroup type "{dg_type}" is not '
                            f'supported, known values: {list(self.digest_configurations)}')
-        # verify digest algorithm
+
         for digest in digest_group['digests']:
+            # verify digest algorithm
             algorithm = digest['algorithm']
             if algorithm == 'skip':
                 pass
@@ -216,6 +217,9 @@ class FileDigestCheck(AbstractCheck):
 
             if 'path' not in digest:
                 raise KeyError('FileDigestCheck: missing "path" key in FileDigestGroup entry')
+
+            # verify a valid digester is selected, if any
+            self._get_digester(digest)
 
         package = digest_group.get('package', None)
         packages = digest_group.get('packages', [])
@@ -261,7 +265,7 @@ class FileDigestCheck(AbstractCheck):
                     pass
         return None
 
-    def _is_valid_digest(self, group_type, path, digest, pkg):
+    def _is_valid_digest(self, path, digest, pkg):
         algorithm = digest['algorithm']
         if algorithm == 'skip':
             return (True, None)
@@ -270,7 +274,8 @@ class FileDigestCheck(AbstractCheck):
         if pkgfile is None:
             return (False, None)
 
-        file_digest = self._calc_digest(group_type, pkgfile, algorithm)
+        digester = self._get_digester(digest)
+        file_digest = self._calc_digest(digester, pkgfile, algorithm)
         return (file_digest == digest['hash'], file_digest)
 
     def _resolve_links(self, pkg, path):
@@ -282,16 +287,15 @@ class FileDigestCheck(AbstractCheck):
 
         return pkgfile
 
-    def _calc_digest(self, group_type, pkgfile, algorithm):
-        # include the group_type in the cache key, because different groups
-        # can use different Digester types
-        cache_key = (group_type, pkgfile.name, algorithm)
+    def _calc_digest(self, digester, pkgfile, algorithm):
+        # include the digester in the cache key, because different entries
+        # might be using different digester types
+        cache_key = (id(digester), pkgfile.name, algorithm)
 
         digest = self.digest_cache.get(cache_key, None)
         if digest is not None:
             return digest
 
-        digester = self.digester_for_group[group_type]
         digest = digester(pkgfile.path, algorithm).get_digest()
 
         self.digest_cache[cache_key] = digest
@@ -326,7 +330,10 @@ class FileDigestCheck(AbstractCheck):
                 digest_path = ''
                 if pkgfile:
                     try:
-                        encountered_digest = self._calc_digest(group_type, pkgfile, DEFAULT_DIGEST_ALG)
+                        # TODO: we could heuristically use a better suitable
+                        # digester e.g. 'xml' for D-Bus groups in a certain
+                        # path.
+                        encountered_digest = self._calc_digest(DIGESTERS['default'], pkgfile, DEFAULT_DIGEST_ALG)
                     except Exception as e:
                         encountered_digest = f'failed to calculate digest: {e}'
                     if pkgfile.name != spath:
@@ -356,7 +363,7 @@ class FileDigestCheck(AbstractCheck):
                     # This digest entry is not needed anymore and could be dropped
                     continue
                 try:
-                    valid_digest, file_digest = self._is_valid_digest(group_type, path, digest, pkg)
+                    valid_digest, file_digest = self._is_valid_digest(path, digest, pkg)
                 except Exception as e:
                     self.output.add_info('E', pkg, f'{group_type}-file-parse-error', path, f'failed to calculate digest: {e}')
                     continue

--- a/rpmlint/checks/FileDigestCheck.py
+++ b/rpmlint/checks/FileDigestCheck.py
@@ -214,6 +214,9 @@ class FileDigestCheck(AbstractCheck):
                 # this will raise on bad algorithm names
                 hashlib.new(algorithm)
 
+            if 'path' not in digest:
+                raise KeyError('FileDigestCheck: missing "path" key in FileDigestGroup entry')
+
         package = digest_group.get('package', None)
         packages = digest_group.get('packages', [])
 

--- a/test/configs/digests_filtered.config
+++ b/test/configs/digests_filtered.config
@@ -1,59 +1,49 @@
-[FileDigestLocation.shellfilter]
-Digester = "shell"
+[FileDigestLocation.filtertest]
 FollowSymlinks = false
 Locations = [
     "/shell/",
-]
-
-[FileDigestLocation.xmlfilter]
-Digester = "xml"
-FollowSymlinks = false
-Locations = [
     "/xml/",
-]
-
-[FileDigestLocation.defaultfilter]
-Digester = "default"
-FollowSymlinks = false
-Locations = [
-    "/default/",
+    "/default/"
 ]
 
 [[FileDigestGroup]]
 package = "shellpkg"
-type = "shellfilter"
+type = "filtertest"
 note = "tests a package that has a shell script; use the 'shell' digester on it"
 bug = "bsc#1234"
 digests = [
     {
         path = "/shell/test.sh",
         algorithm = "sha256",
+        digester = "shell",
         hash = "44c0c33ec06bb5c82bc1d2cefe697db8d3ec20c5d4bc49c90988251fb57e0e19"
     },
 ]
 
 [[FileDigestGroup]]
 package = "xmlpkg"
-type = "xmlfilter"
+type = "filtertest"
 note = "tests a package that has an xml file; use the 'xml' digester on it"
 bug = "bsc#1234"
 digests = [
     {
         path = "/xml/test.xml",
         algorithm = "sha256",
-	hash = "a6de3b9368a6029d793a8abe1e558579215cef4ee15952c409f991e1ecaf2df8"
+        digester = "xml",
+        hash = "a6de3b9368a6029d793a8abe1e558579215cef4ee15952c409f991e1ecaf2df8"
     },
 ]
 
 [[FileDigestGroup]]
 package = "defaultpkg"
-type = "defaultfilter"
+type = "filtertest"
 note = "tests a package that an arbitrary file; use the 'default' digester on it"
 bug = "bsc#1234"
 digests = [
     {
         path = "/default/some.txt",
         algorithm = "sha256",
+        digester = "default",
         hash = "826817e99969b8037801d1886cbee8b87df8aa45f99125e72eb8817920cd3e5d"
     },
 ]


### PR DESCRIPTION
It turns out that tying the digester filter type to the whitelisting type
is not flexible enough. E.g. in the dbus whitelisting type we have two
different kinds of files to whitelist: actual D-Bus XML service
definitions but also systemd D-Bus activation files that are non-XML
files.