### PR TITLE
No need to mention 'wheel'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=39.2",
-    "wheel"
+    "setuptools>=39.2"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
As per PEP 517, there is no need of explicitly mentioning `wheel` in `install_requires` in pyproject.toml. [Reference](https://github.com/pypa/setuptools/commit/f7d30a95) [pypa/setuptools](https://github.com/pypa/setuptools) describes that "it will be installed by
PEP 517 front-ends automatically, when building wheels."

