### PR TITLE
sudoers-whitelist: add another integration test whitelisting entry

### DIFF
--- a/configs/openSUSE/sudoers-whitelist.toml
+++ b/configs/openSUSE/sudoers-whitelist.toml
@@ -13,6 +13,20 @@ digests = [
 ]
 
 [[FileDigestGroup]]
+package = "rpmlint-integration-test"
+type = "sudoers"
+note = "mismatching test whitelisting entry for the OBS integration test package"
+bug = "bsc#1188704"
+digests = [
+    {
+        path = "/etc/sudoers.d/mismatching-rules",
+        algorithm = "sha256",
+        digester = "shell",
+        hash = "a4cf85013ddd404ad1f67ccf1259567b57305acd3b5bfaa696cf9f25a25dfcaa"
+    }
+]
+
+[[FileDigestGroup]]
 package = "monitoring-plugins-smart"
 type = "sudoers"
 note = "Nagios plugin for monitoring SMART device status. Rather complex Perl script"


### PR DESCRIPTION
we're still missing a bit of test coverage for the new whitelist