### PR TITLE
Remove obsolete check no-cleaning-of-buildroot

### DIFF
--- a/configs/Fedora/fedora.toml
+++ b/configs/Fedora/fedora.toml
@@ -275,9 +275,6 @@ Filters = [
     'dangling-\S*symlink /usr/share/doc/HTML/\S+/common .+/common$',
     'hidden-file-or-dir .*/man5/\.k5login\.5[^/]+$',
     'blender.+ (wrong-script-interpreter|non-executable-script) .+/blender/.+\.py.*BPY.*',
-    # Fedora 12 and newer no longer need a buildroot defined, to have the buildroot cleaned at the beginning
-    # of %install, and do not need to define a %clean section unless the default is invalid.
-    ' no-cleaning-of-buildroot ',
     # Only EL4 needs the files-attr-not-set check, because rpm 4.4 and newer no longer need a %defattr line
     # (it automatically provides one).
     'files-attr-not-set',

--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -158,7 +158,6 @@ Filters = [
     ' file-not-utf8',
     ' tag-not-utf8',
     ' setup-not-quiet',
-    ' no-cleaning-of-buildroot ',
     ' mixed-use-of-spaces-and-tabs ',
     ' prereq-use ',
 

--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -157,7 +157,6 @@ class SpecCheck(AbstractCheck):
         if_depth = 0
         ifarch_depth = -1
         current_section = 'package'
-        buildroot_clean = {'clean': False, 'install': False}
         depscript_override = False
         depgen_disabled = False
         patch_fuzz_override = False
@@ -217,11 +216,6 @@ class SpecCheck(AbstractCheck):
                     ('check', 'changelog', 'package', 'description'):
                 self.output.add_info('W', pkg, 'make-check-outside-check-section',
                                      line[:-1])
-
-            if current_section in buildroot_clean and \
-                    not buildroot_clean[current_section] and \
-                    contains_buildroot(line) and rm_regex.search(line):
-                buildroot_clean[current_section] = True
 
             if ifarch_regex.search(line):
                 if_depth = if_depth + 1
@@ -502,7 +496,6 @@ class SpecCheck(AbstractCheck):
         pkg.current_linenum = None
 
         # Run checks for whole package
-        self._check_no_cleaning_of_buildroot(pkg, buildroot_clean)
         self._check_no_buildroot_tag(pkg, buildroot)
         self._check_no_s_section(pkg, section)
         self._check_superfluous_clean_section(pkg, section)
@@ -535,13 +528,6 @@ class SpecCheck(AbstractCheck):
             if not Pkg.is_utf8(self._spec_file):
                 self.output.add_info('E', pkg, 'non-utf8-spec-file',
                                      self._spec_name or self._spec_file)
-
-    def _check_no_cleaning_of_buildroot(self, pkg, buildroot_clean):
-        """Check if specfile has $RPM_BUILD_ROOT in the %clean section
-        in the beginning of the %install section.
-        """
-        for sect in (x for x in buildroot_clean if not buildroot_clean[x]):
-            self.output.add_info('W', pkg, 'no-cleaning-of-buildroot', '%' + sect)
 
     def _check_no_buildroot_tag(self, pkg, buildroot):
         """Check if BuildRoot tag is used in the specfile."""

--- a/rpmlint/descriptions/SpecCheck.toml
+++ b/rpmlint/descriptions/SpecCheck.toml
@@ -110,13 +110,6 @@ setup-not-quiet="""
 Use the -q option to the %setup macro to avoid useless build output from
 unpacking the sources.
 """
-no-cleaning-of-buildroot="""
-You should clean $RPM_BUILD_ROOT in the %clean section and in the beginning
-of the %install section. Use 'rm -rf $RPM_BUILD_ROOT'. Some rpm configurations
-do this automatically; if your package is only going to be built in such
-configurations, you can ignore this warning for the section(s) where your rpm
-takes care of it.
-"""
 rpm-buildroot-usage="""
 $RPM_BUILD_ROOT or %{buildroot} must not be touched during %build or %prep
 stage, as it will break short circuit builds and will not persist to %install


### PR DESCRIPTION
As discovered in PR #890.

RPM distributions have had automatic cleaning of the buildroot in %install for a long time. Quoting [the commit](https://github.com/rpm-software-management/rpm/commit/f49671d6f3442cfff08d6167b618607e96cf0970) that finally introduced buildroot cleaning in %install directly in RPM in 2020:

> Variations of this exist in virtually every RPM-based Linux distribution
> for more than a decade. At this point, it is expected behavior everywhere
> and it is amazing that it has not yet been put in RPM itself until now...

The buildroot is also cleaned automatically by injection of a default %clean section (if not present) since RPM 4.8.0 (released 2010), and there is a rpmlint check producing an error if %clean is included in the a spec file (superfluous-%clean-section).

In addition, the check cannot have seen significant use elsewhere, as it has been broken since rpmlint 1.10[1] (released September 2017). The issue manifested as false positives (incorrectly reporting a warning for spec files that did clean the buildroot in %install/%clean). If the check had been in active use, this issue should have been discovered much
earlier.

[1]: commit 6de3730a1bda8f2705287186b8af8853dd16e5f9