### PR TITLE
openSUSE: Do not allow files in /etc/NetworkManager/dispatcher.d anymore

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -15,6 +15,10 @@ Checks = [
     "SharedLibraryPolicyCheck",
 ]
 
+# List of directory prefixes that are not allowed in packages
+DisallowedDirs = [
+    "/etc/NetworkManager/dispatcher.d",
+]
 
 Filters = [
 # Stuff autobuild takes care about


### PR DESCRIPTION
Following packages has generated files in /etc/NetworkManager/dispatcher.d: 
chronny, tlp, autofs. 
This has already been fixed to. They are writing to /usr/lib/NetworkManager/dispatcher.d now.
So, users changes can still be done in /etc and will not be overwritten by an update.
NetworkManager is supporting /usr/lib/NetworkManager/dispatcher.d since SLES12.
So there is not reason for writing to /etc/NetworkManager/dispatcher.d  anymore