### PR TITLE
Update shlib-policy-name-error score for openSUSE

### DIFF
--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -25,6 +25,7 @@ percent-in-conflicts = 10000
 percent-in-dependency = 10000
 percent-in-obsoletes = 10000
 percent-in-provides = 10000
+shlib-policy-name-error = 10000
 spurious-executable-perm = 50
 summary-ended-with-dot = 20
 summary-not-capitalized = 20


### PR DESCRIPTION
In openSUSE Leap 15.3, rpmlint 1.x reported shlib-policy-name-error
instances with a 10000 point penalty. Restore this for rpmlint 2.x.