### PR TITLE
Improve binary-or-shlib-defines-rpath error

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -431,7 +431,7 @@ class BinariesCheck(AbstractCheck):
                     runpath = runpath.replace(self.rpath_origin, str(Path(pkgfile.name).parent))
                     runpath = str(Path(runpath).resolve())
                 if not runpath.startswith(self.system_lib_paths) and not self.usr_lib_regex.search(runpath):
-                    self.output.add_info('E', pkg, 'binary-or-shlib-defines-rpath', pkgfile.name, runpath)
+                    self.output.add_info('E', pkg, 'binary-or-shlib-defines-rpath', pkgfile.name, f'(RUNPATH: {runpath})')
                     return
 
     def _check_library_dependency(self, pkg, pkgfile):

--- a/rpmlint/descriptions/BinariesCheck.toml
+++ b/rpmlint/descriptions/BinariesCheck.toml
@@ -46,7 +46,8 @@ the libtool wrapper file run
 to install the relinked file.
 """
 binary-or-shlib-defines-rpath="""
-The binary or shared library defines `RPATH' (or `RUNPATH').
+The binary or shared library defines `RPATH' (or `RUNPATH') that points
+to a non-system library path.
 """
 statically-linked-binary="""
 The package installs a statically linked binary or object file.


### PR DESCRIPTION
Make error description more informative and change wording when
reporting the error.