### PR TITLE
Support filtering of warnings/errors based on title

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -20,6 +20,10 @@ DisallowedDirs = [
     "/etc/NetworkManager/dispatcher.d",
 ]
 
+FilterErrorTitles = [
+    'cross-directory-hard-link',
+]
+
 Filters = [
 # Stuff autobuild takes care about
     '.*invalid-version.*',
@@ -31,7 +35,6 @@ Filters = [
     '.*shlib-policy-name-error.*',
     '.*hardcoded-path-in-buildroot-tag.*',
     '.*no-buildroot-tag.*',
-    '.*cross-directory-hard-link.*',
 
 # Do not validate package rpm groups
     '.*devel-package-with-non-devel-group.*',

--- a/rpmlint/configdefaults.toml
+++ b/rpmlint/configdefaults.toml
@@ -28,6 +28,8 @@ Checks = [
     "ZipCheck",
     "ZyppSyntaxCheck",
 ]
+# List of error titles that should be filtered
+FilterErrorTitles = []
 # Various output filters, list of regexp strings eg. "E: .* no-signature"
 Filters = []
 # List of errors that can't be filtered

--- a/rpmlint/filter.py
+++ b/rpmlint/filter.py
@@ -32,6 +32,7 @@ class Filter:
         self.strict = config.strict
         # list of filter regexes
         self.filters_regexes = [re.compile(f) for f in config.configuration['Filters']]
+        self.filter_titles = set(config.configuration['FilterErrorTitles'])
         # list of blocked filters
         self.blocked_filters = set(config.configuration['BlockedFilters'])
         # set of filters that are actually used in add_info
@@ -135,6 +136,9 @@ class Filter:
         result_no_color = f'{filename}{arch}:{line} {level}: {rpmlint_issue}{detail_output}'
         # unused-rpmlintrc-filter warnings should be skipped
         if rpmlint_issue != 'unused-rpmlintrc-filter' and rpmlint_issue not in self.blocked_filters:
+            if rpmlint_issue in self.filter_titles:
+                self.filtered_out += 1
+                return
             for f in self.filters_regexes:
                 if f.search(result_no_color):
                     self.used_filters.add(f.pattern)


### PR DESCRIPTION
There are package like glibc-locale.x86_64 where one can meet thousands of warnings that are filtered eventually. Regex-based filtering can be expensive and cross-directory-hard-link title-based match can save 40% of rpmlint time.

Fixes: #989