### PR TITLE
Improve executable-stack error.

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -294,9 +294,9 @@ class BinariesCheck(AbstractCheck):
         if not self.is_archive and not any(pkgfile.name.startswith(p) for p in KERNEL_MODULES_PATHS):
             stack_headers = [h for h in self.readelf_parser.program_header_info.headers if h.name == 'GNU_STACK']
             if not stack_headers:
-                self.output.add_info('E', pkg, 'missing-PT_GNU_STACK-section', pkg.name)
+                self.output.add_info('E', pkg, 'missing-PT_GNU_STACK-section', pkgfile.name)
             elif 'E' in stack_headers[0].flags:
-                self.output.add_info('E', pkg, 'executable-stack', pkg.name)
+                self.output.add_info('E', pkg, 'executable-stack', pkgfile.name)
 
     def _check_soname_symlink(self, pkg, shlib, soname):
         """

--- a/test/test_readelf_parser.py
+++ b/test/test_readelf_parser.py
@@ -169,9 +169,9 @@ def test_archive_with_debuginfo(binariescheck):
 def test_executable_stack(binariescheck):
     output, test = binariescheck
     with FakePkg('fake') as pkg:
-        pkgfile = pkg.add_file(get_full_path('executable-stack'), 'a.out')
+        pkgfile = pkg.add_file(get_full_path('executable-stack'), '/lib64/my/a.out')
         run_elf_checks(test, pkg, pkgfile)
-        assert 'E: executable-stack' in output.results[0]
+        assert 'E: executable-stack /lib64/my/a.out' in output.results[0]
 
 
 def test_readelf_failure():


### PR DESCRIPTION
Point to binary that violates the policy.