### PR TITLE
rpmdiff: handle script argument with argparse

### DIFF
--- a/rpmlint/cli.py
+++ b/rpmlint/cli.py
@@ -56,11 +56,6 @@ def process_diff_args(argv):
                                 When relative, files matching the pattern anywhere
                                 are excluded but not directory contents.""")
 
-    # print help if there is no argument or less than the 2 mandatory ones
-    if len(argv) < 2:
-        parser.print_help()
-        sys.exit(0)
-
     options = parser.parse_args(args=argv)
 
     # convert options to dict


### PR DESCRIPTION
The RPM_ORIG and RPM_NEW arguments are mandatory so the argv len is not needed, that will be handled by the parse_args method.

This will allow to call rpmdiff with just one parameter like: $ rpmdiff -V
2.4.0

Fix https://github.com/rpm-software-management/rpmlint/issues/1078