### PR TITLE
SpecCheck: Improve patch applied regex

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -19,7 +19,7 @@ def re_tag_compile(tag):
 
 patch_regex = re_tag_compile(r'Patch(\d*)')
 applied_patch_regex = re.compile(r'^%patch(\d*)')
-applied_patch_p_regex = re.compile(r'\s-P\s+(\d+)\b')
+applied_patch_p_regex = re.compile(r'\s-P\s*(\d+)\b')
 applied_patch_pipe_regex = re.compile(r'\s%\{PATCH(\d+)\}\s*\|\s*(%\{?__)?patch\b')
 applied_patch_i_regex = re.compile(r'(?:%\{?__)?patch\}?.*?\s+(?:<|-i)\s+%\{PATCH(\d+)\}')
 source_dir_regex = re.compile(r'^[^#]*(\$RPM_SOURCE_DIR|%{?_sourcedir}?)')

--- a/test/spec/SpecCheckPatch.spec
+++ b/test/spec/SpecCheckPatch.spec
@@ -1,0 +1,40 @@
+
+Name:           SpecCheckPatch
+Version:        0
+Release:        0
+Summary:        None here
+
+Group:          Undefined
+License:        GPLv2
+URL:            http://rpmlint.zarb.org/#%{name}
+Source0:        Source0.tar.gz
+Patch1:         Patch1.patch
+Patch2:         Patch2.patch
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+%description
+SpecCheck test 2.
+
+
+%prep
+%setup -q
+%patch -P 1 -p1
+%patch -P2 -p1
+
+%build
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/foo
+
+
+%changelog

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -24,7 +24,11 @@ def test_check_include(tmp_path, speccheck):
     assert 'E: specfile-error error: query of specfile' not in out
 
 
-@pytest.mark.parametrize('package', ['spec/SpecCheck2', 'spec/SpecCheck3'])
+@pytest.mark.parametrize('package', [
+    'spec/SpecCheck2',
+    'spec/SpecCheck3',
+    'spec/SpecCheckPatch',
+])
 def test_patch_not_applied(package, speccheck):
     output, test = speccheck
     pkg = get_tested_spec_package(package)


### PR DESCRIPTION
This patch improves the SpecCheck regular expression to detect patterns like `%patch -P1 -p1`.

Fix https://github.com/rpm-software-management/rpmlint/issues/461