### PR TITLE
Distinguish exit code in --strict mode.

### DIFF
--- a/rpmlint/filter.py
+++ b/rpmlint/filter.py
@@ -43,6 +43,8 @@ class Filter(object):
         self.error_details.update(self._load_descriptions())
         # Counter of how many issues we encountered
         self.printed_messages = {'I': 0, 'W': 0, 'E': 0}
+        # Number of promoted warnings and infos to errors
+        self.promoted_to_error = 0
         # Messages
         self.results = []
 
@@ -99,6 +101,8 @@ class Filter(object):
         # allow strict reporting where we override levels and treat everything
         # as an error
         if self.strict:
+            if level != 'E':
+                self.promoted_to_error += 1
             level = 'E'
 
         if badness is None:

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -87,7 +87,8 @@ class Lint(object):
             retcode = 66
         elif self.output.printed_messages['E'] > 0 and not self.config.permissive:
             quit_color = Color.Red
-            retcode = 64
+            all_promoted = self.output.printed_messages['E'] == self.output.promoted_to_error
+            retcode = 65 if all_promoted else 64
 
         self._maybe_print_reports()
 


### PR DESCRIPTION
When all errors are promoted, exit with 65, otherwise exit
with 64.

Fixes: #843.