### PR TITLE
Add python-module-def check to SpecCheck

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -79,6 +79,7 @@ pkgname_regex = re.compile(r'\s+(?:-n\s+)?(\S+)')
 tarball_regex = re.compile(r'\.(?:t(?:ar|[glx]z|bz2?)|zip)\b', re.IGNORECASE)
 
 python_setup_test_regex = re.compile(r'^[^#]*(setup.py test)')
+python_module_def_regex = re.compile(r'^[^#]*%{\?!python_module:%define python_module()')
 
 UNICODE_NBSP = '\xa0'
 
@@ -364,6 +365,7 @@ class SpecCheck(AbstractCheck):
         self._checkline_valid_groups(line)
         self._checkline_macros_in_comments(line)
         self._checkline_python_setup_test(line)
+        self._checkline_python_module_def(line)
 
         # If statement, starts
         if ifarch_regex.search(line):
@@ -740,3 +742,12 @@ class SpecCheck(AbstractCheck):
         # Test if the "python setup.py test" deprecated subcommand is used
         if self.current_section == 'check' and python_setup_test_regex.search(line):
             self.output.add_info('W', self.pkg, 'python-setup-test', line[:-1])
+
+    def _checkline_python_module_def(self, line):
+        """
+        Test if the "python_module" macro is defined in the spec file
+        This macro was in py2pack but now it should be provided by
+        python-rpm-macros
+        """
+        if python_module_def_regex.search(line):
+            self.output.add_info('W', self.pkg, 'python-module-def', line[:-1])

--- a/rpmlint/descriptions/SpecCheck.toml
+++ b/rpmlint/descriptions/SpecCheck.toml
@@ -188,3 +188,9 @@ python-setup-test="""
 The python setup.py test subcommand is deprecated and should be replaced with a
 modern testing tool like %pytest or %pyunittest discover -v.
 """
+python-module-def="""
+The spec file contains a conditional definition of python_module macro, this
+macro is present in recent versions of python-rpm-macros.
+The following conditional python_module macro definition can be removed:
+%{?!python_module:%define python_module() python-%{**} python3-%{**}}
+"""

--- a/test/spec/python-module-def.spec
+++ b/test/spec/python-module-def.spec
@@ -1,0 +1,36 @@
+%{?!python_module:%define python_module() python-%{**} python3-%{**}}
+
+Name:           python-module-def
+Version:        1.0
+Release:        0
+Summary:        python-module-def warning
+License:        MIT
+URL:            https://www.example.com
+Source:         Source.tar.gz
+BuildRequires:  gcc
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+%description
+A test specfile with python setup.py test that is deprecated.
+
+%prep
+%setup -q
+
+%build
+%configure
+%make_build
+
+%install
+%make_install
+
+%check
+%pytest
+
+%post
+%postun
+
+%files
+%license COPYING
+%doc ChangeLog README
+
+%changelog

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -1102,3 +1102,30 @@ def test_python_setup_test(package, speccheck):
     test.check_spec(pkg)
     out = output.print_results(output.results)
     assert 'W: python-setup-test' in out
+
+
+@pytest.mark.parametrize('package', ['spec/python-module-def'])
+def test_python_module_definition(package, speccheck):
+    """Test if python_module macro is defined in the spec file."""
+    output, test = speccheck
+    pkg = get_tested_spec_package(package)
+    test.check_spec(pkg)
+    out = output.print_results(output.results)
+    assert 'W: python-module-def' in out
+
+
+@pytest.mark.parametrize('package', [
+    'spec/SpecCheck',
+    'spec/SpecCheck2',
+    'spec/SpecCheck3',
+    'spec/SpecCheck4',
+])
+def test_python_module_definition_not_present(package, speccheck):
+    """Test if python_module macro warning is not shown if the macro is not
+       defined in the spec file.
+    """
+    output, test = speccheck
+    pkg = get_tested_spec_package(package)
+    test.check_spec(pkg)
+    out = output.print_results(output.results)
+    assert 'W: python-module-def' not in out


### PR DESCRIPTION
This patch adds a new warning when detecting the use of python_module macro definition in the spec file.

It's included by default in python-rpm-macros so every modern distro should have this module defined.

This macro was added by py2pack by default in new packages, but now it's removed:
https://github.com/openSUSE/py2pack/pull/166