### PR TITLE
dbus-services: autofs: temporarily accept old path (bsc#1203362)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -467,9 +467,10 @@ package = "autofs"
 type = "dbus"
 note = "imported from rpmlint1 DBUSServices.WhiteList"
 bugs = ["bsc#782691", "bsc#1203362"]
-nodigests = [
-    "/usr/share/dbus-1/system.d/org.freedesktop.AutoMount.conf",
-]
+[[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system.d/org.freedesktop.AutoMount.conf"
+digester = "xml"
+hash = "d53d87b0673808f3cd01b9f474371b6ea5ed82fcad3277551c506055b4ace568"
 
 [[FileDigestGroup]]
 package = "NetworkManager-iodine"


### PR DESCRIPTION
dbus-services: autofs: temporarily accept old path (bsc#1203362)

https://bugzilla.suse.com/show_bug.cgi?id=1203362
https://github.com/rpm-software-management/rpmlint/pull/931#issuecomment-1247791018

Due to a conflict in openSUSE Factory staging, I'd like to whitelist the old path temporarily, set a reminder for next week and remove it once autofs is updated.