### PR TITLE
SpecCheck: allow more %suse_version value comparisons

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -586,7 +586,7 @@ class SpecCheck(AbstractCheck):
             version = int(res.group('version'))
             if version > 0 and version < 1315:
                 self.output.add_info('E', self.pkg, 'obsolete-suse-version-check', version)
-            elif version > 1550:
+            elif version > 1599:
                 self.output.add_info('E', self.pkg, 'invalid-suse-version-check', version)
 
     def _checkline_package_prereq(self, line):


### PR DESCRIPTION
openSUSE Tumbleweed has %suse_version 1599 currently (up from its earlier value of 1550), so now people have started using e.g. `%if %suse_version < 1590`.
(libXISF)