### PR TITLE
FilesCheck: fix typo and shorten setuid/setgid check

### DIFF
--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -899,7 +899,7 @@ class FilesCheck(AbstractCheck):
         self._file_is_buildconfig = False
 
         # set[ug]id bit check
-        self._check_file_normal_file_setui_bit_check(pkg, fname, pkgfile)
+        self._check_file_normal_file_setuid_bit(pkg, fname, pkgfile)
         self._check_file_normal_file_libfile(pkg, fname)
         self._check_file_normal_file_logfile(pkg, fname, pkgfile)
         # Fill class attributes, chunk, istext, interpreter, is_buildconfig
@@ -933,7 +933,7 @@ class FilesCheck(AbstractCheck):
         self._check_file_normal_file_text(pkg, fname, pkgfile)
         self._check_file_normal_file_not_utf8(pkg, fname, pkgfile)
 
-    def _check_file_normal_file_setui_bit_check(self, pkg, fname, pkgfile):
+    def _check_file_normal_file_setuid_bit(self, pkg, fname, pkgfile):
         user = pkgfile.user
         group = pkgfile.group
         mode = pkgfile.mode


### PR DESCRIPTION
When _check_file_normal_file_setuid_bit_check was added in 52b224ed (FilesCheck: Split big check method, 2022-10-18), the 'd' was missing. Add it to make the function name clearer and more easily found when searching for setuid.

Remove the redundant trailing '_check' to shorten the already long function name.