### PR TITLE
magic: stop using compat API

### DIFF
--- a/.packit/rpmlint.spec
+++ b/.packit/rpmlint.spec
@@ -32,7 +32,7 @@ BuildRequires:  python3-zstandard
 %else
 BuildRequires:  python3dist(setuptools)
 # For tests
-BuildRequires:  python3dist(file-magic)
+BuildRequires:  python3dist(magic)
 BuildRequires:  python3dist(pybeam)
 BuildRequires:  python3dist(pyenchant)
 BuildRequires:  python3dist(pytest)

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -356,8 +356,8 @@ def parse_deps(line):
 
 def get_magic(path):
     try:
-        return magic.detect_from_filename(path).name
-    except ValueError:
+        return magic.from_file(path)
+    except (ValueError, FileNotFoundError):
         return ''
 
 


### PR DESCRIPTION
We moved to https://github.com/ahupp/python-magic and we should not use the compat API as described here:
https://github.com/ahupp/python-magic/blob/master/COMPAT.md