### PR TITLE
sysctl-whitelist: add kubernetes1.27 (bsc#1210951)

### DIFF
--- a/configs/openSUSE/sysctl-whitelist.toml
+++ b/configs/openSUSE/sysctl-whitelist.toml
@@ -154,11 +154,12 @@ packages = [
     "kubernetes1.23-kubeadm",
     "kubernetes1.24-kubeadm",
     "kubernetes1.25-kubeadm",
-    "kubernetes1.26-kubeadm"
+    "kubernetes1.26-kubeadm",
+    "kubernetes1.27-kubeadm"
 ]
 type = "sysctl"
 note = "enabled IPv4 forwarding system wide, same content for all kubeadm versions"
-bugs = ["bsc#1174722", "bsc#1209363"]
+bugs = ["bsc#1174722", "bsc#1209363", "bsc#1210951"]
 [[FileDigestGroup.digests]]
 path = "/usr/lib/sysctl.d/90-kubeadm.conf"
 digester = "shell"


### PR DESCRIPTION
Added a new version of kubernetes to an existing whitelisting.
https://bugzilla.suse.com/show_bug.cgi?id=1210951