### PR TITLE
missing alpha_3 hye added for Armenian

### DIFF
--- a/rpmlint/__isocodes__.py
+++ b/rpmlint/__isocodes__.py
@@ -2525,6 +2525,7 @@ LANGUAGES = set(
  'hwo',
  'hy',
  'hya',
+ 'hye',
  'hz',
  'ia',
  'iai',


### PR DESCRIPTION
I was updating a xfce package and rpmlint gave an error as "E: invalid-lc-messages-dir /usr/share/locale/hye/LC_MESSAGES/xfce4-taskmanager.mo" then I tested for some other xfce packages from fedora35 and got the same error. I also checked xfce packages on Ubuntu + Archlinux + Pardus and they've the locale.