### PR TITLE
Pytest documentation recommends refactoring "tmpdir" to "tmp_path"

### DIFF
--- a/test/test_FHS.py
+++ b/test/test_FHS.py
@@ -14,12 +14,12 @@ def fhscheck():
 
 
 @pytest.mark.parametrize('package', ['binary/non-fhs'])
-def test_FHS_compliance(tmpdir, package, fhscheck):
+def test_FHS_compliance(tmp_path, package, fhscheck):
     """
     Check that the directories are not FHS compliant.
     """
     output, test = fhscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
 
     # Check invalid /usr subdirectory

--- a/test/test_LSB.py
+++ b/test/test_LSB.py
@@ -14,12 +14,12 @@ def lsbcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/fPing'])
-def test_LSB_compliance(tmpdir, package, lsbcheck):
+def test_LSB_compliance(tmp_path, package, lsbcheck):
     """
     Check that the package name, version and release number are LSB compliant.
     """
     output, test = lsbcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
 
     # Check invalid package name

--- a/test/test_alternatives.py
+++ b/test/test_alternatives.py
@@ -19,9 +19,9 @@ def alternativescheck():
 
 
 @pytest.mark.parametrize('package', ['binary/alternatives-ok'])
-def test_update_alternative_ok(tmpdir, package, alternativescheck):
+def test_update_alternative_ok(tmp_path, package, alternativescheck):
     output, test = alternativescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'I: package-supports-update-alternatives' in out
     assert 'E' not in out
@@ -29,9 +29,9 @@ def test_update_alternative_ok(tmpdir, package, alternativescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/alternatives-borked'])
-def test_update_alternative_borked(tmpdir, package, alternativescheck):
+def test_update_alternative_borked(tmp_path, package, alternativescheck):
     output, test = alternativescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: update-alternatives-requirement-missing' in out
     assert 'E: alternative-generic-name-not-symlink' in out
@@ -40,9 +40,9 @@ def test_update_alternative_borked(tmpdir, package, alternativescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/self'])
-def test_non_update_alternative_pkg(tmpdir, package, alternativescheck):
+def test_non_update_alternative_pkg(tmp_path, package, alternativescheck):
     output, test = alternativescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # here we just check if there is no requirements checking on
     # non update-alternatived package
@@ -51,9 +51,9 @@ def test_non_update_alternative_pkg(tmpdir, package, alternativescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/python39-evtx'])
-def test_update_alternatives_correctness(tmpdir, package, alternativescheck):
+def test_update_alternatives_correctness(tmp_path, package, alternativescheck):
     output, test = alternativescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: update-alternatives-postun-call-missing' not in out
 
@@ -64,9 +64,9 @@ def test_update_alternatives_correctness(tmpdir, package, alternativescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/libalternatives-ok'])
-def test_libalternative_ok(tmpdir, package, alternativescheck):
+def test_libalternative_ok(tmp_path, package, alternativescheck):
     output, test = alternativescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'I: package-supports-libalternatives' in out
     assert 'E' not in out
@@ -74,9 +74,9 @@ def test_libalternative_ok(tmpdir, package, alternativescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/libalternatives-borked'])
-def test_libalternative_borked(tmpdir, package, alternativescheck):
+def test_libalternative_borked(tmp_path, package, alternativescheck):
     output, test = alternativescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'I: package-supports-libalternatives' in out
     assert 'I: libalternatives-conf-not-found' in out

--- a/test/test_appdata.py
+++ b/test/test_appdata.py
@@ -17,9 +17,9 @@ def appdatacheck():
 
 @pytest.mark.skipif(not HAS_APPSTREAM_GLIB, reason='Optional dependency appstream-glib not installed')
 @pytest.mark.parametrize('package', ['binary/appdata'])
-def test_appdata_fail(tmpdir, package, appdatacheck):
+def test_appdata_fail(tmp_path, package, appdatacheck):
     output, test = appdatacheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # there are two borked packages
     assert len(output.results) == 2
@@ -28,9 +28,9 @@ def test_appdata_fail(tmpdir, package, appdatacheck):
 
 @pytest.mark.parametrize('package', ['binary/appdata'])
 @patch('rpmlint.checks.AppDataCheck.AppDataCheck.cmd', 'command-really-not-found')
-def test_appdata_fail_no_checker(tmpdir, package, appdatacheck):
+def test_appdata_fail_no_checker(tmp_path, package, appdatacheck):
     output, test = appdatacheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # there is just one borked file as the other is invalid content
     # but valid xml

--- a/test/test_bashisms.py
+++ b/test/test_bashisms.py
@@ -16,9 +16,9 @@ def bashismscheck():
 @pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
 @pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('package', ['binary/bashisms'])
-def test_bashisms(tmpdir, package, bashismscheck):
+def test_bashisms(tmp_path, package, bashismscheck):
     output, test = bashismscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: potential-bashisms /bin/script1' in out
     assert 'W: bin-sh-syntax-error /bin/script2' in out
@@ -27,9 +27,9 @@ def test_bashisms(tmpdir, package, bashismscheck):
 @pytest.mark.skipif(not HAS_CHECKBASHISMS, reason='Optional dependency checkbashisms not installed')
 @pytest.mark.skipif(not HAS_DASH, reason='Optional dependency dash not installed')
 @pytest.mark.parametrize('package', ['binary/bashisms'])
-def test_bashisms_error(tmpdir, package, bashismscheck):
+def test_bashisms_error(tmp_path, package, bashismscheck):
     output, test = bashismscheck
-    package = get_tested_package(package, tmpdir)
+    package = get_tested_package(package, tmp_path)
     package.dirname = 'I-do-not-exist-for-sure'
     with pytest.raises(FileNotFoundError):
         test.check(package)

--- a/test/test_binaries.py
+++ b/test/test_binaries.py
@@ -15,51 +15,51 @@ def binariescheck():
 
 @pytest.mark.parametrize('package', ['binary/crypto-policy'])
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
-def test_forbidden_c_calls(tmpdir, package, binariescheck):
+def test_forbidden_c_calls(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'crypto-policy-non-compliance-openssl /usr/lib/cyrus-imapd/arbitron SSL_CTX_set_cipher_list' in out
     assert 'crypto-policy-non-compliance-openssl /usr/lib64/dovecot/libssl_iostream_openssl.so SSL_CTX_set_cipher_list' in out
 
 
 @pytest.mark.parametrize('package', ['binary/ngircd'])
-def test_waived_forbidden_c_calls(tmpdir, package, binariescheck):
+def test_waived_forbidden_c_calls(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'crypto-policy-non-compliance' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/libreiserfscore-devel'])
-def test_lto_bytecode(tmpdir, package, binariescheck):
+def test_lto_bytecode(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'lto-bytecode' in out
 
 
 @pytest.mark.parametrize('package', ['binary/lto-text'])
-def test_lto_archive_text(tmpdir, package, binariescheck):
+def test_lto_archive_text(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'lto-no-text-in-archive /usr/lib64/libiberty.a' in out
     assert 'lto-no-text-in-archive /usr/lib64/libdl_p.a' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/ghc'])
-def test_lto_ghc_archive(tmpdir, package, binariescheck):
+def test_lto_ghc_archive(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'lto-no-text-in-archive' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/libtool-wrapper'])
-def test_libtool_wrapper(tmpdir, package, binariescheck):
+def test_libtool_wrapper(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: libtool-wrapper-in-package' in out
     assert 'W: unstripped-binary-or-object' in out
@@ -69,27 +69,27 @@ def test_libtool_wrapper(tmpdir, package, binariescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/noarch'])
-def test_no_arch_issues(tmpdir, package, binariescheck):
+def test_no_arch_issues(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: arch-independent-package-contains-binary-or-object /bin/main' in out
     assert 'E: noarch-with-lib64' in out
 
 
 @pytest.mark.parametrize('package', ['binary/libnoexec'])
-def test_shlib_with_no_exec(tmpdir, package, binariescheck):
+def test_shlib_with_no_exec(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: shared-library-not-executable /lib64/libfoo.so' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/glibc'])
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
-def test_shlib_with_no_exec_glibc(tmpdir, package, binariescheck):
+def test_shlib_with_no_exec_glibc(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: shared-library-not-executable /lib64/libpthread.so' in out
     assert 'missing-hash-section' not in out
@@ -97,19 +97,19 @@ def test_shlib_with_no_exec_glibc(tmpdir, package, binariescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/bcc-lua'])
-def test_position_independent_executable(tmpdir, package, binariescheck):
+def test_position_independent_executable(tmp_path, package, binariescheck):
     CONFIG.configuration['PieExecutables'] = ['.*']
     output = Filter(CONFIG)
     test = BinariesCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: non-position-independent-executable /usr/bin/bcc-lua' in out
 
 
 @pytest.mark.parametrize('package', ['binary/only-non-binary-in-usr-lib'])
-def test_only_non_binary_in_usr_lib(tmpdir, package, binariescheck):
+def test_only_non_binary_in_usr_lib(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: only-non-binary-in-usr-lib' in out
     # there is a file in /usr/lib64, so no error
@@ -126,19 +126,19 @@ def test_only_non_binary_in_usr_lib(tmpdir, package, binariescheck):
 # thrown.
 @pytest.mark.parametrize('package',
                          ['binary/only-non-binary-in-usr-lib_exception'])
-def test_only_non_binary_in_usr_lib_exception(tmpdir, package, binariescheck):
+def test_only_non_binary_in_usr_lib_exception(tmp_path, package, binariescheck):
     CONFIG.configuration['UsrLibBinaryException'] = '^/usr/lib(64)?/python'
     output = Filter(CONFIG)
     test = BinariesCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: only-non-binary-in-usr-lib' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/no-binary'])
-def test_no_binary(tmpdir, package, binariescheck):
+def test_no_binary(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: no-binary' in out
     # no .la file or binary there
@@ -147,9 +147,9 @@ def test_no_binary(tmpdir, package, binariescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/invalid-la-file'])
-def test_invalid_la_file(tmpdir, package, binariescheck):
+def test_invalid_la_file(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: invalid-la-file' in out
     # no /usr/share dir there
@@ -157,9 +157,9 @@ def test_invalid_la_file(tmpdir, package, binariescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/binary-in-etc'])
-def test_binary_in_etc(tmpdir, package, binariescheck):
+def test_binary_in_etc(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: binary-in-etc' in out
     # it's not a library package
@@ -167,12 +167,12 @@ def test_binary_in_etc(tmpdir, package, binariescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/non-position-independent-exec'])
-def test_non_position_independent_sugg(tmpdir, package, binariescheck):
+def test_non_position_independent_sugg(tmp_path, package, binariescheck):
     # reset PieExecutable option
     CONFIG.configuration['PieExecutables'] = []
     output = Filter(CONFIG)
     test = BinariesCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: position-independent-executable-suggested' in out
     # it should throw just a warning as it's not forced by PieExecutables opt
@@ -181,11 +181,11 @@ def test_non_position_independent_sugg(tmpdir, package, binariescheck):
 
 # Force an error by setting PieExecutables option to the no-pie binary
 @pytest.mark.parametrize('package', ['binary/non-position-independent-exec'])
-def test_non_position_independent(tmpdir, package, binariescheck):
+def test_non_position_independent(tmp_path, package, binariescheck):
     CONFIG.configuration['PieExecutables'] = ['sparta', '.*hello']
     output = Filter(CONFIG)
     test = BinariesCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: non-position-independent-executable' in out
     # It should throw just the error, not warning
@@ -195,9 +195,9 @@ def test_non_position_independent(tmpdir, package, binariescheck):
 # libtest package
 @pytest.mark.parametrize('package', ['binary/libtest'])
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
-def test_library(tmpdir, package, binariescheck):
+def test_library(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: executable-in-library-package' in out
     assert 'W: no-soname' in out
@@ -208,9 +208,9 @@ def test_library(tmpdir, package, binariescheck):
 # invalid-soname test package
 @pytest.mark.parametrize('package', ['binary/libtest1'])
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
-def test_shared_library1(tmpdir, package, binariescheck):
+def test_shared_library1(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: invalid-soname' in out
     # there is an invalid soname here, so no "no-soname" error
@@ -220,9 +220,9 @@ def test_shared_library1(tmpdir, package, binariescheck):
 # shlib-policy-name-error test package
 @pytest.mark.parametrize('package', ['binary/libtest2'])
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
-def test_shared_library2(tmpdir, package, binariescheck):
+def test_shared_library2(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: shlib-policy-name-error' in out
     # it doesn't call /sbin/ldconfig
@@ -236,9 +236,9 @@ def test_shared_library2(tmpdir, package, binariescheck):
 # invalid-ldconfig-symlink test package
 @pytest.mark.parametrize('package', ['binary/libtest3'])
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
-def test_invalid_ldconfig_symlink(tmpdir, package, binariescheck):
+def test_invalid_ldconfig_symlink(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: invalid-ldconfig-symlink' in out
     # executable doesn't call mktemp, setuid or gethostbyname
@@ -252,18 +252,18 @@ def test_invalid_ldconfig_symlink(tmpdir, package, binariescheck):
 # valid symlink should not report invalid-ldconfig-symlink
 @pytest.mark.parametrize('package', ['binary/libtest4'])
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
-def test_not_valid_ldconfig_symlink(tmpdir, package, binariescheck):
+def test_not_valid_ldconfig_symlink(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: invalid-ldconfig-symlink' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/multiple_errors'])
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')
-def test_multiple_errors(tmpdir, package, binariescheck):
+def test_multiple_errors(tmp_path, package, binariescheck):
     output, test = binariescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: call-to-mktemp' in out
     assert 'E: missing-call-to-setgroups-before-setuid' in out

--- a/test/test_build_date.py
+++ b/test/test_build_date.py
@@ -16,20 +16,20 @@ def builddatecheck():
 
 
 @pytest.mark.parametrize('package', ['binary/builddate'])
-def test_build_date_time(tmpdir, package, builddatecheck):
+def test_build_date_time(tmp_path, package, builddatecheck):
     output, test = builddatecheck
     test.istoday = re.compile('Jan  1 2019')
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: file-contains-date-and-time /bin/with-datetime' in out
     assert 'E: file-contains-current-date /bin/with-date' in out
 
 
 @pytest.mark.parametrize('package', ['binary/bashisms'])
-def test_build_date_time_correct(tmpdir, package, builddatecheck):
+def test_build_date_time_correct(tmp_path, package, builddatecheck):
     output, test = builddatecheck
     test.istoday = re.compile('Jan  1 2019')
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: file-contains-date-and-time' not in out
     assert 'E: file-contains-current-date' not in out

--- a/test/test_build_root.py
+++ b/test/test_build_root.py
@@ -14,9 +14,9 @@ def buildrootcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/buildroot'])
-def test_build_root(tmpdir, package, buildrootcheck):
+def test_build_root(tmp_path, package, buildrootcheck):
     output, test = buildrootcheck
     test.prepare_regex('/home/marxin/rpmbuild/BUILDROOT/%{NAME}-%{VERSION}-%{RELEASE}.x86_64')
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: file-contains-buildroot /bin/trace' in out

--- a/test/test_config_files.py
+++ b/test/test_config_files.py
@@ -14,9 +14,9 @@ def configfilescheck():
 
 
 @pytest.mark.parametrize('package', ['binary/config-files'])
-def test_config_files(tmpdir, package, configfilescheck):
+def test_config_files(tmp_path, package, configfilescheck):
     output, test = configfilescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'non-etc-or-var-file-marked-as-conffile /usr/share/conffile3' in out
     assert 'conffile-without-noreplace-flag /etc/conffile1' in out
@@ -25,9 +25,9 @@ def test_config_files(tmpdir, package, configfilescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/logrotate'])
-def test_config_files_correct(tmpdir, package, configfilescheck):
+def test_config_files_correct(tmp_path, package, configfilescheck):
     output, test = configfilescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'non-etc-or-var-file-marked-as-conffile' not in out
     assert 'conffile-without-noreplace-flag' not in out

--- a/test/test_dbus_policy.py
+++ b/test/test_dbus_policy.py
@@ -14,9 +14,9 @@ def dbuspolicycheck():
 
 
 @pytest.mark.parametrize('package', ['binary/dbusrule'])
-def test_dbus_policy(tmpdir, package, dbuspolicycheck):
+def test_dbus_policy(tmp_path, package, dbuspolicycheck):
     output, test = dbuspolicycheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: dbus-parsing-exception raised an exception: no element found: line 1, column 0 /etc/dbus-1/system.d/noxml.conf' in out
     assert 'E: dbus-policy-allow-without-destination <allow send_interface="org.freedesktop.NetworkManager.PPP"/>' in out

--- a/test/test_doc.py
+++ b/test/test_doc.py
@@ -14,9 +14,9 @@ def doccheck():
 
 
 @pytest.mark.parametrize('package', ['binary/mydoc'])
-def test_doccheck(tmpdir, package, doccheck):
+def test_doccheck(tmp_path, package, doccheck):
     output, test = doccheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: executable-docs /usr/share/doc/packages/mydoc/doc.html' in out
     assert 'E: executable-docs /usr/share/doc/packages/mydoc/README' in out
@@ -24,18 +24,18 @@ def test_doccheck(tmpdir, package, doccheck):
 
 
 @pytest.mark.parametrize('package', ['binary/doc-file-dependency'])
-def test_doc_file_dep(tmpdir, package, doccheck):
+def test_doc_file_dep(tmp_path, package, doccheck):
     output, test = doccheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: doc-file-dependency' in out
     assert 'W: install-file-in-docs' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/install-file-in-docs'])
-def test_install_file_in_docs(tmpdir, package, doccheck):
+def test_install_file_in_docs(tmp_path, package, doccheck):
     output, test = doccheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: install-file-in-docs' in out
     assert 'E: executable-docs' not in out

--- a/test/test_duplicates.py
+++ b/test/test_duplicates.py
@@ -14,9 +14,9 @@ def duplicatescheck():
 
 
 @pytest.mark.parametrize('package', ['binary/duplicates'])
-def test_duplicates(tmpdir, package, duplicatescheck):
+def test_duplicates(tmp_path, package, duplicatescheck):
     output, test = duplicatescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
 
     assert 'E: hardlink-across-partition /var/foo /etc/foo' in out
@@ -28,9 +28,9 @@ def test_duplicates(tmpdir, package, duplicatescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/bad-crc-uncompressed'])
-def test_duplicates_correct(tmpdir, package, duplicatescheck):
+def test_duplicates_correct(tmp_path, package, duplicatescheck):
     output, test = duplicatescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
 
     assert 'E: hardlink-across-partition' not in out

--- a/test/test_erlang.py
+++ b/test/test_erlang.py
@@ -16,9 +16,9 @@ def erlangcheck():
 
 @pytest.mark.skipif(get_distribution('pybeam').parsed_version < parse_version('0.7'), reason='pybeam >= 0.7 required')
 @pytest.mark.parametrize('package', ['binary/erlang-test'])
-def test_erlang(tmpdir, package, erlangcheck):
+def test_erlang(tmp_path, package, erlangcheck):
     output, test = erlangcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: beam-compiled-without-debuginfo /usr/lib/erlang/m.beam' in out
     assert 'W: beam-compile-info-missed /usr/lib/erlang/m-no-CInf.beam' in out

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -40,26 +40,26 @@ def chunk_from_pyc(version, size=16):
 
 
 @pytest.mark.parametrize('package', ['binary/unexpanded-macro-files'])
-def test_unexpanded_macros(tmpdir, package, filescheck):
+def test_unexpanded_macros(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'unexpanded-macro' in out
 
 
 @pytest.mark.parametrize('package', ['binary/python3-power'])
-def test_python_bytecode_magic(tmpdir, package, filescheck):
+def test_python_bytecode_magic(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     assert not output.results
     out = output.print_results(output.results)
     assert 'python-bytecode-wrong-magic-value' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/testdocumentation'])
-def test_file_not_utf8_for_compression_algorithms(tmpdir, package, filescheck):
+def test_file_not_utf8_for_compression_algorithms(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'file-not-utf8 /usr/share/doc/packages/testdocumentation/README1.gz' in out
     assert 'file-not-utf8 /usr/share/doc/packages/testdocumentation/README2.bz2' in out
@@ -79,9 +79,9 @@ def test_pyc_mtime_from_chunk(version, mtime):
 
 
 @pytest.mark.parametrize('package', ['binary/netmask-debugsource'])
-def test_devel_files(tmpdir, package, filescheck):
+def test_devel_files(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     assert len(output.results) == 5
     out = output.print_results(output.results)
     assert 'devel-file-in-non-devel-package' not in out
@@ -90,25 +90,25 @@ def test_devel_files(tmpdir, package, filescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/makefile-junk'])
-def test_makefile_junk(tmpdir, package, filescheck):
+def test_makefile_junk(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: makefile-junk /usr/share/Makefile.am' in out
     assert out.count('W: makefile-junk') == 1
 
 
 @pytest.mark.parametrize('package', ['binary/python3-greenlet'])
-def test_sphinx_inv_files(tmpdir, package, filescheck):
+def test_sphinx_inv_files(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     assert not len(output.results)
 
 
 @pytest.mark.parametrize('package', ['binary/filechecks'])
-def test_invalid_package(tmpdir, package, filescheck):
+def test_invalid_package(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: non-ghost-in-run /run/foo' in out
     assert 'W: systemd-unit-in-etc /etc/systemd/system/foo' in out
@@ -124,9 +124,9 @@ def test_invalid_package(tmpdir, package, filescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/tclpackage'])
-def test_tcl_package(tmpdir, package, filescheck):
+def test_tcl_package(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: tcl-extension-file /usr/lib64/tcl/pkgIndex.tcl' in out
 
@@ -169,18 +169,18 @@ def test_lib_regex():
 
 
 @pytest.mark.parametrize('package', ['binary/rust'])
-def test_rust_files(tmpdir, package, filescheck):
+def test_rust_files(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: wrong-script-interpreter /etc/foo.rs' in out
     assert 'E: wrong-script-interpreter /etc/bar.rs' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/ngircd'])
-def test_distribution_tags(tmpdir, package, filescheck):
+def test_distribution_tags(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'manpage-not-compressed' in out
     assert 'no-manual-page-for-binary' not in out
@@ -188,17 +188,17 @@ def test_distribution_tags(tmpdir, package, filescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/development'])
-def test_provides_devel(tmpdir, package, filescheck):
+def test_provides_devel(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: non-devel-file-in-devel-package /usr/x.typelib' in out
 
 
 @pytest.mark.parametrize('package', ['binary/shlib1'])
-def test_shlib1(tmpdir, package, filescheck):
+def test_shlib1(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'library-without-ldconfig-postin' in out
     assert 'library-without-ldconfig-postun' in out
@@ -206,9 +206,9 @@ def test_shlib1(tmpdir, package, filescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/shlib2-devel'])
-def test_shlib2_devel(tmpdir, package, filescheck):
+def test_shlib2_devel(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'library-without-ldconfig-postin' in out
     assert 'library-without-ldconfig-postun' in out
@@ -226,9 +226,9 @@ def test_shlib2_devel(tmpdir, package, filescheck):
      ('/usr/lib/python/py.typed', False),
      ('/usr/lib/python/pypackagefromwheel-0.0.0.dist-info/REQUESTED', False),
      ('/usr/lib/ruby/gem.build_complete', False)])
-def test_zero_length_ignore(tmpdir, package, filescheck, filename, show):
+def test_zero_length_ignore(tmp_path, package, filescheck, filename, show):
     output, test = filescheck
-    pkg = get_tested_package(package, tmpdir)
+    pkg = get_tested_package(package, tmp_path)
     test.check(pkg)
     out = output.print_results(output.results)
     assert filename in pkg.files
@@ -236,9 +236,9 @@ def test_zero_length_ignore(tmpdir, package, filescheck, filename, show):
 
 
 @pytest.mark.parametrize('package', ['binary/manual-pages'])
-def test_manual_pages(tmpdir, package, filescheck):
+def test_manual_pages(tmp_path, package, filescheck):
     output, test = filescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: manual-page-in-subfolder /usr/share/man/man3/foo/bar/baz.3.gz' in out
     assert 'W: manpage-not-compressed bz2 /usr/share/man/man1/test.1.zst' in out

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -22,14 +22,14 @@ def test_filters_regexp():
     assert cfg.configuration['Filters'][0] == '.*invalid-buildhost.*'
 
 
-def test_data_storing(tmpdir):
+def test_data_storing(tmp_path):
     """
     Load some filters and make sure we generate nice regexp
     """
     cfg = Config(TEST_CONFIG_FILTERS)
     cfg.load_rpmlintrc(TEST_RPMLINTRC)
     result = Filter(cfg)
-    pkg = get_tested_package(TEST_PACKAGE, tmpdir)
+    pkg = get_tested_package(TEST_PACKAGE, tmp_path)
     # this should be upgraded to error
     result.add_info('I', pkg, 'suse-other-error', '')
     assert len(result.results) == 1
@@ -42,7 +42,7 @@ def test_data_storing(tmpdir):
     assert result.printed_messages['E'] == 1
 
 
-def test_data_storing_backward_compat(tmpdir):
+def test_data_storing_backward_compat(tmp_path):
     """
     Make sure we can load some filters from rpmlintrc that
     worked with rpmlint v1.
@@ -56,7 +56,7 @@ def test_data_storing_backward_compat(tmpdir):
     assert 'doublequotes-instead-of-singlequotes' in parsed_filters
 
 
-def test_description_storing(tmpdir):
+def test_description_storing(tmp_path):
     """
     Test if we can store extra destcriptions and formatting is up par
     """
@@ -68,7 +68,7 @@ eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt
 in culpa qui officia deserunt mollit anim id est laborum.\n\n"""
     cfg = Config(TEST_CONFIG_FILTERS)
     result = Filter(cfg)
-    pkg = get_tested_package(TEST_PACKAGE, tmpdir)
+    pkg = get_tested_package(TEST_PACKAGE, tmp_path)
     assert len(result.results) == 0
     result.add_info('E', pkg, 'suse-dbus-unauthorized-service', '')
     # two options so we check the description is added only once
@@ -80,7 +80,7 @@ in culpa qui officia deserunt mollit anim id est laborum.\n\n"""
     assert result.get_description('suse-other-error') == lorem_formated
 
 
-def test_description_from_toml(tmpdir):
+def test_description_from_toml(tmp_path):
     """
     Test if description loaded from toml shows up details
     """
@@ -90,7 +90,7 @@ def test_description_from_toml(tmpdir):
     assert result.get_description('uncompressed-zip') == 'The zip file is not compressed.\n\n'
 
 
-def test_description_from_conf(tmpdir):
+def test_description_from_conf(tmp_path):
     """
     Test that descriptions strings are updated from configuration file.
 
@@ -122,7 +122,7 @@ def test_description_from_conf(tmpdir):
         'A new text for non-standard-dir-in-var error.\n\n'
 
 
-def test_output(tmpdir):
+def test_output(tmp_path):
     """
     Test the actual output of rpmlint on one file
     """
@@ -139,8 +139,8 @@ in culpa qui officia deserunt mollit anim id est laborum.
 ngircd.x86_64: E: suse-dbus-unauthorized-service\n"""
     cfg = Config(TEST_CONFIG_FILTERS)
     result = Filter(cfg)
-    pkg = get_tested_package(TEST_PACKAGE, tmpdir)
-    pkg2 = get_tested_package(TEST_PACKAGE2, tmpdir)
+    pkg = get_tested_package(TEST_PACKAGE, tmp_path)
+    pkg2 = get_tested_package(TEST_PACKAGE2, tmp_path)
     # here we check if empty detail will not add whitespace
     result.add_info('E', pkg, 'suse-dbus-unauthorized-service', '')
     # two options so we check the description is added only once
@@ -154,10 +154,10 @@ ngircd.x86_64: E: suse-dbus-unauthorized-service\n"""
     assert result.print_results(result.results) == expected_output
 
 
-def test_filtered_output(tmpdir):
+def test_filtered_output(tmp_path):
     cfg = Config(TEST_CONFIG_FILTERS)
     result = Filter(cfg)
-    pkg = get_tested_package(TEST_PACKAGE, tmpdir)
+    pkg = get_tested_package(TEST_PACKAGE, tmp_path)
     assert len(result.results) == 0
     result.add_info('E', pkg, 'no-regex', '')
     result.add_info('E', pkg, 'no-regex-with-leading-space', '')
@@ -166,11 +166,11 @@ def test_filtered_output(tmpdir):
     assert len(result.results) == 0
 
 
-def test_blocked_filters(tmpdir):
+def test_blocked_filters(tmp_path):
     key = 'fatal-error'
     cfg = Config(TEST_CONFIG_FILTERS)
     result = Filter(cfg)
-    pkg = get_tested_package(TEST_PACKAGE, tmpdir)
+    pkg = get_tested_package(TEST_PACKAGE, tmp_path)
     assert len(result.results) == 0
     assert key in cfg.configuration['Filters']
     result.add_info('E', pkg, key, '')

--- a/test/test_icon_sizes.py
+++ b/test/test_icon_sizes.py
@@ -14,8 +14,8 @@ def iconsizescheck():
 
 
 @pytest.mark.parametrize('package', ['binary/tasque'])
-def test_icon_sizes(tmpdir, package, iconsizescheck):
+def test_icon_sizes(tmp_path, package, iconsizescheck):
     output, test = iconsizescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: wrong-icon-size /usr/share/tasque/icons/hicolor/16x16/status/tasque-note.png expected: 16x16 actual: 22x22' in out

--- a/test/test_lib_dependency.py
+++ b/test/test_lib_dependency.py
@@ -14,9 +14,9 @@ def libdependencycheck():
 
 
 @pytest.mark.parametrize('package', ['binary/shlib2-devel'])
-def test_shlib2_devel(tmpdir, package, libdependencycheck):
+def test_shlib2_devel(tmp_path, package, libdependencycheck):
     output, test = libdependencycheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     test.after_checks()
     out = output.print_results(output.results)
     assert 'E: no-library-dependency-for /usr/lib/libfoo.so.1' in out

--- a/test/test_logrotate.py
+++ b/test/test_logrotate.py
@@ -14,9 +14,9 @@ def logrotatecheck():
 
 
 @pytest.mark.parametrize('package', ['binary/logrotate'])
-def test_logrotate(tmpdir, package, logrotatecheck):
+def test_logrotate(tmp_path, package, logrotatecheck):
     output, test = logrotatecheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: logrotate-log-dir-not-packaged /var/log/myapp' in out
     assert 'E: logrotate-duplicate /var/log/myapp' in out

--- a/test/test_menuxdg.py
+++ b/test/test_menuxdg.py
@@ -15,9 +15,9 @@ def menuxdgcheck():
 
 @pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/menuxdg1'])
-def test_raises_parse_error(tmpdir, package, menuxdgcheck):
+def test_raises_parse_error(tmp_path, package, menuxdgcheck):
     output, test = menuxdgcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     assert len(output.results) == 4
     out = output.print_results(output.results)
     assert 'contains parsing error' in out
@@ -27,18 +27,18 @@ def test_raises_parse_error(tmpdir, package, menuxdgcheck):
 
 @pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/desktopfile-bad-binary'])
-def test_without_binary(tmpdir, package, menuxdgcheck):
+def test_without_binary(tmp_path, package, menuxdgcheck):
     output, test = menuxdgcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'desktopfile-without-binary' in out
 
 
 @pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/desktopfile-bad-duplicate'])
-def test_duplicate(tmpdir, package, menuxdgcheck):
+def test_duplicate(tmp_path, package, menuxdgcheck):
     output, test = menuxdgcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'desktopfile-duplicate-section' in out
     assert 'invalid-desktopfile' in out
@@ -46,9 +46,9 @@ def test_duplicate(tmpdir, package, menuxdgcheck):
 
 @pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/desktopfile-bad-section'])
-def test_missing_header(tmpdir, package, menuxdgcheck):
+def test_missing_header(tmp_path, package, menuxdgcheck):
     output, test = menuxdgcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'desktopfile-missing-header' in out
     assert 'invalid-desktopfile' in out
@@ -56,17 +56,17 @@ def test_missing_header(tmpdir, package, menuxdgcheck):
 
 @pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/desktopfile-bad-unicode'])
-def test_bad_unicode(tmpdir, package, menuxdgcheck):
+def test_bad_unicode(tmp_path, package, menuxdgcheck):
     output, test = menuxdgcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'non-utf8-desktopfile' in out
 
 
 @pytest.mark.skipif(not HAS_DESKTOP_FILE_UTILS, reason='Optional dependency desktop-file-utils not installed')
 @pytest.mark.parametrize('package', ['binary/desktopfile-good'])
-def test_good(tmpdir, package, menuxdgcheck):
+def test_good(tmp_path, package, menuxdgcheck):
     output, test = menuxdgcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert not out

--- a/test/test_mixed_ownership.py
+++ b/test/test_mixed_ownership.py
@@ -14,9 +14,9 @@ def mixedownershipcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/mixed-ownership'])
-def test_mixed_ownership(tmpdir, package, mixedownershipcheck):
+def test_mixed_ownership(tmp_path, package, mixedownershipcheck):
     output, test = mixedownershipcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'noproblem' not in out
     assert 'file-parent-ownership-mismatch Path "/var/lib/badfolder/broken1" owned by "root" is stored in directory owned by "nobody"' in out

--- a/test/test_pam_modules.py
+++ b/test/test_pam_modules.py
@@ -14,8 +14,8 @@ def pammodulecheck():
 
 
 @pytest.mark.parametrize('package', ['binary/pam-module'])
-def test_pam_modules(tmpdir, package, pammodulecheck):
+def test_pam_modules(tmp_path, package, pammodulecheck):
     output, test = pammodulecheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: pam-unauthorized-module pam-module.so' in out

--- a/test/test_pkgconfig.py
+++ b/test/test_pkgconfig.py
@@ -14,9 +14,9 @@ def pkgconfigcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/pc'])
-def test_pkg_config(tmpdir, package, pkgconfigcheck):
+def test_pkg_config(tmp_path, package, pkgconfigcheck):
     output, test = pkgconfigcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: invalid-pkgconfig-file /tmp/pkgconfig/xcb.pc' in out
     assert 'E: pkgconfig-invalid-libs-dir /tmp/pkgconfig/xcb.pc Libs: -L/usr/lib' in out
@@ -24,9 +24,9 @@ def test_pkg_config(tmpdir, package, pkgconfigcheck):
 
 
 @pytest.mark.parametrize('package', ['binary/libreiserfscore-devel'])
-def test_pkg_config_correct(tmpdir, package, pkgconfigcheck):
+def test_pkg_config_correct(tmp_path, package, pkgconfigcheck):
     output, test = pkgconfigcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: invalid-pkgconfig-file' not in out
     assert 'E: pkgconfig-invalid-libs-dir' not in out

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -14,9 +14,9 @@ def pythoncheck():
 
 
 @pytest.mark.parametrize('package', ['binary/pythoncheck-python-doc-in-package'])
-def test_python_doc_in_package(tmpdir, package, pythoncheck):
+def test_python_doc_in_package(tmp_path, package, pythoncheck):
     output, test = pythoncheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: python-doc-in-package /usr/lib/python2.7/site-packages/python-mypackage/doc' in out
     assert 'W: python-doc-in-package /usr/lib/python2.7/site-packages/python-mypackage/docs' in out
@@ -29,9 +29,9 @@ def test_python_doc_in_package(tmpdir, package, pythoncheck):
 
 
 @pytest.mark.parametrize('package', ['binary/pythoncheck-python-doc-module-in-package'])
-def test_python_doc_module_in_package(tmpdir, package, pythoncheck):
+def test_python_doc_module_in_package(tmp_path, package, pythoncheck):
     output, test = pythoncheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: python-doc-in-package /usr/lib/python2.7/site-packages/python-mypackage/doc' not in out
     assert 'W: python-doc-in-package /usr/lib/python2.7/site-packages/python-mypackage/docs' not in out
@@ -44,9 +44,9 @@ def test_python_doc_module_in_package(tmpdir, package, pythoncheck):
 
 
 @pytest.mark.parametrize('package', ['binary/pythoncheck-python-egg-info-distutils-style'])
-def test_python_distutils_egg_info(tmpdir, package, pythoncheck):
+def test_python_distutils_egg_info(tmp_path, package, pythoncheck):
     output, test = pythoncheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: python-egg-info-distutils-style /usr/lib/python2.7/site-packages/mydistutilspackage.egg-info' in out
     assert 'E: python-egg-info-distutils-style /usr/lib/python3.10/site-packages/mydistutilspackage.egg-info' in out
@@ -55,9 +55,9 @@ def test_python_distutils_egg_info(tmpdir, package, pythoncheck):
 
 
 @pytest.mark.parametrize('package', ['binary/pythoncheck-python-doc-in-site-packages'])
-def test_python_doc_in_site_packages(tmpdir, package, pythoncheck):
+def test_python_doc_in_site_packages(tmp_path, package, pythoncheck):
     output, test = pythoncheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: python-doc-in-site-packages /usr/lib/python2.7/site-packages/doc' in out
     assert 'E: python-doc-in-site-packages /usr/lib/python2.7/site-packages/docs' in out
@@ -70,9 +70,9 @@ def test_python_doc_in_site_packages(tmpdir, package, pythoncheck):
 
 
 @pytest.mark.parametrize('package', ['binary/pythoncheck-python-src-in-site-packages'])
-def test_python_src_in_site_packages(tmpdir, package, pythoncheck):
+def test_python_src_in_site_packages(tmp_path, package, pythoncheck):
     output, test = pythoncheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: python-src-in-site-packages /usr/lib/python2.7/site-packages/src' in out
     assert 'E: python-src-in-site-packages /usr/lib/python3.10/site-packages/src' in out
@@ -81,9 +81,9 @@ def test_python_src_in_site_packages(tmpdir, package, pythoncheck):
 
 
 @pytest.mark.parametrize('package', ['binary/pythoncheck-python-tests-in-site-packages'])
-def test_python_tests_in_site_packages(tmpdir, package, pythoncheck):
+def test_python_tests_in_site_packages(tmp_path, package, pythoncheck):
     output, test = pythoncheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: python-tests-in-site-packages /usr/lib/python2.7/site-packages/test' in out
     assert 'E: python-tests-in-site-packages /usr/lib/python2.7/site-packages/tests' in out
@@ -99,9 +99,9 @@ def test_python_tests_in_site_packages(tmpdir, package, pythoncheck):
     'binary/python3-flit-3.8.0',
     'binary/python3-icecream-2.1.3',
 ])
-def test_python_dependencies(tmpdir, package, pythoncheck):
+def test_python_dependencies(tmp_path, package, pythoncheck):
     output, test = pythoncheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: python-missing-require' not in out
     assert 'W: python-leftover-require' not in out
@@ -111,9 +111,9 @@ def test_python_dependencies(tmpdir, package, pythoncheck):
     'binary/python3-icecream-missingdeps',
     'binary/python3-flit-missingdeps',
 ])
-def test_python_dependencies_missing(tmpdir, package, pythoncheck):
+def test_python_dependencies_missing(tmp_path, package, pythoncheck):
     output, test = pythoncheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: python-missing-require' in out
 
@@ -122,8 +122,8 @@ def test_python_dependencies_missing(tmpdir, package, pythoncheck):
     'binary/python3-icecream-leftovers',
     'binary/python3-flit-leftovers',
 ])
-def test_python_dependencies_leftover(tmpdir, package, pythoncheck):
+def test_python_dependencies_leftover(tmp_path, package, pythoncheck):
     output, test = pythoncheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: python-leftover-require' in out

--- a/test/test_shlib_policy.py
+++ b/test/test_shlib_policy.py
@@ -14,24 +14,24 @@ def slpcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/libtest1'])
-def test_shlib_policy_wrong_name(tmpdir, package, slpcheck):
+def test_shlib_policy_wrong_name(tmp_path, package, slpcheck):
     output, test = slpcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: shlib-unversioned-lib libtest.so.1x' in out
 
 
 @pytest.mark.parametrize('package', ['binary/libslp-missing-suffix'])
-def test_shlib_policy_missing_suffix(tmpdir, package, slpcheck):
+def test_shlib_policy_missing_suffix(tmp_path, package, slpcheck):
     output, test = slpcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: shlib-policy-excessive-dependency libsparta.so.2' in out
 
 
 @pytest.mark.parametrize('package', ['binary/libslp1234'])
-def test_shlib_policy_errors(tmpdir, package, slpcheck):
+def test_shlib_policy_errors(tmp_path, package, slpcheck):
     output, test = slpcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: shlib-fixed-dependency libsparta.so.2 = 1.23' in out

--- a/test/test_signature.py
+++ b/test/test_signature.py
@@ -15,9 +15,9 @@ def signaturecheck():
 
 # The signature was stripped via "rpmsign --delsign <package>"
 @pytest.mark.parametrize('package', ['binary/no-signature'])
-def test_no_signature(tmpdir, package, signaturecheck):
+def test_no_signature(tmp_path, package, signaturecheck):
     output, test = signaturecheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: no-signature' in out
     assert 'E: unknown-key' not in out
@@ -27,9 +27,9 @@ def test_no_signature(tmpdir, package, signaturecheck):
 # The test rpm was signed with gpg key created for this purpose that is not
 # imported in rpm db and therefore unknown-key error should be thrown
 @pytest.mark.parametrize('package', ['binary/unknown-key'])
-def test_unknown_key(tmpdir, package, signaturecheck):
+def test_unknown_key(tmp_path, package, signaturecheck):
     output, test = signaturecheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: unknown-key 31fdc502' in out
     assert 'E: no-signature' not in out
@@ -42,9 +42,9 @@ def test_unknown_key(tmpdir, package, signaturecheck):
 # of=hello-2.0-1.x86_64-signed.rpm conv=notrunc bs=1 seek=264 count=6
 # 2> /dev/null"
 @pytest.mark.parametrize('package', ['binary/hello'])
-def test_invalid_signature(tmpdir, package, signaturecheck):
+def test_invalid_signature(tmp_path, package, signaturecheck):
     output, test = signaturecheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: invalid-signature' in out
     assert 'E: no-signature' not in out

--- a/test/test_sources.py
+++ b/test/test_sources.py
@@ -14,9 +14,9 @@ def sourcescheck():
 
 
 @pytest.mark.parametrize('package', ['source/wrongsrc'])
-def test_extension_and_permissions(tmpdir, package, sourcescheck):
+def test_extension_and_permissions(tmp_path, package, sourcescheck):
     output, test = sourcescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
 
     assert len(output.results) == 1
@@ -29,9 +29,9 @@ def test_extension_and_permissions(tmpdir, package, sourcescheck):
 
 
 @pytest.mark.parametrize('package', ['source/not-compressed-multi-spec'])
-def test_compression_and_multispec(tmpdir, package, sourcescheck):
+def test_compression_and_multispec(tmp_path, package, sourcescheck):
     output, test = sourcescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
 
     assert 'source-not-compressed' in out

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -15,9 +15,9 @@ def speccheck():
     return output, test
 
 
-def test_check_include(tmpdir, speccheck):
+def test_check_include(tmp_path, speccheck):
     output, test = speccheck
-    test.check_source(get_tested_package('source/CheckInclude', tmpdir))
+    test.check_source(get_tested_package('source/CheckInclude', tmp_path))
     out = output.print_results(output.results)
     assert "specfile-error can't parse specfile" not in out
     assert 'no-buildroot-tag' in out
@@ -67,19 +67,19 @@ def test_forbidden_controlchars_found(package, speccheck):
 
 
 @pytest.mark.parametrize('package', ['source/no-spec-file'])
-def test_check_no_spec_file(tmpdir, package, speccheck):
+def test_check_no_spec_file(tmp_path, package, speccheck):
     """Test if spec file is not found inside RPM metadata."""
     output, test = speccheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: no-spec-file' in out
 
 
 @pytest.mark.parametrize('package', ['source/CheckInclude'])
-def test_check_no_spec_file_not_applied(tmpdir, package, speccheck):
+def test_check_no_spec_file_not_applied(tmp_path, package, speccheck):
     """Test if there is no spec file inside RPM metadata."""
     output, test = speccheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: no-spec-file' not in out
 
@@ -105,19 +105,19 @@ def test_check_non_utf8_spec_file_not_applied(package, speccheck):
 
 
 @pytest.mark.parametrize('package', ['source/invalid-spec-name'])
-def test_check_invalid_spec_name(tmpdir, package, speccheck):
+def test_check_invalid_spec_name(tmp_path, package, speccheck):
     """Test if specfile name does not matches the ('Name: ') tag."""
     output, test = speccheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: invalid-spec-name' in out
 
 
 @pytest.mark.parametrize('package', ['source/CheckInclude'])
-def test_check_invalid_spec_name_not_applied(tmpdir, package, speccheck):
+def test_check_invalid_spec_name_not_applied(tmp_path, package, speccheck):
     """Test if specfile has specfile name as ('Name: ') tag."""
     output, test = speccheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: invalid-spec-name' not in out
 

--- a/test/test_sysvinitonsystemd.py
+++ b/test/test_sysvinitonsystemd.py
@@ -14,9 +14,9 @@ def sysvcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/init'])
-def test_sysv_init_on_systemd_check(tmpdir, package, sysvcheck):
+def test_sysv_init_on_systemd_check(tmp_path, package, sysvcheck):
     output, test = sysvcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: obsolete-insserv-requirement' in out
     assert 'E: deprecated-init-script weekly.script' in out
@@ -24,8 +24,8 @@ def test_sysv_init_on_systemd_check(tmpdir, package, sysvcheck):
 
 
 @pytest.mark.parametrize('package', ['binary/rc-links'])
-def test_overshadowing_of_initscript(tmpdir, package, sysvcheck):
+def test_overshadowing_of_initscript(tmp_path, package, sysvcheck):
     output, test = sysvcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: systemd-shadowed-initscript bar' in out

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -14,9 +14,9 @@ def tagscheck():
 
 
 @pytest.mark.parametrize('package', ['binary/unexpanded1'])
-def test_unexpanded_macros(tmpdir, package, tagscheck):
+def test_unexpanded_macros(tmp_path, package, tagscheck):
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'unexpanded-macro Recommends' in out
     assert 'unexpanded-macro Provides' in out
@@ -27,100 +27,100 @@ def test_unexpanded_macros(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/self'])
-def test_self_provides(tmpdir, package, tagscheck):
+def test_self_provides(tmp_path, package, tagscheck):
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: useless-provides self' in out
 
 
 @pytest.mark.parametrize('package', ['binary/fuse-common'])
-def test_useless_provides_only_versions(tmpdir, package, tagscheck):
+def test_useless_provides_only_versions(tmp_path, package, tagscheck):
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: useless-provides self' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/foo-devel'])
-def test_development_package(tmpdir, package, tagscheck):
+def test_development_package(tmp_path, package, tagscheck):
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: devel-package-with-non-devel-group Games' in out
 
 
 @pytest.mark.parametrize('package', ['binary/missingprovides'])
-def test_missing_provides(tmpdir, package, tagscheck):
+def test_missing_provides(tmp_path, package, tagscheck):
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: no-pkg-config-provides' in out
 
 
 @pytest.mark.parametrize('package', ['binary/invalid-exception'])
-def test_invalid_license_exception(tmpdir, package, tagscheck):
+def test_invalid_license_exception(tmp_path, package, tagscheck):
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: invalid-license-exception sparta' in out
 
 
 @pytest.mark.parametrize('package', ['binary/valid-exception'])
-def test_valid_license_exception(tmpdir, package, tagscheck):
+def test_valid_license_exception(tmp_path, package, tagscheck):
     CONFIG.info = True
     CONFIG.configuration['ValidLicenseExceptions'] = ['389-exception']
     output = Filter(CONFIG)
     test = TagsCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: invalid-license-exception' not in out
 
 
 @pytest.mark.parametrize('package', ['source/valid-exception-in-grouping'])
-def test_valid_license_exception_in_grouping(tmpdir, package, tagscheck):
+def test_valid_license_exception_in_grouping(tmp_path, package, tagscheck):
     CONFIG.info = True
     CONFIG.configuration['ValidLicenses'] = ['BSD-3-Clause', 'GPL-2.0-only']
     CONFIG.configuration['ValidLicenseExceptions'] = ['Qt-GPL-exception-1.0']
     output = Filter(CONFIG)
     test = TagsCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: invalid-license-exception' not in out
 
 
 @pytest.mark.parametrize('package', ['source/valid-exception-begin-grouping'])
-def test_valid_license_exception_begin_grouping(tmpdir, package, tagscheck):
+def test_valid_license_exception_begin_grouping(tmp_path, package, tagscheck):
     CONFIG.info = True
     CONFIG.configuration['ValidLicenses'] = ['BSD-3-Clause', 'GPL-2.0-only']
     CONFIG.configuration['ValidLicenseExceptions'] = ['Qt-GPL-exception-1.0']
     output = Filter(CONFIG)
     test = TagsCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: invalid-license-exception' not in out
 
 
 @pytest.mark.parametrize('package', ['binary/xtables-addons-kmp-default'])
-def test_forbidden_controlchar_found_requires(tmpdir, package, tagscheck):
+def test_forbidden_controlchar_found_requires(tmp_path, package, tagscheck):
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: forbidden-controlchar-found Requires:' in out
 
 
 @pytest.mark.parametrize('package', ['binary/ruby2.6-rubygem-fast_gettext'])
-def test_forbidden_controlchar_found_changelog(tmpdir, package, tagscheck):
+def test_forbidden_controlchar_found_changelog(tmp_path, package, tagscheck):
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: forbidden-controlchar-found %changelog' in out
 
 
 @pytest.mark.parametrize('package', ['binary/SpecCheck4'])
-def test_forbidden_controlchar_found(tmpdir, package, tagscheck):
+def test_forbidden_controlchar_found(tmp_path, package, tagscheck):
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: forbidden-controlchar-found Requires:' in out
     assert 'E: forbidden-controlchar-found Provides:' in out
@@ -130,10 +130,10 @@ def test_forbidden_controlchar_found(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/unexpanded-macro-exp'])
-def test_check_unexpanded_macro(tmpdir, package, tagscheck):
+def test_check_unexpanded_macro(tmp_path, package, tagscheck):
     """Test if a package has an unexpanded macro in it's specfile."""
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: unexpanded-macro Packager %ppc' in out
     assert 'W: unexpanded-macro Group %ppc' in out
@@ -148,10 +148,10 @@ def test_check_unexpanded_macro(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/invalid-version'])
-def test_check_errors(tmpdir, package, tagscheck):
+def test_check_errors(tmp_path, package, tagscheck):
     """Test package for check invalid-version."""
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package has a Version: tag with pre/alpha/beta suffixes in it's specfile
     assert 'E: invalid-version 0pre' in out
@@ -161,7 +161,7 @@ def test_check_errors(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/summary-warning'])
-def test_check_summary_warning(tmpdir, package, tagscheck):
+def test_check_summary_warning(tmp_path, package, tagscheck):
     """Test package for check
     - in out,
         summary-too-long, summary-has-leading-spaces,
@@ -170,7 +170,7 @@ def test_check_summary_warning(tmpdir, package, tagscheck):
     invalid-version, unexpanded-macro.
     """
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if package has a summary longer than 80 characters
     assert 'E: summary-too-long' in out
@@ -189,12 +189,12 @@ def test_check_summary_warning(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/no-url-tag'])
-def test_check_warning(tmpdir, package, tagscheck):
+def test_check_warning(tmp_path, package, tagscheck):
     """Test if a package contains the warning for
     summary-not-capitalized, summary-ended-with-dot,
     no-url-tag."""
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if package Summary does not start with a capital letter
     assert 'W: summary-not-capitalized no-url-tag warning.' in out
@@ -205,14 +205,14 @@ def test_check_warning(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/invalid-la-file'])
-def test_check_errors_not_found(tmpdir, package, tagscheck):
+def test_check_errors_not_found(tmp_path, package, tagscheck):
     """Test packages for checks
     summary-too-long, summary-not-capitalized,
     summary-ended-with-dot, summary-has-leading-spaces,
     no-url-tag, description-shorter-than-summary.
     """
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package Summary is not longer than 80 characters
     assert 'W: summary-too-long' not in out
@@ -229,11 +229,11 @@ def test_check_errors_not_found(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/misc-warnings'])
-def test_check_misc_warning(tmpdir, package, tagscheck):
+def test_check_misc_warning(tmp_path, package, tagscheck):
     """Test package for check tag-in-description,
     name-repeated-in-summary, invalid-url."""
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package has a tag such as Name: in the description
     assert 'W: tag-in-description Name:' in out
@@ -244,11 +244,11 @@ def test_check_misc_warning(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/misc-no-warnings'])
-def test_check_misc_warning_not_found(tmpdir, package, tagscheck):
+def test_check_misc_warning_not_found(tmp_path, package, tagscheck):
     """Test package for check not in out
     tag-in-description, name-repeated-in-summary, invalid-url."""
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package does not have a tag in description
     assert 'W: tag-in-description' not in out
@@ -259,11 +259,11 @@ def test_check_misc_warning_not_found(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/invalid-dependency'])
-def test_check_invalid_dependency(tmpdir, package, tagscheck):
+def test_check_invalid_dependency(tmp_path, package, tagscheck):
     """Test if a package has
     invalid-dependency, no-description-tag, unreasonable-epoch."""
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package has a Epoch tag value greater than 99
     assert 'W: unreasonable-epoch 100' in out
@@ -274,7 +274,7 @@ def test_check_invalid_dependency(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/random-exp'])
-def test_package_random_warnings(tmpdir, package, tagscheck):
+def test_package_random_warnings(tmp_path, package, tagscheck):
     """Test if a package has check,
     - in out,
         obsolete-not-provided
@@ -285,7 +285,7 @@ def test_package_random_warnings(tmpdir, package, tagscheck):
         no-description-tag,
         self-obsoletion."""
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package that was obsoleted is still provided
     # in newer package to avoid unnecessary dependency breakage
@@ -304,7 +304,7 @@ def test_package_random_warnings(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/random-devel'])
-def test_package_random_exp(tmpdir, package, tagscheck):
+def test_package_random_exp(tmp_path, package, tagscheck):
     """Test if a package check,
     - in out,
         self-obsoletion,
@@ -313,7 +313,7 @@ def test_package_random_exp(tmpdir, package, tagscheck):
         description-line-too-long,
         devel-dependency."""
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package obsoletes itself i.e. Obsoletes: random-devel
     assert 'W: self-obsoletion random-devel obsoletes random-devel' in out
@@ -327,19 +327,19 @@ def test_package_random_exp(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/requires-on-release'])
-def test_check_requires_on_release(tmpdir, package, tagscheck):
+def test_check_requires_on_release(tmp_path, package, tagscheck):
     """Test if a package check,
     - in out,
         requires-on-release."""
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package requires specific release of another package
     assert 'W: requires-on-release baz = 2.1-1' in out
 
 
 @pytest.mark.parametrize('package', ['binary/invalid-license'])
-def test_check_invalid_license(tmpdir, package, tagscheck):
+def test_check_invalid_license(tmp_path, package, tagscheck):
     """Test if a package check,
     - in out,
         invalid-license,
@@ -348,7 +348,7 @@ def test_check_invalid_license(tmpdir, package, tagscheck):
     CONFIG.configuration['ValidLicenses'] = ['MIT']
     output = Filter(CONFIG)
     test = TagsCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package has a License: tag value different from
     # ValidLicense = [] list in configuration
@@ -358,7 +358,7 @@ def test_check_invalid_license(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/not-standard-release-extension'])
-def test_package_not_std_release_extension(tmpdir, package, tagscheck):
+def test_package_not_std_release_extension(tmp_path, package, tagscheck):
     """Test if package has check,
     - in out,
         not-standard-release-extension
@@ -368,7 +368,7 @@ def test_package_not_std_release_extension(tmpdir, package, tagscheck):
     CONFIG.configuration['ValidLicenses'] = ['Apache-2.0 License']
     output = Filter(CONFIG)
     test = TagsCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package has a ReleaseExtension regex does not match with the Release: tag value expression
     # i.e. Release tag value must not match regex expression 'hello$'
@@ -378,7 +378,7 @@ def test_package_not_std_release_extension(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/non-standard-group'])
-def test_check_non_standard_group(tmpdir, package, tagscheck):
+def test_check_non_standard_group(tmp_path, package, tagscheck):
     """Test if a package has check,
     - in out,
         non-standard-group
@@ -388,7 +388,7 @@ def test_check_non_standard_group(tmpdir, package, tagscheck):
     CONFIG.configuration['ReleaseExtension'] = '0'
     output = Filter(CONFIG)
     test = TagsCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package has a different Group: tag value than ValidGroups = []
     assert 'W: non-standard-group non/standard/group' in out
@@ -397,7 +397,7 @@ def test_check_non_standard_group(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/dev-dependency'])
-def test_package_dev_dependency(tmpdir, package, tagscheck):
+def test_package_dev_dependency(tmp_path, package, tagscheck):
     """Test if a package check,
     - in out,
         devel-dependency,
@@ -406,7 +406,7 @@ def test_package_dev_dependency(tmpdir, package, tagscheck):
     CONFIG.configuration['ValidGroups'] = ['Devel/Something']
     output = Filter(CONFIG)
     test = TagsCheck(CONFIG, output)
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # Test if a package is not a devel package itself but requires a devel dependency
     assert 'E: devel-dependency glibc-devel' in out
@@ -415,9 +415,9 @@ def test_package_dev_dependency(tmpdir, package, tagscheck):
 
 
 @pytest.mark.parametrize('package', ['binary/summary-on-multiple-lines'])
-def test_summary_on_multiple_lines(tmpdir, package, tagscheck):
+def test_summary_on_multiple_lines(tmp_path, package, tagscheck):
     # Test if a package has summary on multiple lines.
     output, test = tagscheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: summary-on-multiple-lines' in out

--- a/test/test_tmp_files.py
+++ b/test/test_tmp_files.py
@@ -14,9 +14,9 @@ def tmpfilescheck():
 
 
 @pytest.mark.parametrize('package', ['binary/tempfiled'])
-def test_tmpfiles(tmpdir, package, tmpfilescheck):
+def test_tmpfiles(tmp_path, package, tmpfilescheck):
     output, test = tmpfilescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
 
     assert 'W: pre-with-tmpfile-creation ' not in out
@@ -26,9 +26,9 @@ def test_tmpfiles(tmpdir, package, tmpfilescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/systemd-tmpfiles'])
-def test_tmpfiles2(tmpdir, package, tmpfilescheck):
+def test_tmpfiles2(tmp_path, package, tmpfilescheck):
     output, test = tmpfilescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
 
     assert 'W: pre-with-tmpfile-creation /usr/lib/tmpfiles.d/systemd-tmpfiles.conf' in out
@@ -38,9 +38,9 @@ def test_tmpfiles2(tmpdir, package, tmpfilescheck):
 
 
 @pytest.mark.parametrize('package', ['binary/systemd-tmpfiles_correct'])
-def test_tmpfiles_correct(tmpdir, package, tmpfilescheck):
+def test_tmpfiles_correct(tmp_path, package, tmpfilescheck):
     output, test = tmpfilescheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
 
     assert 'W: pre-with-tmpfile-creation' not in out

--- a/test/test_xinetd.py
+++ b/test/test_xinetd.py
@@ -14,8 +14,8 @@ def xinetdcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/needxinetd'])
-def test_xinetd(tmpdir, package, xinetdcheck):
+def test_xinetd(tmp_path, package, xinetdcheck):
     output, test = xinetdcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: obsolete-xinetd-requirement' in out

--- a/test/test_zip.py
+++ b/test/test_zip.py
@@ -14,9 +14,9 @@ def zipcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/bad-crc-uncompressed'])
-def test_bad_crc_and_compression(tmpdir, package, zipcheck):
+def test_bad_crc_and_compression(tmp_path, package, zipcheck):
     output, test = zipcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
 
     assert 'bad-crc-in-zip' in out
@@ -27,9 +27,9 @@ def test_bad_crc_and_compression(tmpdir, package, zipcheck):
 
 
 @pytest.mark.parametrize('package', ['binary/asm'])
-def test_classpath_and_index(tmpdir, package, zipcheck):
+def test_classpath_and_index(tmp_path, package, zipcheck):
     output, test = zipcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'class-path-in-manifest' in out
     assert 'jar contains a hardcoded Class-Path' in out
@@ -39,9 +39,9 @@ def test_classpath_and_index(tmpdir, package, zipcheck):
 
 
 @pytest.mark.parametrize('package', ['binary/ruby2.5-rubygem-rubyzip-testsuite'])
-def test_zip1(tmpdir, package, zipcheck):
+def test_zip1(tmp_path, package, zipcheck):
     output, test = zipcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     # these are PW protected not broken so do not error about them
     assert 'W: unable-to-read-zip' in out
@@ -52,8 +52,8 @@ def test_zip1(tmpdir, package, zipcheck):
 
 
 @pytest.mark.parametrize('package', ['binary/texlive-codepage-doc'])
-def test_zip2(tmpdir, package, zipcheck):
+def test_zip2(tmp_path, package, zipcheck):
     output, test = zipcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'W: unable-to-read-zip' in out

--- a/test/test_zypp_syntax.py
+++ b/test/test_zypp_syntax.py
@@ -14,9 +14,9 @@ def zyppsyntaxcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/packageand'])
-def test_packageand(tmpdir, package, zyppsyntaxcheck):
+def test_packageand(tmp_path, package, zyppsyntaxcheck):
     output, test = zyppsyntaxcheck
-    test.check(get_tested_package(package, tmpdir))
+    test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'suse-zypp-packageand packageand(c:d)' in out
     assert 'suse-zypp-packageand packageand(a:b)' in out


### PR DESCRIPTION
According to pytest documentation, it is recommended to use tmp_path instead of tmpdir. closes rpm-software-management/rpmlint#1036