### PR TITLE
rpmdiff: clarify help text on -i/-e options

### DIFF
--- a/rpmlint/cli.py
+++ b/rpmlint/cli.py
@@ -37,7 +37,7 @@ def process_diff_args(argv):
 
     parser = argparse.ArgumentParser(prog='rpmdiff',
                                      description='Shows basic differences between two rpm packages',
-                                     epilog="""When using multiple values for the -i or -e options,
+                                     epilog="""When using the -i or -e options,
                                                separate values from package arguments with '--',
                                                e.g.: 'rpmdiff -i 5 T -- old.rpm new.rpm' or place
                                                the options _after_ the package arguments.""")


### PR DESCRIPTION
The epilog added in f551541a (rpmdiff: improve help for multiple values with -i/-e options, 2022-10-04) mentions multiple values for the -i/-e options.  However, the issue is present regardless of the number of values.  Remove the reference to multiple values to simplify the help text.

Related: #940