### PR TITLE
Releasing rpmlint as pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: rpmlint
+  name: Check RPM package errors
+  description: rpmlint is a tool for checking common errors in RPM packages. 
+  entry: rpmlint
+  language: python
+  files: \.rpm
+  types: [file]


### PR DESCRIPTION
Minimum setup needed for integration with the pre-commit system. 