### PR TITLE
Revert "Revert "Use zypper for openSUSE.""

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
         container:
           - 'registry.fedoraproject.org/fedora:latest'
           - 'registry.fedoraproject.org/fedora:rawhide'
-          - 'registry.opensuse.org/opensuse/tumbleweed-dnf:latest'
+          - 'registry.opensuse.org/opensuse/tumbleweed:latest'
         include:
           - container: 'registry.fedoraproject.org/fedora:latest'
             build-type: 'no-optional-deps'
-          - container: 'registry.opensuse.org/opensuse/tumbleweed-dnf:latest'
+          - container: 'registry.opensuse.org/opensuse/tumbleweed:latest'
             build-type: 'no-optional-deps'
       fail-fast: false
 
@@ -29,7 +29,7 @@ jobs:
       options: --security-opt seccomp=unconfined
 
     steps:
-      - run: dnf --assumeyes install
+      - run: zypper -n install
               cpio gzip
               bzip2 xz
               binutils glibc glibc-32bit glibc-locale
@@ -54,14 +54,14 @@ jobs:
               rpm-build
               git
         if: ${{ contains(matrix.container, 'opensuse') }}
-      - run: dnf --assumeyes install
+      - run: zypper -n install
               checkbashisms dash
               desktop-file-utils
               appstream-glib
               myspell-en_US myspell-cs_CZ
               python3-pyenchant
         if: ${{ contains(matrix.container, 'opensuse') && matrix.build-type == 'normal' }}
-      - run: dnf --assumeyes install python3-flake8-comprehensions
+      - run: zypper -n install python3-flake8-comprehensions
         if: ${{ contains(matrix.container, 'opensuse') }}
       - run: dnf --nogpgcheck --assumeyes install
               /usr/bin/cpio


### PR DESCRIPTION
Based on the recent openSUSE discussion, we are going to stick with `zypper` and thus I would like to use it for openSUSE.

This reverts commit 846c63d20ffa9ea37ae9fc245636b736a11e2383.