### PR TITLE
support $ORIGIN in R{,UN}PATH.

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -146,6 +146,7 @@ Filters = [
     'ldconfig-post.*/ddiwrapper/wine/',
     'glibc\.\S+: \w: statically-linked-binary /usr/sbin/glibc_post_upgrade',
     ' symlink-should-be-relative ',
+    ' binary-or-shlib-defines-rpath .*ORIGIN',
     'libzypp.*shlib-policy-name-error.*libzypp',
     'libtool.*shlib-policy.*',
 


### PR DESCRIPTION
The following is valid use-case:
$ readelf -Wd /usr/lib64/qt5/examples/multimedia/spectrum/spectrum | grep RUN
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]