### PR TITLE
Revert "disable opensuse-tumbleweed-aarch64 due to system crash"

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,7 +15,7 @@ jobs:
     - mageia-cauldron-x86_64
     - mageia-cauldron-aarch64
     - opensuse-tumbleweed-x86_64
-#    - opensuse-tumbleweed-aarch64
+    - opensuse-tumbleweed-aarch64
   trigger: pull_request
 - job: copr_build
   trigger: commit
@@ -26,7 +26,7 @@ jobs:
     - mageia-cauldron-x86_64
     - mageia-cauldron-aarch64
     - opensuse-tumbleweed-x86_64
-#    - opensuse-tumbleweed-aarch64
+    - opensuse-tumbleweed-aarch64
     branch: main
     project: rpm-software-management-rpmlint-mainline
     list_on_homepage: True
@@ -36,7 +36,7 @@ jobs:
   metadata:
     targets:
     - opensuse-tumbleweed-x86_64
-#    - opensuse-tumbleweed-aarch64
+    - opensuse-tumbleweed-aarch64
     branch: opensuse
     project: rpm-software-management-rpmlint-opensuse
     list_on_homepage: True


### PR DESCRIPTION
This reverts commit 56429a8dbb5ab798f74a72aed752560450bc714c.