### PR TITLE
rpmdiff: improve help for multiple values with -i/-e options

### DIFF
--- a/rpmlint/cli.py
+++ b/rpmlint/cli.py
@@ -36,7 +36,11 @@ def process_diff_args(argv):
     """
 
     parser = argparse.ArgumentParser(prog='rpmdiff',
-                                     description='Shows basic differences between two rpm packages')
+                                     description='Shows basic differences between two rpm packages',
+                                     epilog="""When using multiple values for the -i or -e options,
+                                               separate values from package arguments with '--',
+                                               e.g.: 'rpmdiff -i 5 T -- old.rpm new.rpm' or place
+                                               the options _after_ the package arguments.""")
     parser.add_argument('old_package', metavar='RPM_ORIG', type=Path, help='the old package')
     parser.add_argument('new_package', metavar='RPM_NEW', type=Path, help='the new package')
     parser.add_argument('-V', '--version', action='version', version=__version__, help='show package version and exit')


### PR DESCRIPTION
When using multiple values with the -i or -e options, rpmlint-2.x is incompatible with earlier releases.  Moreover, the behavior is not immediately obvious to users¹.

To help alleviate this slightly, add an epilog to the parser which explains how to pass multiple options to -i/-e options using either '--' to separate the values from the following positional arguments or lists the options _after_ the positional arguments.

This isn't really a fix for the poor behavior we get from argparse relative to what older releases had with getopt, but maybe it's enough until folks get used to how the options must be handled in 2.x releases.

This partially addresses #940.

¹ https://bugzilla.redhat.com/1969534