### PR TITLE
Franklin Street address is ok

### DIFF
--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -207,7 +207,7 @@ non_readable_regexs = (re.compile(r'^/var/log/'),
 man_base_regex = re.compile(r'^/usr(?:/share)?/man(?:/overrides)?/man(?P<category>[^/]+)/(?P<filename>((?P<binary>[^.]+)\..+))')
 
 fsf_license_regex = re.compile(br'(GNU((\s+(Library|Lesser|Affero))?(\s+General)?\s+Public|\s+Free\s+Documentation)\s+Licen[cs]e|(GP|FD)L)', re.IGNORECASE)
-fsf_wrong_address_regex = re.compile(br'(675\s+Mass\s+Ave|59\s+Temple\s+Place|Franklin\s+Steet|02139|02111-1307)', re.IGNORECASE)
+fsf_wrong_address_regex = re.compile(br'(675\s+Mass\s+Ave|59\s+Temple\s+Place|02139)', re.IGNORECASE)
 
 scalable_icon_regex = re.compile(r'^/usr(?:/local)?/share/icons/.*/scalable/')
 tcl_regex = re.compile(r'^/usr/lib(64)?/([^/]+/)?pkgIndex\.tcl')


### PR DESCRIPTION
Franklin Street Address is used in:
 https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt 
and is the current address listed at:
 https://www.fsf.org/about/contact/