### PR TITLE
Add `--file` as an alias for `--rpmlintrc`

### DIFF
--- a/rpmlint/cli.py
+++ b/rpmlint/cli.py
@@ -76,7 +76,7 @@ def process_lint_args(argv):
     parser.add_argument('-V', '--version', action='version', version=__version__, help='show package version and exit')
     parser.add_argument('-c', '--config', type=_validate_conf_location, help='load up additional configuration data from specified path (file or directory with *.toml files)')
     parser.add_argument('-e', '--explain', nargs='+', default='', help='provide detailed explanation for one specific message id')
-    parser.add_argument('-r', '--rpmlintrc', type=_is_file_path, help='load up specified rpmlintrc file')
+    parser.add_argument('-r', '--rpmlintrc', '--file', type=_is_file_path, help='load up specified rpmlintrc file')
     parser.add_argument('-v', '--verbose', '--info', action='store_true', help='provide detailed explanations where available')
     parser.add_argument('-p', '--print-config', action='store_true', help='print the settings that are in effect when using the rpmlint')
     parser.add_argument('-i', '--installed', nargs='+', default='', help='installed packages to be validated by rpmlint')


### PR DESCRIPTION
This eases the compatibility story between 1.x and 2.x versions.

See issue #887.