### PR TITLE
Whitelist /var/spool/mail in postfix-bdb (bsc#1179574)

### DIFF
--- a/configs/openSUSE/world-writable-whitelist.toml
+++ b/configs/openSUSE/world-writable-whitelist.toml
@@ -39,6 +39,16 @@ owner = "root"
 group = "root"
 
 [[WorldWritableWhitelist]]
+package = "postfix-bdb"
+bug = "bsc#1179574"
+note = "Public standard sticky-bit directories"
+[[WorldWritableWhitelist.files]]
+path = '/var/spool/mail'
+mode = "drwxrwxrwt"
+owner = "root"
+group = "root"
+
+[[WorldWritableWhitelist]]
 package = "postfix"
 bug = "bsc#1179574"
 note = "Public standard sticky-bit directories"


### PR DESCRIPTION
Visit https://build.opensuse.org/request/show/1002629