### PR TITLE
systemd-tmpfiles whitelisting: also ignore -mini variants of systemd …

### DIFF
--- a/configs/openSUSE/security.toml
+++ b/configs/openSUSE/security.toml
@@ -66,5 +66,7 @@ DropinDirs = [
 IgnorePackages = [
     "filesystem",
     "udev",
-    "systemd"
+    "udev-mini",
+    "systemd",
+    "systemd-mini"
 ]


### PR DESCRIPTION
…and udev

See errors in current rpmlint staging https://build.opensuse.org/request/show/981457