### PR TITLE
openSUSE: new whitelisting restriction for zypper plugins (bsc#1204314)

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -273,6 +273,9 @@ BlockedFilters = [
     "systemd-tmpfile-entry-unauthorized",
     "world-writable-mismatched-attrs",
     "world-writable-unauthorized-file",
+    "zypperplugin-file-digest-mismatch",
+    "zypperplugin-file-ghost",
+    "zypperplugin-file-unauthorized"
 ]
 
 [DanglingSymlinkExceptions."/usr/share/doc/licenses/"]

--- a/configs/openSUSE/scoring-strict.override.toml
+++ b/configs/openSUSE/scoring-strict.override.toml
@@ -42,3 +42,6 @@ systemd-tmpfile-parse-error = 10000
 systemd-tmpfile-symlink = 10000
 world-writable-mismatched-attrs = 10000
 world-writable-unauthorized-file = 10000
+zypperplugin-file-digest-mismatch = 10000
+zypperplugin-file-ghost = 10000
+zypperplugin-file-unauthorized = 10000

--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -90,3 +90,6 @@ systemd-tmpfile-ghost = 10
 systemd-tmpfile-parse-error = 10
 systemd-tmpfile-symlink = 10
 missing-hash-section = 10000
+zypperplugin-file-digest-mismatch = 10
+zypperplugin-file-ghost = 10
+zypperplugin-file-unauthorized = 10

--- a/configs/openSUSE/security.toml
+++ b/configs/openSUSE/security.toml
@@ -47,6 +47,12 @@ Locations = [
     "/lib64/security/"
 ]
 
+[FileDigestLocation.zypperplugin]
+FollowSymlinks = true
+Locations = [
+    "/usr/lib/zypp/plugins/"
+]
+
 [FileDigestLocation.sudoers]
 FollowSymlinks = false
 # the directories for this are currently configured in /etc/sudoers via

--- a/configs/openSUSE/zypper-plugins.toml
+++ b/configs/openSUSE/zypper-plugins.toml
@@ -1,0 +1,78 @@
+[[FileDigestGroup]]
+package = "rpmlint-integration-test"
+type = "zypperplugin"
+note = "test whitelisting entry for the OBS integration test package"
+bug = "bsc#1204314"
+[[FileDigestGroup.digests]]
+path = "/usr/lib/zypp/plugins/commit/test-plugin.sh"
+digester = "shell"
+hash = "2709ba21a4c4905560166ab13bb7bf6a92ff604adc7cb61fa1768d3f562ab189"
+
+[[FileDigestGroup]]
+package = "btrfsmaintenance"
+type = "zypperplugin"
+note = "this plugin defragments the RPM database after zypper operations are complete"
+bug = "bsc#1204314"
+[[FileDigestGroup.digests]]
+path = "/usr/lib/zypp/plugins/commit/btrfs-defrag-plugin.sh"
+digester = "shell"
+hash = "dbfdf581ce1929f2815ed854c267b1e47bbedb9e8083e835f66850168fabf2d2"
+
+[[FileDigestGroup]]
+package = "etckeeper-zypp-plugin"
+type = "zypperplugin"
+note = "this plugin performs commits for /etc before and after every zypper operation"
+bug = "bsc#1204314"
+[[FileDigestGroup.digests]]
+path = "/usr/lib/zypp/plugins/commit/zypper-etckeeper.py"
+digester = "shell"
+hash = "14f744b4146f304b9432ec768cb2a08b184a1a214ecb9bf5086b9a98151dc4b0"
+
+[[FileDigestGroup]]
+package = "libzypp-plugin-appdata"
+type = "zypperplugin"
+note = "this plugin maintains AppStream metadata for each installed package"
+bug = "bsc#1204314"
+[[FileDigestGroup.digests]]
+path = "/usr/lib/zypp/plugins/appdata/InstallAppdata"
+digester = "shell"
+hash = "659f9bdf79eebdca9f69a4924c0c3b53388ab3469c737759c1ea133eab460969"
+
+[[FileDigestGroup]]
+package = "permissions-zypp-plugin"
+type = "zypperplugin"
+note = "this plugin calls `chkstat --system` after certain package install to make sure the permission settings are maintained at all times"
+bug = "bsc#1204314"
+[[FileDigestGroup.digests]]
+path = "/usr/lib/zypp/plugins/commit/permissions.py"
+digester = "shell"
+hash = "db141ad0e17dd6c0b34a671159f95357914693c3ab5e23f64f3724f713bb7c5d"
+
+[[FileDigestGroup]]
+package = "snapper-zypp-plugin"
+type = "zypperplugin"
+note = "this plugin creates snapper snapshots before zypper modifications take place"
+bug = "bsc#1204314"
+nodigests = [
+    "/usr/lib/zypp/plugins/commit/snapper-zypp-plugin"
+]
+
+[[FileDigestGroup]]
+package = "container-suseconnect"
+type = "zypperplugin"
+note = "this plugin make host SUSE subscriptions available in containers"
+bug = "bsc#1204314"
+nodigests = [
+    "/usr/lib/zypp/plugins/services/container-suseconnect-zypp",
+    "/usr/lib/zypp/plugins/urlresolver/susecloud"
+]
+
+[[FileDigestGroup]]
+package = "salt-minion"
+type = "zypperplugin"
+note = "this plugin maintains a timestamp and checksum of the RPM database"
+bug = "bsc#1204314"
+[[FileDigestGroup.digests]]
+path = "/usr/lib/zypp/plugins/commit/zyppnotify"
+digester = "shell"
+hash = "58a04efaa1ca353f298b61be48dbb7a6512837733ef42468fcb5cb07cd82db92"

--- a/rpmlint/descriptions/FileDigestCheck.toml
+++ b/rpmlint/descriptions/FileDigestCheck.toml
@@ -32,3 +32,8 @@ sudoers-file-unauthorized="Packaging sudoers.d drop-in configuration files #SUFF
 sudoers-file-digest-mismatch="A whitelisting related sudoers.d drop-in file changed in content. Packaging sudoers.d drop in configuration files #SUFFIX#. #REVIEW_NEEDED_TEXT#"
 sudoers-file-ghost="This package installs a sudoers.d drop-in configuration file as a %ghost file. #GHOST_ENCOUNTERED_TEXT#"
 sudoers-file-symlink="Symlinks are not allowed for sudoers.d drop-in configuration files"
+
+zypperplugin-file-digest-mismatch="A whitelisting related zypper plugin file changed in content. Packaging zypper plugins #SUFFIX#. #REVIEW_NEEDED_TEXT#"
+zypperplugin-file-unauthorized="Packaging new zypper plugins #SUFFIX#. #REVIEW_NEEDED_TEXT#"
+zypperplugin-file-ghost="This package installs a zypper plugin as a %ghost file. #GHOST_ENCOUNTERED_TEXT#"
+zypperplugin-file-symlink="this should never happen"


### PR DESCRIPTION
Based on the file digest whitelisting check this introduces a new whitelisting restriction for installation of zypper plugins. The plugins whitelist here have been reviewed, the impact for future packages should be rather small, since this is a rather specialized area.