### PR TITLE
decode('utf-8', errors='replace')

### DIFF
--- a/rpmlint/checks/MenuCheck.py
+++ b/rpmlint/checks/MenuCheck.py
@@ -94,7 +94,7 @@ class MenuCheck(AbstractCheck):
             directory = pkg.dir_name()
             for f in menus:
                 # remove comments and handle cpp continuation lines
-                text = subprocess.run(('/lib/cpp', directory + f), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=ENGLISH_ENVIROMENT).stdout.decode()
+                text = subprocess.run(('/lib/cpp', directory + f), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=ENGLISH_ENVIROMENT).stdout.decode('utf-8', errors='replace')
                 if text.endswith('\n'):
                     text = text[:-1]
 

--- a/rpmlint/checks/MenuXDGCheck.py
+++ b/rpmlint/checks/MenuXDGCheck.py
@@ -46,7 +46,7 @@ class MenuXDGCheck(AbstractFilesCheck):
         f = root + filename
         try:
             command = subprocess.run(('desktop-file-validate', f), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=ENGLISH_ENVIROMENT)
-            text = command.stdout.decode()
+            text = command.stdout.decode('utf-8', errors='replace')
             if command.returncode:
                 error_printed = False
                 for line in text.splitlines():

--- a/rpmlint/checks/ZipCheck.py
+++ b/rpmlint/checks/ZipCheck.py
@@ -78,7 +78,7 @@ class ZipCheck(AbstractCheck):
             return
 
         # otherwise check for the hardcoded classpath
-        manifest = jarfile.read(mf).decode()
+        manifest = jarfile.read(mf).decode('utf-8', errors='replace')
         if classpath_regex.search(manifest):
             self.output.add_info('W', pkg, 'class-path-in-manifest', fname)
 

--- a/rpmlint/helpers.py
+++ b/rpmlint/helpers.py
@@ -46,7 +46,7 @@ def byte_to_string(item):
         return [byte_to_string(i) for i in item]
 
     # everything else shall be decoded and fails replaced
-    return item.decode(encoding='UTF-8', errors='replace')
+    return item.decode(encoding='utf-8', errors='replace')
 
 
 def readlines(path):

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -116,7 +116,7 @@ def is_utf8_bytestr(s):
     Due to changes in rpm, needs to handle both bytes and unicode."""
     try:
         if hasattr(s, 'decode'):
-            s.decode('utf-8')
+            s.decode('utf-8', errors='replace')
         elif hasattr(s, 'encode'):
             s.encode('utf-8')
         else:
@@ -498,7 +498,7 @@ class Pkg(AbstractPkg):
         ret = subprocess.run(('rpm', '-Kv', self.filename),
                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                              env=ENGLISH_ENVIROMENT)
-        text = ret.stdout.decode()
+        text = ret.stdout.decode('utf-8', errors='replace')
         if text.endswith('\n'):
             text = text[:-1]
         return ret.returncode, text
@@ -521,7 +521,7 @@ class Pkg(AbstractPkg):
         """Mmap a file, return it's content decoded."""
         try:
             with open(Path(self.dir_name() or '/', filename.lstrip('/'))) as in_file:
-                return mmap.mmap(in_file.fileno(), 0, mmap.MAP_SHARED, mmap.PROT_READ).read().decode()
+                return mmap.mmap(in_file.fileno(), 0, mmap.MAP_SHARED, mmap.PROT_READ).read().decode('utf-8', errors='replace')
         except Exception:
             return ''
 


### PR DESCRIPTION
When packaging Atlassian Confluence with OBS (see https://build.opensuse.org/package/show/home:alvistack/atlassian-atlassian-confluence-7.19.0), openSUSE Tumbleweed with rpmlint-2.3.0+git20220725.94636c5e will failed with `rpmlint/checks/ZipCheck.py`, due to incorrect UTF-8 characters inside some `.jar` files.

This PR ensure all `decode()` use are now handled as `decode('utf-8', errors='replace')`, in order to avoid such decode error issue.

Error log from OBS:
```
[  213s] RPMLINT report:
[  213s] ===============
[  270s] (none): E: fatal error while reading //home/abuild/rpmbuild/RPMS/x86_64/atlassian-confluence-7.19.0-1.1.x86_64.rpm: 'utf-8' codec can't decode byte 0xf8 in position 79: invalid start byte
[  270s] Traceback (most recent call last):
[  270s]   File "/opt/testing/bin/rpmlint.real", line 33, in <module>
[  270s]     sys.exit(load_entry_point('rpmlint==2.3.0', 'console_scripts', 'rpmlint')())
[  270s]   File "./rpmlint/cli.py", line 185, in lint
[  270s]   File "./rpmlint/lint.py", line 120, in run
[  270s]   File "./rpmlint/lint.py", line 91, in _run
[  270s]   File "./rpmlint/lint.py", line 255, in validate_files
[  270s]   File "./rpmlint/lint.py", line 279, in validate_file
[  270s]   File "./rpmlint/lint.py", line 272, in validate_file
[  270s]   File "./rpmlint/lint.py", line 288, in run_checks
[  270s]   File "./rpmlint/checks/ZipCheck.py", line 28, in check
[  270s]   File "./rpmlint/checks/ZipCheck.py", line 81, in _check_classpath
[  270s] UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf8 in position 79: invalid start byte
```

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>