### PR TITLE
dbus-services: move dnsmasq.conf to /usr (bsc#1200344)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -306,8 +306,9 @@ digests = [
 package = "dnsmasq"
 type = "dbus"
 note = "legacy: not audited"
+bugs = ['bsc#1200344']
 nodigests = [
-    "/etc/dbus-1/system.d/dnsmasq.conf",
+    "/usr/share/dbus-1/system.d/dnsmasq.conf",
 ]
 
 [[FileDigestGroup]]


### PR DESCRIPTION
Move `/etc/dbus-1/system.d/dnsmasq.conf` to `/usr/share/dbus-1/system.d/dnsmasq.conf`.