### PR TITLE
Remove Python entries from Filelist checks.

### DIFF
--- a/rpmlint/checks/FilelistCheck.toml
+++ b/rpmlint/checks/FilelistCheck.toml
@@ -84,16 +84,6 @@ GoodPrefixes = [
         "/usr/lib/perl5/site_perl/*",
     ]
 [[Check]]
-    Message = "filelist-forbidden-python"
-    Bad = [
-        "/usr/lib*/python*/site-packages/test",
-        "/usr/lib*/python*/site-packages/tests",
-        "/usr/lib*/python*/site-packages/doc",
-        "/usr/lib*/python*/site-packages/docs",
-        "/usr/lib*/python*/site-packages/src",
-        "/usr/lib*/python*/site-packages/__init__.py",
-    ]
-[[Check]]
     Message = "filelist-forbidden-backup-file"
     Bad = [
         "*~",

--- a/rpmlint/descriptions/FilelistCheck.toml
+++ b/rpmlint/descriptions/FilelistCheck.toml
@@ -5,9 +5,6 @@ Please use %{_fillupdir}/sysconfig.<pkgname>
 and call %fillup_and_insserv for new sysconfig files."""
 filelist-forbidden-perl-dir="""
 Perl files installed a non-vendor installed path."""
-filelist-forbidden-python="""
-Python package installs content directly to the sitelib,
-which can cause file list conflict."""
 filelist-forbidden-backup-file="""
 Backup files (~, .swp or .bak) are not allowed."""
 filelist-forbidden-devel-in-lib="""

--- a/test/test_filelist.py
+++ b/test/test_filelist.py
@@ -21,7 +21,6 @@ def test_filelist(tmpdir, package, filelistcheck):
     assert 'E: filelist-forbidden-sysconfig /etc/rc.config.d/foo.config' in out
     assert 'E: filelist-forbidden /var/adm/setup' in out
     assert 'E: filelist-forbidden-perl-dir /usr/lib/perl5/site_perl/x.pl' in out
-    assert 'E: filelist-forbidden-python /usr/lib/python/site-packages/tests' in out
     assert 'E: filelist-forbidden-backup-file /foo~' in out
     assert 'E: filelist-forbidden-devel-in-lib /lib64/x.a' in out
     assert 'E: filelist-forbidden-devel-in-lib /lib64/y.so' in out


### PR DESCRIPTION
With the dedicated PythonCheck in place, we no longer need the Python entries in the FilelistCheck configuration.

See https://github.com/rpm-software-management/rpmlint/issues/423