### PR TITLE
PythonCheck: Remove spaces from requirements before compare

### DIFF
--- a/rpmlint/checks/PythonCheck.py
+++ b/rpmlint/checks/PythonCheck.py
@@ -176,6 +176,11 @@ class PythonCheck(AbstractFilesCheck):
                 continue
 
             module_name = match.group('name').strip().lower()
+            # ignore python-base packages, that are provided by python
+            # base interpreter library
+            if module_name == 'base':
+                continue
+
             names = set(self._module_names(module_name))
 
             if not (names & requirements):

--- a/rpmlint/checks/PythonCheck.py
+++ b/rpmlint/checks/PythonCheck.py
@@ -176,9 +176,9 @@ class PythonCheck(AbstractFilesCheck):
                 continue
 
             module_name = match.group('name').strip().lower()
-            # ignore python-base packages, that are provided by python
-            # base interpreter library
-            if module_name == 'base':
+            # ignore python-base, python-devel packages, that are
+            # not python modules
+            if module_name in ('base', 'devel'):
                 continue
 
             names = set(self._module_names(module_name))

--- a/rpmlint/checks/PythonCheck.py
+++ b/rpmlint/checks/PythonCheck.py
@@ -168,14 +168,14 @@ class PythonCheck(AbstractFilesCheck):
         """
 
         pythonpac = re.compile(r'^python\d*-(?P<name>.+)$')
-        requirements = {i.lower() for i in requirements}
+        requirements = {i.strip().lower() for i in requirements}
 
         for req in pkg.req_names:
             match = pythonpac.match(req)
             if not match:
                 continue
 
-            module_name = match.group('name').lower()
+            module_name = match.group('name').strip().lower()
             names = set(self._module_names(module_name))
 
             if not (names & requirements):


### PR DESCRIPTION
I've detected errors with some packages like cloud-init.