### PR TITLE
Add missing dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(
         'toml',
         'zstandard',
         'importlib-metadata;python_version<"3.8"',
+        'pyenchant',
+        'python-magic'
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
To simplify management on my fork, I updated the project to use poetry instead of setuptools and I found there are missing dependencies in setup.py that I had to add to run the tests:
* pyenchant
* python-magic