### PR TITLE
dbus-services whitelist: add test whitelisting to cover dbus-file-par…

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -21,6 +21,12 @@ digests = [
         path = "/etc/dbus-1/system.d/rpmlint_mismatch.conf",
         algorithm = "sha256",
         hash = "4a5e8e9ca514c73f1dbee55e88c4d75a235473c1d5cef4751d84016833961fdf"
+    },
+    {
+        path = "/usr/share/dbus-1/system.d/nonsense.conf",
+        algorithm = "sha256",
+        hash = "9a4e829ca514c73f1dbee55e88c4d75a235473c1d5cef4751d84016833961fda",
+        digester = "xml"
     }
 ]
 


### PR DESCRIPTION
…se-error

Our integration test in OBS security:rpmlint:testing/rpmlint-integration-test
wants to cover this new error category, therefore add another test
whitelisting for an XML file with XML parsing that fails.