### PR TITLE
Increase badness for executable-stack

### DIFF
--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -34,5 +34,6 @@ wrong-script-interpreter = 490
 obsolete-insserv-requirement = 10000
 deprecated-init-script = 10000
 deprecated-boot-script = 10000
+executable-stack = 10000
 # Temporarily disable once boo#1199268 gets fixed
 # binary-or-shlib-defines-rpath = 10000


### PR DESCRIPTION
A binary with executable stack can be a subject for security
vulnerabilities.