### PR TITLE
pkg_resource is deprecated, importlib and packaging are standard now

### DIFF
--- a/test/test_erlang.py
+++ b/test/test_erlang.py
@@ -1,4 +1,6 @@
-from pkg_resources import get_distribution, parse_version
+from importlib.metadata import distribution
+
+from packaging.version import parse
 import pytest
 from rpmlint.checks.ErlangCheck import ErlangCheck
 from rpmlint.filter import Filter
@@ -14,7 +16,7 @@ def erlangcheck():
     return output, test
 
 
-@pytest.mark.skipif(get_distribution('pybeam').parsed_version < parse_version('0.7'), reason='pybeam >= 0.7 required')
+@pytest.mark.skipif(parse(distribution('pybeam').version) < parse('0.7'), reason='pybeam >= 0.7 required')
 @pytest.mark.parametrize('package', ['binary/erlang-test'])
 def test_erlang(tmp_path, package, erlangcheck):
     output, test = erlangcheck


### PR DESCRIPTION
In test/test_erlang.py file, 
`import pkg_resource` is deprecated. To replace we use `importlib` and `packaging` modules