### PR TITLE
systemd-tmpfiles: drop version from libtss2-fapi1 filename

### DIFF
--- a/configs/openSUSE/systemd-tmpfiles.toml
+++ b/configs/openSUSE/systemd-tmpfiles.toml
@@ -20,7 +20,7 @@ entries = [
 package = "libtss2-fapi1"
 bug = "bsc#1150905"
 note = "shared setgid tss directories for the feature API framework"
-path = "/usr/lib/tmpfiles.d/tpm2-tss-fapi-3.1.0.conf"
+path = "/usr/lib/tmpfiles.d/tpm2-tss-fapi.conf"
 entries = [
 	"d  /var/lib/tpm2-tss/system/keystore 2775 tss tss - -",
 	"d  /run/tpm2-tss/eventlog            2775 tss tss - -",


### PR DESCRIPTION
OBS sr#988349 removes the version number from the filename again,
because it causes trouble during updates. The version number was
originally introduced to fix a file conflict in a package rename
context.