### PR TITLE
Update the Python module regex to also match stable ABI names

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -32,7 +32,7 @@ class BinariesCheck(AbstractCheck):
     la_file_regex = re.compile(r'\.la$')
     invalid_dir_ref_regex = re.compile(r'/(home|tmp)(\W|$)')
     usr_arch_share_regex = re.compile(r'/share/.*/(?:x86|i.86|x86_64|ppc|ppc64|s390|s390x|ia64|m68k|arm|aarch64|mips|riscv)')
-    python_module_regex = re.compile(r'.*\.\w*(python|pypy)\w*(-\w+){4}\.so')
+    python_module_regex = re.compile(r'.*\.(\w*(python|pypy)\w*(-\w+){4}|abi3)\.so')
 
     lto_text_like_sections = {'.preinit_array', '.init_array', '.fini_array'}
     # The following sections are part of the RX ABI and do correspond to .text, .data and .bss


### PR DESCRIPTION
Python stable API extension modules have filenames with the .ai3.so suffix, e.g.:

    python3-tpm2-pytss.x86_64: W: undefined-non-weak-symbol /usr/lib64/python3.11/site-packages/tpm2_pytss/_libtpm2_pytss.abi3.so ...