### PR TITLE
Exclude systemd directory in UsrLibBinaryException

### DIFF
--- a/rpmlint/configdefaults.toml
+++ b/rpmlint/configdefaults.toml
@@ -259,7 +259,7 @@ SystemLibPaths = [
 PieExecutables = []
 # Architecture dependent paths in which packages are allowed to install files
 # even if they are all non-binary
-UsrLibBinaryException = '^/usr/lib(64)?/(perl|python|ruby|menu|pkgconfig|ocaml|lib[^/]+\.(so|l?a)$|bonobo/servers/|\.build-id|firmware)'
+UsrLibBinaryException = '^/usr/lib(64)?/(perl|python|ruby|menu|pkgconfig|ocaml|lib[^/]+\.(so|l?a)$|bonobo/servers/|\.build-id|firmware|systemd)'
 # List of compilation flags that are mandatory
 MandatoryOptflags = []
 # List of forbidden compilation flags


### PR DESCRIPTION
Update UsrLibBinaryException in configdefaults.toml to exclude the systemd directory since it is common to install non-binary preset and systemd unit files there.

Closes #1035 