### PR TITLE
pam-module whitelist: add lastlog2 (bsc#1209238)

### DIFF
--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -506,3 +506,12 @@ bug = "bsc#1205459"
 nodigests = [
     "*/security/pam_saslauthd.so",
 ]
+
+[[FileDigestGroup]]
+package = "lastlog2"
+type = "pam"
+note = "Logs user session information to an sqlite3 database"
+bug = "bsc#1209238"
+nodigests = [
+    "*/security/pam_lastlog2.so",
+]


### PR DESCRIPTION
audit complete
https://bugzilla.suse.com/show_bug.cgi?id=1209238