### PR TITLE
FileDigestCheck: print digest hint for all possible filter types

### DIFF
--- a/test/test_file_digest.py
+++ b/test/test_file_digest.py
@@ -109,7 +109,7 @@ def test_missing_entry():
         test.check(pkg)
         assert len(output.results) == 1
         error = output.results[0]
-        assert error == 'testpkg: E: somerestriction-file-unauthorized /restricted/1/evil (file digest sha256:f2175fc16d5a482baa71b2e77831b354afa91a5fda5ef0df59d8e87376598d4f)'
+        assert error == 'testpkg: E: somerestriction-file-unauthorized /restricted/1/evil (sha256 file digest default filter:f2175fc16d5a482baa71b2e77831b354afa91a5fda5ef0df59d8e87376598d4f shell filter:8336ce7a3fb22e404a767f7b7302cfc6637083fa1b4fd63fe11c2d977d65dfa2 xml filter:<failed-to-calculate>)'
 
 
 @pytest.mark.parametrize('package', ['binary/tmpwatch'])
@@ -133,8 +133,8 @@ def test_wrong_pkg_name():
         pkg.add_file_with_content('/related/and/also/sensitive', 'related sensitive stuff')
         test.check(pkg)
         assert len(output.results) == 2
-        assert 'otherpkg: E: somerestriction-file-unauthorized /alsorestricted/2/suspicious (file digest of resolved path /other/place/suspicious.txt sha256:a412bca55af87ea264063df10d08a40ff3b8e68106f4a48a3c4a1cacb6394c94)' in output.results
-        assert 'otherpkg: E: somerestriction-file-unauthorized /restricted/1/dangerous (file digest sha256:537b320f9c3b30276bd54b838b6e6b72e923e70dbdb126926f992d594a30256c)' in output.results
+        assert 'otherpkg: E: somerestriction-file-unauthorized /alsorestricted/2/suspicious (sha256 file digest of resolved path /other/place/suspicious.txt default filter:a412bca55af87ea264063df10d08a40ff3b8e68106f4a48a3c4a1cacb6394c94 shell filter:26f40cba5d4f8d6ff9815a12890fb1dbc9e32771a29ccc4ecbb300475dfeb057 xml filter:<failed-to-calculate>)' in output.results
+        assert 'otherpkg: E: somerestriction-file-unauthorized /restricted/1/dangerous (sha256 file digest default filter:537b320f9c3b30276bd54b838b6e6b72e923e70dbdb126926f992d594a30256c shell filter:eb372739a52b2c1a400038e1bea1ff3e194ed2a2986d098d01fd631fb3f29c81 xml filter:<failed-to-calculate>)' in output.results
 
 
 def test_unaffected_pkg():
@@ -172,7 +172,7 @@ def test_missing_nodigests_entry():
         test.check(pkg)
         assert len(output.results) == 1
         error = output.results[0]
-        assert error == 'testpkg: E: somerestriction-file-unauthorized /restricted/1/evil (file digest sha256:f2175fc16d5a482baa71b2e77831b354afa91a5fda5ef0df59d8e87376598d4f)'
+        assert error == 'testpkg: E: somerestriction-file-unauthorized /restricted/1/evil (sha256 file digest default filter:f2175fc16d5a482baa71b2e77831b354afa91a5fda5ef0df59d8e87376598d4f shell filter:8336ce7a3fb22e404a767f7b7302cfc6637083fa1b4fd63fe11c2d977d65dfa2 xml filter:<failed-to-calculate>)'
 
 
 def test_wrong_pkg_name_for_nodigests():
@@ -187,8 +187,8 @@ def test_wrong_pkg_name_for_nodigests():
         pkg.add_file_with_content('/related/and/also/sensitive', 'whatever')
         test.check(pkg)
         assert len(output.results) == 2
-        assert 'otherpkg: E: somerestriction-file-unauthorized /alsorestricted/2/suspicious (file digest of resolved path /other/place/suspicious.txt sha256:85738f8f9a7f1b04b5329c590ebcb9e425925c6d0984089c43a022de4f19c281)' in output.results
-        assert 'otherpkg: E: somerestriction-file-unauthorized /restricted/1/dangerous (file digest sha256:85738f8f9a7f1b04b5329c590ebcb9e425925c6d0984089c43a022de4f19c281)' in output.results
+        assert 'otherpkg: E: somerestriction-file-unauthorized /alsorestricted/2/suspicious (sha256 file digest of resolved path /other/place/suspicious.txt default filter:85738f8f9a7f1b04b5329c590ebcb9e425925c6d0984089c43a022de4f19c281 shell filter:cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411 xml filter:<failed-to-calculate>)' in output.results
+        assert 'otherpkg: E: somerestriction-file-unauthorized /restricted/1/dangerous (sha256 file digest default filter:85738f8f9a7f1b04b5329c590ebcb9e425925c6d0984089c43a022de4f19c281 shell filter:cd293be6cea034bd45a0352775a219ef5dc7825ce55d1f7dae9762d80ce64411 xml filter:<failed-to-calculate>)' in output.results
 
 
 def test_combination_nodigests_and_digests():


### PR DESCRIPTION
This eases the whitelisting process and also makes it clearer to people unaccustomed to the process.

While we're at it, separate the logic into its own member function and simplify it.

Also adjust tests to new output.