### PR TITLE
Move autosetup regex into config options file

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -241,7 +241,7 @@ class SpecCheck(AbstractCheck):
                 if current_section != 'prep':
                     self.output.add_info('W', pkg, '%autopatch-not-in-prep')
             else:
-                res = autosetup_regex.search(line)
+                res = self.autosetup_regex.search(line)
                 if res:
                     if not autosetup_n_regex.search(res.group(1)):
                         patches_auto_applied = True

--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -71,7 +71,6 @@ setup_regex = re.compile(r'%setup\b')  # intentionally no whitespace before!
 setup_q_regex = re.compile(r' -[A-Za-z]*q')
 setup_t_regex = re.compile(r' -[A-Za-z]*T')
 setup_ab_regex = re.compile(r' -[A-Za-z]*[ab]')
-autosetup_regex = re.compile(r'^\s*%autosetup(\s.*|$)')
 autosetup_n_regex = re.compile(r' -[A-Za-z]*N')
 autopatch_regex = re.compile(r'^\s*%autopatch(?:\s|$)')
 
@@ -113,6 +112,7 @@ class SpecCheck(AbstractCheck):
                                          """The value of the Group tag in the package is not valid.  Valid groups are:
                                          '%s'.""" % ', '.join(self.valid_groups)})
         self.hardcoded_lib_path_exceptions_regex = re.compile(config.configuration['HardcodedLibPathExceptions'])
+        self.autosetup_regex = re.compile(config.configuration['AutosetupMacro'])
 
     def check_source(self, pkg):
         """Find specfile in SRPM and run spec file related checks."""

--- a/rpmlint/configdefaults.toml
+++ b/rpmlint/configdefaults.toml
@@ -89,6 +89,8 @@ ExtraMenuNeeds = [
 ]
 # Regexp string with exceptions for hardcoded library paths.
 HardcodedLibPathExceptions = '/lib/(modules|cpp|perl5|rpm|hotplug|firmware|systemd)($|[\s/,])'
+# Regexp string to match autosetup macro and its variants
+AutosetupMacro = '^\s*%autosetup(\s.*|$)'
 # Values for non-XDG legacy menu item sections
 ValidMenuSections = [
     "Office/Accessories",


### PR DESCRIPTION
There is a `forgemeta` macro in Fedora which provides `forgeautosetup` macro with the same functionality as `autosetup`, so we would like `autosetup` regex pattern to be customizable. 