### PR TITLE
SpecCheck: Allow macros for special comments

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -736,8 +736,13 @@ class SpecCheck(AbstractCheck):
         # Test if there are macros in comments
         if hash_pos != -1 and \
                 (hash_pos == 0 or line[hash_pos - 1] in (' ', '\t')):
-            for match in self.macro_regex.findall(
-                    line[hash_pos + 1:]):
+
+            comment = line[hash_pos + 1:]
+            # Ignore special comments like #!BuildIgnore
+            if comment and comment[0] == '!':
+                return
+
+            for match in self.macro_regex.findall(comment):
                 res = re.match('%+', match)
                 if len(res.group(0)) % 2:
                     self.output.add_info('W', self.pkg, 'macro-in-comment', match)

--- a/test/spec/MacroInComment.spec
+++ b/test/spec/MacroInComment.spec
@@ -1,0 +1,49 @@
+Name:           MacroInComment
+Version:        0
+Release:        0
+Summary:        None here
+
+Group:          Undefined
+License:        GPLv2
+URL:            http://rpmlint.zarb.org/#%{name}
+Source0:        Source0.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+Provides:       unversioned-provides, versioned-provides = 1.0
+Obsoletes:      versioned-obsoletes < 2.0
+Obsoletes:      unversioned-obsoletes
+Obsoletes:      /usr/bin/unversioned-but-filename
+Provides:       /sbin/another-unversioned-but-filename
+#!BuildIgnore:  %{name}
+
+%description
+MacroInComment test.
+
+%package        noarch-sub
+Summary:        Noarch subpackage
+Group:          Undefined
+BuildArch:      noarch
+
+%description    noarch-sub
+Noarch subpackage test.
+
+%prep
+%autosetup -p 1
+
+%build
+# %configure
+# %%%
+
+%install
+rm -rf $RPM_BUILD_ROOT
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/foo
+
+%files noarch-sub
+%defattr(-,root,root,-)
+
+%changelog

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -12,7 +12,19 @@ def speccheck():
     CONFIG.info = True
     output = Filter(CONFIG)
     test = SpecCheck(CONFIG, output)
-    return output, test
+    yield output, test
+
+
+@pytest.fixture
+def output(speccheck):
+    output, _test = speccheck
+    yield output
+
+
+@pytest.fixture
+def test(speccheck):
+    _output, test = speccheck
+    yield test
 
 
 def test_check_include(tmp_path, speccheck):
@@ -1168,3 +1180,13 @@ def test_null_char(package, speccheck):
     test.check_spec(pkg)
     out = output.print_results(output.results)
     assert 'forbidden-controlchar-found' in out
+
+
+@pytest.mark.parametrize('package', [
+    get_tested_spec_package('spec/MacroInComment'),
+])
+def test_special_comments(package, output, test):
+    test.check_spec(package)
+    out = output.print_results(output.results)
+    assert 'W: macro-in-comment %configure' in out
+    assert 'W: macro-in-comment %{name}' not in out


### PR DESCRIPTION
Do not warn for "macro in comment" for special comments like `#!BuildIgnore`

Fix https://github.com/rpm-software-management/rpmlint/issues/1069