### PR TITLE
Setuptools deprecations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-license_file = COPYING
+license_files = COPYING
 
 [aliases]
 test=pytest

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     packages=[
         'rpmlint',
         'rpmlint.checks',
+        'rpmlint.descriptions',
     ],
     package_data={
         'rpmlint': ['configdefaults.toml'],


### PR DESCRIPTION
Minor fixes to silence `SetuptoolsDeprecationWarning`s.  These were noticed when building the Fedora packages against newer python releases.

* rename license_file to license_files

  In setuptools-56.0.0¹ license_file was changed to license_files.  The
  former causes a deprecation warning.

  ¹ https://github.com/pypa/setuptools/issues/2620
    https://setuptools.pypa.io/en/latest/history.html?highlight=license_files#v56-0-0

* include rpmlint.descriptions in packages

  Since setuptools-62.3.0², a warning is issued when setuptools finds an
  importable package is listed in package_data rather than in packages.

  ² https://github.com/pypa/setuptools/pull/3308
     https://setuptools.pypa.io/en/latest/history.html#v62-3-0

It feels a little strange to list `rpmlint.descriptions` in the `packages` section as well as `package_data`.  I don't know if there's a better way to do that or not.  (I did try moving the line as-is from `package_data` to `packages` but that wasn't valid.)

Perhaps at some point, reworking things to just use a toml file as the more modern setuptools describes might be good?