### PR TITLE
Modify format of binary-or-shlib-defines-rpath

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -431,7 +431,7 @@ class BinariesCheck(AbstractCheck):
                     runpath = runpath.replace(self.rpath_origin, str(Path(pkgfile.name).parent))
                     runpath = str(Path(runpath).resolve())
                 if not runpath.startswith(self.system_lib_paths) and not self.usr_lib_regex.search(runpath):
-                    self.output.add_info('E', pkg, 'binary-or-shlib-defines-rpath', pkgfile.name, f'(RUNPATH: {runpath})')
+                    self.output.add_info('E', pkg, 'binary-or-shlib-defines-rpath', pkgfile.name, f'(RUNPATH: {runpaths})')
                     return
 
     def _check_library_dependency(self, pkg, pkgfile):


### PR DESCRIPTION
Before:
E: binary-or-shlib-defines-rpath /usr/bin/remmina (RUNPATH: /usr)

After:
E: binary-or-shlib-defines-rpath /usr/bin/remmina (RUNPATH: $ORIGIN/../lib64:$ORIGIN/..)

Fixes: #911