### PR TITLE
Add python-setup-test check to SpecCheck

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -79,6 +79,8 @@ filelist_regex = re.compile(r'\s+-f\s+\S+')
 pkgname_regex = re.compile(r'\s+(?:-n\s+)?(\S+)')
 tarball_regex = re.compile(r'\.(?:t(?:ar|[glx]z|bz2?)|zip)\b', re.IGNORECASE)
 
+python_setup_test_regex = re.compile(r'^[^#]*(setup.py test)')
+
 UNICODE_NBSP = u'\xa0'
 
 
@@ -489,6 +491,10 @@ class SpecCheck(AbstractCheck):
                     res = re.match('%+', match)
                     if len(res.group(0)) % 2:
                         self.output.add_info('W', pkg, 'macro-in-comment', match)
+
+            # Test if the "python setup.py test" deprecated subcommand is used
+            if current_section == 'check' and python_setup_test_regex.search(line):
+                self.output.add_info('W', pkg, 'python-setup-test', line[:-1])
 
         # Last line read is not useful after this point
         pkg.current_linenum = None

--- a/rpmlint/descriptions/SpecCheck.toml
+++ b/rpmlint/descriptions/SpecCheck.toml
@@ -184,3 +184,7 @@ the sign that someone didn't check if a patch is still needed and do not want
 to rediff it. It is usually better to rediff the patch and try to send it
 upstream.
 """
+python-setup-test="""
+The python setup.py test subcommand is deprecated and should be replaced with a
+modern testing tool like %pytest or %pyunittest discover -v.
+"""

--- a/test/spec/python-setup-test.spec
+++ b/test/spec/python-setup-test.spec
@@ -1,0 +1,34 @@
+Name:           python-setup-test
+Version:        1.0
+Release:        0
+Summary:        python-setup-test warning
+License:        MIT
+URL:            https://www.example.com
+Source:         Source.tar.gz
+BuildRequires:  gcc
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+%description
+A test specfile with python setup.py test that is deprecated.
+
+%prep
+%setup -q
+
+%build
+%configure
+%make_build
+
+%install
+%make_install
+
+%check
+%python_exec setup.py test
+
+%post
+%postun
+
+%files
+%license COPYING
+%doc ChangeLog README
+
+%changelog

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -1092,3 +1092,13 @@ def test_check_invalid_url_not_applied(package, speccheck):
     test.check_spec(pkg)
     out = output.print_results(output.results)
     assert 'W: invalid-url' not in out
+
+
+@pytest.mark.parametrize('package', ['spec/python-setup-test'])
+def test_python_setup_test(package, speccheck):
+    """Test if specfile has deprecated use of 'setup.py test'."""
+    output, test = speccheck
+    pkg = get_tested_spec_package(package)
+    test.check_spec(pkg)
+    out = output.print_results(output.results)
+    assert 'W: python-setup-test' in out


### PR DESCRIPTION
This patch adds a new warning when detecting the use of "setup.py test" in the check section.

Fixes: #677.