### PR TITLE
opensuse: also exclude systemd-mini symlink from new sysctl.d restriction

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -298,7 +298,7 @@ paths = [
 #
 # files matching this condition will be ignored and not be verified at all
 [[SymlinkExceptions]]
-package = "systemd"
+packages = ["systemd", "systemd-mini"]
 paths = [
     # compability symlink towards /etc/sysctl.conf for systemd-sysctl
     "/usr/lib/sysctl.d/99-sysctl.conf"


### PR DESCRIPTION
Along with this make it possible to share exception entries between multiple packages to avoid duplication.