### PR TITLE
checkbashism: fix stuck when run with Emacs

### DIFF
--- a/rpmlint/checks/BashismsCheck.py
+++ b/rpmlint/checks/BashismsCheck.py
@@ -13,7 +13,7 @@ class BashismsCheck(AbstractFilesCheck):
         self.file_cache = {}
 
     def _detect_early_fail_option(self):
-        output = subprocess.check_output(['checkbashisms', '--help'],
+        output = subprocess.check_output('checkbashisms --help',
                                          shell=True, encoding='utf8')
         # FIXME: remove in the future
         self.use_early_fail = '[-e]' in output


### PR DESCRIPTION
Apparently, when shell=True is used for subprocess::check_output, one
is supposed to not using sequence as first argument:

```
The shell argument (which defaults to False) specifies whether to use the shell as the program to execute.
If shell is True, it is recommended to pass args as a string rather than as a sequence.
```

Fixes: #886