### PR TITLE
Fix up binary-or-shlib-defines-rpath error.

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -146,7 +146,6 @@ Filters = [
     'ldconfig-post.*/ddiwrapper/wine/',
     'glibc\.\S+: \w: statically-linked-binary /usr/sbin/glibc_post_upgrade',
     ' symlink-should-be-relative ',
-    ' binary-or-shlib-defines-rpath .*ORIGIN',
     'libzypp.*shlib-policy-name-error.*libzypp',
     'libtool.*shlib-policy.*',
 
@@ -177,7 +176,6 @@ Filters = [
     ' preun-without-chkconfig ',
     ' no-dependency-on locales',
     ' shlib-policy-name-error',
-    ' binary-or-shlib-defines-rpath',
     ' executable-marked-as-config-file',
     ' log-files-without-logrotate',
     ' hardcoded-prefix-tag',

--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -34,3 +34,4 @@ wrong-script-interpreter = 490
 obsolete-insserv-requirement = 10000
 deprecated-init-script = 10000
 deprecated-boot-script = 10000
+binary-or-shlib-defines-rpath = 10000

--- a/rpmlint/descriptions/BinariesCheck.toml
+++ b/rpmlint/descriptions/BinariesCheck.toml
@@ -46,7 +46,7 @@ the libtool wrapper file run
 to install the relinked file.
 """
 binary-or-shlib-defines-rpath="""
-The binary or shared library defines `RPATH'.
+The binary or shared library defines `RPATH' (or `RUNPATH').
 """
 statically-linked-binary="""
 The package installs a statically linked binary or object file.

--- a/rpmlint/readelfparser.py
+++ b/rpmlint/readelfparser.py
@@ -217,7 +217,8 @@ class ElfDynamicSectionInfo:
     section_regex = re.compile('\\s+\\w*\\s+\\((?P<key>[^\\)]+)\\)\\s+(?P<value>.*)')
     soname_regex = re.compile('Library soname: \\[(?P<soname>[^\\]]+)\\]')
     needed_regex = re.compile('Shared library: \\[(?P<library>[^\\]]+)\\]')
-    rpath_regex = re.compile('Library runpath: \\[(?P<path>[^\\]]+)\\]')
+    runpath_regex = re.compile('Library runpath: \\[(?P<path>[^\\]]+)\\]')
+    rpath_regex = re.compile('Library rpath: \\[(?P<path>[^\\]]+)\\]')
 
     def __init__(self, path, extra_flags):
         self.path = path
@@ -258,11 +259,17 @@ class ElfDynamicSectionInfo:
             if r:
                 self.needed.append(r.group('library'))
 
-        self.runpath = []
+        self.runpaths = []
+
+        # Parse both RUNPATH and RPATH
         for line in self['RUNPATH']:
+            r = self.runpath_regex.search(line)
+            if r:
+                self.runpaths.append(r.group('path'))
+        for line in self['RPATH']:
             r = self.rpath_regex.search(line)
             if r:
-                self.runpath.append(r.group('path'))
+                self.runpaths.append(r.group('path'))
 
     def __getitem__(self, key):
         return [x.value for x in self.sections if x.key == key]

--- a/test/test_readelf_parser.py
+++ b/test/test_readelf_parser.py
@@ -92,8 +92,8 @@ def test_rpath():
     readelf = readelfparser('rpath-lib.so', '/lib64/rpath-lib.so')
     assert readelf.is_shlib
     assert not readelf.is_archive
-    assert len(readelf.dynamic_section_info.runpath) == 1
-    assert '/tmp/termcap.so.4' in readelf.dynamic_section_info.runpath
+    assert len(readelf.dynamic_section_info.runpaths) == 1
+    assert '/tmp/termcap.so.4' in readelf.dynamic_section_info.runpaths
 
 
 def test_lto_bytecode(binariescheck):


### PR DESCRIPTION
The error should be emitted if it does not point to
a system library folder or /usr/lib*.

Enable the check in openSUSE config.

Fixes: #847.