### PR TITLE
DbusPolicyCheck: use existing dbus-policy-missing-allow

### DIFF
--- a/rpmlint/checks/DBusPolicyCheck.py
+++ b/rpmlint/checks/DBusPolicyCheck.py
@@ -25,7 +25,7 @@ class DBusPolicyCheck(AbstractCheck):
                         self._check_deny_policy_element(pkg, f, policy)
 
                     if not send_policy_seen:
-                        self.output.add_info('E', pkg, 'dbus-communication-not-allowed', f)
+                        self.output.add_info('E', pkg, 'dbus-policy-missing-allow', f)
 
             except Exception as e:
                 self.output.add_info('E', pkg, 'dbus-parsing-exception', 'raised an exception: ' + str(e), f)

--- a/test/test_dbus_policy.py
+++ b/test/test_dbus_policy.py
@@ -22,4 +22,4 @@ def test_dbus_policy(tmpdir, package, dbuspolicycheck):
     assert 'E: dbus-policy-allow-without-destination <allow send_interface="org.freedesktop.NetworkManager.PPP"/>' in out
     assert 'W: dbus-policy-allow-receive <allow receive_sender="foo"/>' in out
     assert 'E: dbus-policy-deny-without-destination <deny send_interface="org.freedesktop.NetworkManager.Settings" send_member="ReloadConnections"/>' in out
-    assert 'E: dbus-communication-not-allowed /etc/dbus-1/system.d/org.freedesktop.NetworkManager2.conf' in out
+    assert 'E: dbus-policy-missing-allow /etc/dbus-1/system.d/org.freedesktop.NetworkManager2.conf' in out


### PR DESCRIPTION
For some reason the already existing dbus-policy-missing-allow in the descriptions was not used before in DbusPolicyCheck. Harmonize that.

Closes #1008