### PR TITLE
dbus-services: remove dead gypsy whitelisting

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -301,15 +301,6 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "gypsy"
-type = "dbus"
-note = "legacy: not audited"
-nodigests = [
-    "/etc/dbus-1/system.d/Gypsy.conf",
-    "/usr/share/dbus-1/system-services/org.freedesktop.Gypsy.service",
-]
-
-[[FileDigestGroup]]
 package = "pommed"
 type = "dbus"
 note = "legacy: not audited"


### PR DESCRIPTION
The gypsy packaged has been removed from Factory via OBS sr#965831.