### PR TITLE
D-Bus services whitelist: add kpmcore (bsc#1178848)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1157,3 +1157,23 @@ digests = [
         hash = "e991c8b4e4b0b1459d16ee33863e6b5425f0b9a9afd3e2fb6e040ab545651a3d"
     }
 ]
+
+[[FileDigestGroup]]
+package = "kpmcore"
+type = "dbus"
+note = "Helper for (re)partitioning block devices"
+bug = "bsc#1178848"
+digests = [
+    {
+        path = "/usr/share/dbus-1/system.d/org.kde.kpmcore.helperinterface.conf",
+        algorithm = "sha256",
+        digester = "xml",
+        hash = "aee71755aa4d24b8d0dde83e704b45e453703c0083c4eb02010cd9ffba25c706"
+    },
+    {
+        path = "/usr/share/dbus-1/system-services/org.kde.kpmcore.helperinterface.service",
+        algorithm = "sha256",
+        digester = "shell",
+        hash = "935e355306402268dcdb4c483f7c61587c621a468e65ee474dd2e08bb961b7f7"
+    }
+]


### PR DESCRIPTION
The upstream code is still a bit shaky but we are whitelisting
nonetheless, because the existing kpmcore package in Factory is even
worse (running completely as root, currently broken build).