### PR TITLE
Dbus whitelist fix

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1172,8 +1172,5 @@ digests = [
     }
 ]
 nodigests = [
-    {
-        path = "/usr/share/dbus-1/system-services/org.kde.kpmcore.helperinterface.service",
-        algorithm = "sha256"
-    }
+    "/usr/share/dbus-1/system-services/org.kde.kpmcore.helperinterface.service"
 ]

--- a/test/test_whitelist_syntax.py
+++ b/test/test_whitelist_syntax.py
@@ -25,6 +25,16 @@ def basic_syntax_checks(entry):
             assert prefix in ('bsc', 'boo')
             assert nr.isdigit()
 
+    for digest in entry.get('digests', []):
+        assert isinstance(digest, dict)
+        for key in ('path', 'hash'):
+            assert key in digest
+            val = digest.get(key, '')
+            assert isinstance(val, str)
+
+    for nodigest in entry.get('nodigests', []):
+        assert isinstance(nodigest, str)
+
     # we use 'note'
     assert 'comment' not in entry
 


### PR DESCRIPTION
Turns out we've been a bit too quick to merge this recent change. I'm tightening the test harness to avoid such situations in the future.