### PR TITLE
add missing-hash-section check for HASH ELF sections

### DIFF
--- a/rpmlint/descriptions/BinariesCheck.toml
+++ b/rpmlint/descriptions/BinariesCheck.toml
@@ -178,3 +178,11 @@ This executable was not compiled with expected flags.
 forbidden-optflags="""
 This executable was compiled with an unexpected flag.
 """
+missing-hash-section="""
+SystemV requires each shared library must provide .hash section that
+is used for efficient symbol resolution.
+"""
+missing-gnu-hash-section="""
+The .gnu.hash section is missing and leads to a slower symbol resolution
+during dynamic linking.
+"""

--- a/test/test_binaries.py
+++ b/test/test_binaries.py
@@ -92,6 +92,8 @@ def test_shlib_with_no_exec_glibc(tmpdir, package, binariescheck):
     test.check(get_tested_package(package, tmpdir))
     out = output.print_results(output.results)
     assert 'E: shared-library-not-executable /lib64/libpthread.so' in out
+    assert 'missing-hash-section' not in out
+    assert 'missing-gnu-hash-section' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/bcc-lua'])


### PR DESCRIPTION
System V requires that .hash sections is present in shared libraries
for dynamic symbol resolution. And we can emit warning when .gnu.hash
section is missing as it rapidly speeds up the symbol resolution.