### PR TITLE
Fix rpm_buildroot_regex

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -33,7 +33,7 @@ prereq_regex = re_tag_compile(r'PreReq(\(.*\))')
 
 make_check_regex = re.compile(r'(^|\s|%{?__)make}?\s+(check|test)')
 rm_regex = re.compile(r'(^|\s)((.*/)?rm|%{?__rm}?) ')
-rpm_buildroot_regex = re.compile(r'^[^#]*(?:(\\\*)\${?RPM_BUILD_ROOT}?|(%+){?buildroot}?)')
+rpm_buildroot_regex = re.compile(r'^[^#]*?(?:(\\*)\${?RPM_BUILD_ROOT}?|(%+){?buildroot}?)')
 configure_libdir_spec_regex = re.compile(r'ln |\./configure[^#]*--libdir=(\S+)[^#]*')
 lib_package_regex = re.compile(r'^%package.*\Wlib')
 ifarch_regex = re.compile(r'^\s*%ifn?arch\s')

--- a/test/spec/rpm-buildroot-usage-shell-var.spec
+++ b/test/spec/rpm-buildroot-usage-shell-var.spec
@@ -1,0 +1,33 @@
+Name:           rpm-buildroot-usage-shell-var
+Version:        0
+Release:        0
+Summary:        rpm-buildroot-usage warning (when referenced as shell variable).
+Group:          Undefined
+License:        GPLv2
+URL:            http://rpmlint.zarb.org/#%{name}
+Source0:        Source0.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+%description
+$RPM_BUILD_ROOT should not be touched during %build or %prep stage, as it
+may break short circuit builds.
+
+%prep
+# None of these actually refer to the build root
+\$RPM_BUILD_ROOT
+\\\$RPM_BUILD_ROOT
+# $RPM_BUILD_ROOT
+
+%build
+\\$RPM_BUILD_ROOT
+echo ${RPM_BUILD_ROOT} # comment
+
+%install
+
+%clean
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/foo
+
+%changelog

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -172,6 +172,17 @@ def test_check_rpm_buildroot_usage_not_applied(package, speccheck):
     assert 'E: rpm-buildroot-usage' not in out
 
 
+@pytest.mark.parametrize('package', ['spec/rpm-buildroot-usage-shell-var'])
+def test_check_rpm_buildroot_usage_shell_var(package, speccheck):
+    """Test detection of $RPM_BUILD_ROOT shell variable in %prep/%build"""
+    output, test = speccheck
+    pkg = get_tested_spec_package(package)
+    test.check_spec(pkg)
+    out = output.print_results(output.results)
+    assert 'E: rpm-buildroot-usage %prep' not in out
+    assert out.count('E: rpm-buildroot-usage %build') == 2
+
+
 @pytest.mark.parametrize('package', ['spec/make-check-outside-check-section'])
 def test_check_make_check_outside_check_section(package, speccheck):
     """Test if specfile has `make check` outside %check."""


### PR DESCRIPTION
The regex was completely broken for the case of $RPM_BUILD_ROOT, and the
cause was twofold:

  - In the capture group matching backslashes before a `$`, the asterisk
    (`*`) is escaped when it shouldn't be.

    Before 6de3730a1bda8f2705287186b8af8853dd16e5f9, the capture group
    was incorrectly escaped as `'\\\*'`, but still got interpreted as
    `'\\\\*'` (as `\*` is not a valid Python string escape) so `\\*` was
    passed to the regex module.

    After that commit, with `r'\\\*'`, what the regex module saw was
    instead `\\\*`, meaning: a literal match for the string `\*`.

    We fix this by using the correct number of bashslashes for a raw
    string literal (2).

  - The initial part of the regex, `^[^#]*`, consumed all backslashes
    preceeding a `$`.

    We fix this by making the match non-greedy (`*` => `*?`).
