### PR TITLE
SystemdTmpfilesCheck: new check to restrict systemd-tmpfiles configur…

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -21,6 +21,7 @@ Checks = [
     "KMPPolicyCheck",
     "PolkitCheck",
     "SystemdInstallCheck",
+    "SystemdTmpfilesCheck",
     "SUIDPermissionsCheck",
     "WorldWritableCheck",
 ]
@@ -264,6 +265,10 @@ BlockedFilters = [
     "polkit-untracked-privilege",
     "polkit-user-privilege",
     "polkit-xml-exception",
+    "systemd-tmpfile-ghost",
+    "systemd-tmpfile-symlink",
+    "systemd-tmpfile-parse-error",
+    "systemd-tmpfile-entry-unauthorized",
     "world-writable-mismatched-attrs",
     "world-writable-unauthorized-file",
 ]
@@ -288,6 +293,8 @@ paths = [
 [DeviceFilesWhitelist]
 
 [WorldWritableWhitelist]
+
+[SystemdTmpfilesWhitelist]
 
 [Descriptions]
 non-standard-uid = '''A file in this package is owned by an unregistered user id.

--- a/configs/openSUSE/scoring-strict.override.toml
+++ b/configs/openSUSE/scoring-strict.override.toml
@@ -36,5 +36,11 @@ sudoers-file-digest-mismatch = 10000
 sudoers-file-ghost = 10000
 sudoers-file-unauthorized = 10000
 sudoers-file-symlink = 10000
+# keep the strict settings disabled until necessary whitelisting entries are
+# established (bsc#1150905)
+#systemd-tmpfile-entry-unauthorized = 10000
+#systemd-tmpfile-ghost = 10000
+#systemd-tmpfile-parse-error = 10000
+#systemd-tmpfile-symlink = 10000
 world-writable-mismatched-attrs = 10000
 world-writable-unauthorized-file = 10000

--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -84,3 +84,7 @@ sudoers-file-digest-mismatch = 10
 sudoers-file-ghost = 10
 sudoers-file-unauthorized = 10
 sudoers-file-symlink = 10
+systemd-tmpfile-entry-unauthorized = 10
+systemd-tmpfile-ghost = 10
+systemd-tmpfile-parse-error = 10
+systemd-tmpfile-symlink = 10

--- a/configs/openSUSE/security.toml
+++ b/configs/openSUSE/security.toml
@@ -54,3 +54,17 @@ FollowSymlinks = false
 Locations = [
     "/etc/sudoers.d"
 ]
+
+[SystemdTmpfiles]
+DropinDirs = [
+    # nothing should ever be installed here, but lets stay on the safe side
+    "/etc/tmpfiles.d",
+    "/usr/lib/tmpfiles.d"
+]
+# base system packages that would create too much noise to include them in the
+# whitelistings
+IgnorePackages = [
+    "filesystem",
+    "udev",
+    "systemd"
+]

--- a/configs/openSUSE/systemd-tmpfiles.toml
+++ b/configs/openSUSE/systemd-tmpfiles.toml
@@ -1,0 +1,8 @@
+[[SystemdTmpfilesWhitelist]]
+package = "rpmlint-integration-test"
+bug = "bsc#1150905"
+note = "valid test whitelisting entry for the OBS integration test package"
+path = "/usr/lib/tmpfiles.d/rpmlint-test.conf"
+entries = [
+	"d /tmp/.rpmlint-stuff 0777 root root -"
+]

--- a/rpmlint/checks/SystemdTmpfilesCheck.py
+++ b/rpmlint/checks/SystemdTmpfilesCheck.py
@@ -1,0 +1,269 @@
+from pathlib import Path
+import stat
+
+from rpmlint.checks import TmpfilesParser
+from rpmlint.checks.AbstractCheck import AbstractCheck
+
+# don't add tmp directories here, they could still be dangerous, since
+# publicly accessible
+WELL_KNOWN_PATHS = (
+    '/var/lib', '/var/run', '/run', '/var/lock', '/var/cache',
+    '/run/lock', '/var/log', '/var/spool', '/srv', '/etc',
+    # some configs somehow reset /sys permissions here
+    '/sys',
+    # moderately well known, NIS stuff
+    '/var/yp'
+)
+
+# chattr() flags that are not interesting security wise
+BORING_ATTRS = (
+    # disable copy-on-write on supported file-systems
+    'C',
+)
+
+
+class SystemdTmpfilesCheck(AbstractCheck):
+    """This check restricts content of systemd-tmpfiles configuration files.
+
+    tmpfiles configuration can grant a wide range of properties from arbitrary
+    file modes, ACLs to creating device files and more. Some of them can be
+    security relevant, therefore we want to control what can and what cannot
+    enter the distribution.
+    """
+
+    def __init__(self, config, output):
+        super().__init__(config, output)
+        # Build trie for fast lookup of restricted paths
+        self.dropin_dir_trie = {}
+
+        check_config = self.config.configuration['SystemdTmpfiles']
+        # these are the tmpfiles.d drop-in dir locations we are restricting
+        self.dropin_dirs = check_config['DropinDirs']
+        # this is a list of base packages that we won't care about for
+        # simplicity (like systemd packages themselves)
+        self.ignore_packages = check_config['IgnorePackages']
+
+        self._setup_location_trie()
+
+        self.whitelist = self.config.configuration.get('SystemdTmpfilesWhitelist', [])
+        for entry in self.whitelist:
+            self._sanity_check_whitelist_entry(entry)
+            self._normalize_whitelist_entry(entry)
+
+    def _setup_location_trie(self):
+        # Build trie of tmpfiles.d drop-in dir locations
+        for location in self.dropin_dirs:
+            path = Path(location)
+            if not path.is_absolute():
+                raise Exception(f'Absolute path expected: {path}')
+            node = self.dropin_dir_trie
+            # Skip initial '/'.
+            parts = path.parts[1:]
+            for part in parts[:-1]:
+                node = node.setdefault(part, {})
+                if node is None:
+                    raise Exception(f'Conflicting paths in trie {location}')
+            node[parts[-1]] = None
+
+    def _is_path_restricted(self, pkgfile):
+        """Returns True if the given path is within a tmpfiles.d drop in
+        directory.
+        """
+        if stat.S_ISDIR(pkgfile.mode):
+            # we only care for configuration files
+            return False
+        elif not pkgfile.name.endswith('.conf'):
+            # systemd-tmpfiles only considers files ending in *.conf
+            return False
+
+        path = Path(pkgfile.name)
+
+        # now check the trie if the path is in a restricted location
+
+        # Skip initial '/'
+        parts = path.parts[1:]
+        node = self.dropin_dir_trie
+        for part in parts:
+            if node is None:
+                return True
+            if part not in node:
+                return False
+            node = node[part]
+        return False
+
+    def _normalize_whitelist_entry(self, entry):
+        """Perform any operations on the whitelisting entry to make it match
+        the format excepted by the rest of the checker.
+        """
+        packages = entry.setdefault('packages', [])
+        if 'package' in entry:
+            # _sanity_check_whitelist_entry() makes sure only one of both keys
+            # is present in an entry
+            packages.append(entry['package'])
+
+    def _sanity_check_whitelist_entry(self, entry):
+        package = entry.get('package', None)
+        packages = entry.get('packages', [])
+
+        if not package and not packages:
+            raise KeyError('SystemdTmpfilesCheck: missing "package" or "packages" key in whitelisting entry')
+        elif package and packages:
+            raise KeyError('SystemdTmpfilesCheck: encountered both "package" and "packages" keys in FileDigestGroup entry')
+
+        if package and not isinstance(package, str):
+            raise KeyError('SystemdTmpfilesCheck: "package" key contains non-string value')
+        elif packages and not isinstance(packages, list):
+            raise KeyError('SystemdTmpfilesCheck: "packages" key contains non-list value')
+
+        if 'path' not in entry:
+            raise KeyError('SystemdTmpfilesCheck: missing "path" key')
+
+    def _is_in_safe_location(self, tf_entry):
+        """Returns whether the given tmpfiles configuration entry affects a
+        safe location that is usually okay to operate in."""
+        # this loop only runs for files actually packaged in a tmpfiles.d
+        # directory, so it shouldn't hurt performance much doing this linear
+        # prefix check
+        for known in WELL_KNOWN_PATHS:
+            if tf_entry.get_target_path().startswith(known):
+                return True
+
+        return False
+
+    def _is_sensitive_entry(self, tf_entry):
+        """Returns whether the given tmpfiles configuration entry contains
+        security sensitive settings."""
+        base_type = tf_entry.get_type()[0]
+
+        if base_type == 'L':
+            # ignore symlinks for now. they are not often dangerous, mostly
+            # only if well known config files are replaced by symlinks like
+            # /etc/resolv.conf. Then it depends on the target file and
+            # context. We could restrict these types in the future somewhen,
+            # for now lets concentrate on more dangerous entries
+            return False
+        elif base_type in ('v', 'q', 'Q'):
+            # deals with btrfs volumes, skip that for now
+            return False
+        elif base_type in ('r', 'R'):
+            # removal of files, possibly recursively (upper case), often
+            # restricted to boot time (! suffix)
+            #
+            # this could break stuff in the sense of a DoS if a bad pattern is
+            # specified but for simplification skip that for now
+            return False
+        elif base_type in ('X', 'x'):
+            # this only controls cleanup behaviour, not so interesting for us
+            return False
+        elif base_type.lower() in ('d', 'f', 'c', 'z', 'p'):
+            # files or directories are created, copied into place or
+            # permissions readjusted if already existing. 'f' may also write
+            # string content from the config file into the file.
+            if not self._is_in_safe_location(tf_entry):
+                # if it's not in a well known place then it could be interesting
+                return True
+            if tf_entry.has_default_mode():
+                # if the default mode applies then this is boring
+                return False
+
+            mode = tf_entry.get_octal_mode()
+            # TODO: should we also check for sticky bits here? they are more
+            # limiting than exposing, but in some special circumstances they
+            # might ease exploits.
+            danger_bits = (stat.S_IWOTH, stat.S_ISUID, stat.S_ISGID)
+            if any([(mode & bit) != 0 for bit in danger_bits]):
+                # a dangerous bit is set, so it's sensitive
+                return True
+
+            # otherwise it is pretty boring
+            return False
+        elif base_type in ('b', 'c'):
+            # character/block devices
+            if not tf_entry.get_target_path.startswith('/dev'):
+                # if the device is not in /dev then it's unusual
+                return True
+            if tf_entry.has_non_root_owner() or tf_entry.has_non_root_group():
+                # if its accessible by non-root in some way then it's sensitive
+                return True
+
+            mode = self.getOctalMode()
+            danger_bits = (stat.S_IROTH, stat.S_IWOTH)
+            if any([(mode & bit) != 0 for bit in danger_bits]):
+                # world readable or writeable, sensitive
+                return True
+
+            # root only access, should be fine
+            return False
+        elif base_type in ('h', 'H'):
+            # sets chattr() attributes, possibly recursively (upper case)
+            attr = self.m_arg
+
+            for prefix in ('+', '-', '='):
+                # remove any possible prefix
+                attr = attr.lstrip(prefix)
+
+            for flag in attr:
+                if flag not in BORING_ATTRS:
+                    return True
+
+            return False
+
+        # other / yet unknown type, treat as sensitive
+        return True
+
+    def _check_for_whitelisting(self, pkg, pkgfile, tf_entry):
+        """Checks whether the given tempfile entry has a valid whitelisting
+        configured and returns the boolean result."""
+        for wl_entry in self.whitelist:
+            if pkg.name not in wl_entry['packages']:
+                continue
+            if tf_entry.get_config_file() != wl_entry['path']:
+                continue
+
+            if tf_entry.get_line() in wl_entry['entries']:
+                return True
+
+        return False
+
+    def check_binary(self, pkg):
+        """Check that all files in secured locations containing relevant
+        entries are covered by a matching whitelisting entry.
+        """
+        if pkg.name in self.ignore_packages:
+            return
+
+        # Find all files in this package that fall in a tmpfiles.d drop-in directory
+        for pkgfile in pkg.files.values():
+            if not self._is_path_restricted(pkgfile):
+                continue
+
+            # now we know it's a systemd-tmpfiles configuration file
+
+            if pkgfile.name in pkg.ghost_files:
+                self.output.add_info('E', pkg, 'systemd-tmpfile-ghost', pkgfile.name)
+                continue
+            elif stat.S_ISLNK(pkgfile.mode):
+                self.output.add_info('E', pkg, 'systemd-tmpfile-symlink', pkgfile.name)
+                continue
+
+            # parse the actual configuration file content
+            entries = TmpfilesParser.parse(pkgfile)
+
+            for entry in filter(lambda e: not e.is_valid(), entries):
+                for warning in entry.get_warnings():
+                    # collect any possible parse errors from the parser
+                    self.output.add_info('E', pkg, 'systemd-tmpfile-parse-error', pkgfile.name, entry.get_line(), warning)
+
+            # only consider security sensitive entries for whitelistings
+            #
+            # if no valid entry could be parsed then there's no point in
+            # demanding a whitelisting, the parse-error above should be
+            # emitted though.
+            for entry in filter(lambda e: e.is_valid() and self._is_sensitive_entry(e), entries):
+                # at this point we require a whitelisting for the sensitive
+                # configuration entries we detected
+                if self._check_for_whitelisting(pkg, pkgfile, entry):
+                    continue
+
+                # no whitelisting found, so emit a corresponding error
+                self.output.add_info('E', pkg, 'systemd-tmpfile-entry-unauthorized', pkgfile.name, f'"{entry.get_line()}"')

--- a/rpmlint/checks/TmpfilesParser.py
+++ b/rpmlint/checks/TmpfilesParser.py
@@ -1,0 +1,172 @@
+import shlex
+
+
+# NOTE: for 'C' the table in the man page does not list permissions
+# support but actually they *are* supported.
+TYPES_WITH_PERMS = (
+    'f', 'd', 'D', 'e',
+    'v', 'q', 'Q', 'p', 'p+',
+    'c', 'C', 'b', 'z', 'Z'
+)
+
+
+class TmpfilesEntry:
+    """This type represents a single systemd-tmpfiles configuration file
+    entry."""
+
+    def __init__(self, source, line, comments):
+        """Parses the given tmpfiles configuration line and stores the
+        resulting information in the object.
+
+        `source` is the configuration file name, `line` the line number of the
+        entry to be parsed and `comments` is a list of context lines that
+        likely belong to this entry."""
+        self.source = source
+        self.line = line
+        self.comments = comments
+        self.valid = False
+        self.warnings = []
+        self._parse()
+
+    def _add_warning(self, msg):
+        self.warnings.append(f'{self.source}:{self.line}: {msg}')
+
+    def get_warnings(self):
+        """Returns a list of parse errors/warnings that have been encountered
+        during parsing the tmpfiles entry."""
+        return self.warnings
+
+    def _parse(self):
+        # each field may be quoted, so use shell like parsing to cope with that
+        fields = shlex.split(self.line)
+        if len(fields) > 7:
+            self._add_warning('Too many fields encountered')
+            return
+        elif len(fields) < 2:
+            self._add_warning('Too few fields encountered')
+            return
+
+        self.type = fields[0]
+        self.target = fields[1]
+
+        findex = 2
+
+        def next_field():
+            nonlocal findex
+            if findex >= len(fields):
+                return None
+
+            ret = fields[findex]
+            findex += 1
+            return ret if ret != '-' else None
+
+        self.mode = next_field()
+        self.owner = next_field()
+        self.group = next_field()
+        self.age = next_field()
+        self.arg = next_field()
+
+        if (self.mode or self.owner or self.group) and not self._supports_perms():
+            self._add_warning("Permissions specified for entry type that doesn't support perms")
+
+        self._normalize()
+        self.valid = True
+
+    def is_valid(self):
+        """Returns whether a valid entry could be parsed."""
+        return self.valid
+
+    def _normalize(self):
+        """Normalizes any data of the current entry for simplification."""
+        # F is a deprecated form of 'f+'
+        if self.type[0] == 'F':
+            self.type = 'f+' + self.type[1:]
+
+    def _supports_perms(self):
+        """Returns whether the current tmpfiles entry supports a file
+        permissions field."""
+        return self.type[0] in TYPES_WITH_PERMS
+
+    def _get_def_mode_label(self):
+        return '-' if self._supports_perms() else 'N/A'
+
+    def get_type(self):
+        return self.type
+
+    def get_config_file(self):
+        return self.source
+
+    def get_target_path(self):
+        return self.target
+
+    def has_default_mode(self):
+        return self.mode is None
+
+    def get_mode(self):
+        if not self.mode:
+            return self._get_def_mode_label()
+        return self.mode
+
+    def get_octal_mode(self):
+        if not self.mode:
+            raise Exception('No mode to convert into octal')
+        mode = self.mode
+        # this means that the mode is masked with the permissions of the
+        # (maybe) already existing file, should not be too relevant for us so
+        # ignore
+        if mode.startswith('~'):
+            mode = mode[1:]
+        return int(mode, 8)
+
+    def get_owner(self):
+        if not self.owner:
+            return self._get_def_mode_label()
+        return self.owner
+
+    def has_non_root_owner(self):
+        if self.owner and self.owner != 'root':
+            return True
+        return False
+
+    def get_group(self):
+        if not self.group:
+            return self._get_def_mode_label()
+        return self._group
+
+    def has_non_root_group(self):
+        if self.group and self.group != 'root':
+            return True
+        return False
+
+    def get_arg(self):
+        """Returns the custom argument field, the meaning depends on the entry
+        type."""
+        return self._arg if self._args else '-'
+
+    def get_comments(self):
+        return self.comments
+
+    def get_line(self):
+        """Returns the full line (stripped of whitespace) that makes up the
+        entry."""
+        return self.line
+
+
+def parse(pkgfile):
+    """Parses the given systemd-tmpfiles.d configuration file and returns a
+    list of TmpfilesEntry objects corresponding to the file's content."""
+    entries = []
+    context = []
+
+    for line in open(pkgfile.path):
+        line = line.strip()
+        if not line:
+            context = []
+        elif line.startswith('#'):
+            context.append(line)
+        else:
+            entry = TmpfilesEntry(pkgfile.name, line, context)
+            entries.append(entry)
+            context = []
+
+    return entries

--- a/rpmlint/descriptions/SystemdTmpfilesCheck.toml
+++ b/rpmlint/descriptions/SystemdTmpfilesCheck.toml
@@ -1,0 +1,19 @@
+TMPFILES_SUFFIX="Please refer to #AUDIT_BUG_URL# for more information"
+
+systemd-tmpfile-ghost="""
+This package installs a systemd-tmpfiles drop-in configuration file as %ghost
+file. This is not allowed, since it is impossible to review. #TMPFILES_SUFFIX#
+"""
+systemd-tmpfile-symlink="""
+This package installs a symlink as a systemd-tmpfiles drop-in configuration
+file. This is not allowed currently. #TMPFILES_SUFFIX#
+"""
+systemd-tmpfile-parse-error="""
+A warning occured trying to parse a systemd-tmpfiles drop-in configuration
+file line. Either the configuration file is inconsistent or this rpmlint check
+has issues. #TMPFILES_SUFFIX#
+"""
+systemd-tmpfile-entry-unauthorized="""
+This package installs a systemd-tmpfiles drop-in configuration file that
+contains sensitive configuration entries. #REVIEW_NEEDED_TEXT#
+"""

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -810,6 +810,12 @@ class FakePkg(AbstractPkg):
         pkg_file.linkto = target
         self.files[name] = pkg_file
 
+    def add_ghost(self, name):
+        pkg_file = PkgFile(name)
+        pkg_file.flags |= rpm.RPMFILE_GHOST
+        self.files[name] = pkg_file
+        self.ghost_files[name] = pkg_file
+
     def readlink(self, pkgfile):
         # HACK: reuse the real Pkg's logic
         return Pkg.readlink(self, pkgfile)

--- a/test/configs/test.config
+++ b/test/configs/test.config
@@ -130,3 +130,31 @@ files = [
     group = "tty"
   }
 ]
+
+[SystemdTmpfiles]
+DropinDirs = [
+    "/tmpfiles1",
+    "/tmpfiles2"
+]
+IgnorePackages = [
+    "boring1",
+    "boring2"
+]
+
+[[SystemdTmpfilesWhitelist]]
+package = "goodpkg"
+bug = "bsc#4711"
+note = "test whitelisting"
+path = "/tmpfiles1/some.conf"
+entries = [
+	"d /tmp/.rpmlint-stuff 0777 root root -"
+]
+
+[[SystemdTmpfilesWhitelist]]
+packages = ["goodpkg"]
+bug = "bsc#4712"
+note = "test whitelisting 2"
+path = "/tmpfiles2/other.conf"
+entries = [
+	"d /tmp/.more-stuff 0777 root root -"
+]

--- a/test/test_systemd_tmpfiles.py
+++ b/test/test_systemd_tmpfiles.py
@@ -1,0 +1,75 @@
+import os
+
+import pytest
+from rpmlint.checks.SystemdTmpfilesCheck import SystemdTmpfilesCheck
+from rpmlint.config import Config
+from rpmlint.filter import Filter
+from rpmlint.pkg import FakePkg
+
+import Testing
+
+
+def get_tmpfilescheck(config_path):
+    if not os.path.isabs(config_path):
+        config_path = Testing.testpath() / 'configs' / config_path
+    config = Config([config_path])
+    config.info = True
+    output = Filter(config)
+    test = SystemdTmpfilesCheck(config, output)
+    return output, test, config
+
+
+@pytest.fixture(scope='function', autouse=True)
+def tmpfilescheck():
+    return get_tmpfilescheck(Testing.TEST_CONFIG[0])
+
+
+def test_dropin_dir_restriction(tmpfilescheck):
+    # basic test that restricted systemd-tmpfiles items are complained about
+    output, test, config = tmpfilescheck
+    with FakePkg('testpkg') as pkg:
+        for dropindir in config.configuration['SystemdTmpfiles'].get('DropinDirs'):
+            pkg.add_file_with_content(f'{dropindir}/some.conf', 'd /run/somedir 1777 root root')
+            # make sure parse errors are handled correctly
+            pkg.add_file_with_content(f'{dropindir}/broken.conf', 'broken')
+            # also test rejection of symlinks
+            pkg.add_symlink_to(f'{dropindir}/link.conf', '/some/where/some.conf')
+            # ... and ghost files
+            pkg.add_ghost(f'{dropindir}/ghost.conf')
+            # make sure non-sensitive entries *don't* trigger a report
+            pkg.add_file_with_content(f'{dropindir}/harmless.conf', 'd /run/harmless 750 root root')
+            # make sure files not ending in *.conf are ignored
+            pkg.add_file_with_content(f'{dropindir}/harmless', 'd /run/somedir 1777 root root')
+
+        # now the same in a non-restricted directory
+        pkg.add_file_with_content('/harmless/some.conf', 'd /run/somedir 1777 root root')
+        pkg.add_symlink_to('/harmless/link.conf', '/some/where/some.conf')
+        pkg.add_ghost('/harmless/ghost.conf')
+
+        test.check(pkg)
+
+        # make sure the non-restricted items have not been complained about
+        assert 'harmless' not in ''.join(output.results)
+
+        for expected in (
+                'testpkg: E: systemd-tmpfile-entry-unauthorized /tmpfiles1/some.conf "d /run/somedir 1777 root root"',
+                'testpkg: E: systemd-tmpfile-ghost /tmpfiles2/ghost.conf',
+                'testpkg: E: systemd-tmpfile-symlink /tmpfiles2/link.conf',
+                'testpkg: E: systemd-tmpfile-parse-error /tmpfiles2/broken.conf broken /tmpfiles2/broken.conf:broken: Too few fields encountered'):
+            assert expected in output.results
+
+
+def test_whitelistings(tmpfilescheck):
+    # this tests whether a valid whitelisting is correctly accepted for
+    # sensitive entries.
+    # furthermore pkg name restrictions are checked
+    output, test, config = tmpfilescheck
+    for pkgname in ('goodpkg', 'badpkg'):
+        with FakePkg(pkgname) as pkg:
+            pkg.add_file_with_content('/tmpfiles1/some.conf', 'd /tmp/.rpmlint-stuff 0777 root root -')
+            pkg.add_file_with_content('/tmpfiles2/other.conf', 'd /tmp/.more-stuff 0777 root root -')
+            test.check(pkg)
+            if pkgname == 'goodpkg':
+                assert 'systemd-tmpfile-entry-unauthorized' not in ''.join(output.results)
+            else:
+                assert 'systemd-tmpfile-entry-unauthorized' in ''.join(output.results)


### PR DESCRIPTION
…ation

This introduces a new check that restricts what kind of systemd-tmpfiles
configuration file entries can be shipped by a package. This supplements
the existing security related checkers like FileDigestCheck. Since this
check requires parsing of the custom systemd-tmpfiles format the generic
existing checkers cannot be reused for this.

This change does not yet raise badness in the strict configuration,
because the check first needs some realife testing and the affected
packages first need to be reviewed and whitelisted before actually
generating badness.