### PR TITLE
Update search regexes for %service_* macros

### DIFF
--- a/.packit/rpmlint.spec
+++ b/.packit/rpmlint.spec
@@ -52,6 +52,8 @@ BuildRequires:  dash
 BuildRequires:  /usr/bin/appstream-util
 BuildRequires:  /usr/bin/checkbashisms
 BuildRequires:  /usr/bin/desktop-file-validate
+# required for the systemd test
+BuildRequires:  rpm_macro(_unitdir)
 
 %if 0%{?suse_version}
 BuildRequires:  myspell-en_US

--- a/rpmlint/checks/SystemdInstallCheck.py
+++ b/rpmlint/checks/SystemdInstallCheck.py
@@ -26,16 +26,17 @@ class SystemdInstallCheck(AbstractCheck):
                 processed = {'pre': False, 'post': False, 'preun': False, 'postun': False}
 
                 escaped_basename = re.escape(Path(fname).name)
-                PRE_POST_PATTERN = re.compile(r'for service in .*' + escaped_basename)
-                PREUN_PATTERN = re.compile(r'systemctl --no-reload disable .*' + escaped_basename)
-                POSTUN_PATTERN = re.compile(r'(systemctl try-restart .*|# Restart of .*)' + escaped_basename)
+                PRE_PATTERN = re.compile(r'systemd-update-helper mark-install-system-units .*' + escaped_basename)
+                POST_PATTERN = re.compile(r'systemd-update-helper install-system-units .*' + escaped_basename)
+                PREUN_PATTERN = re.compile(r'systemd-update-helper remove-system-units .*' + escaped_basename)
+                POSTUN_PATTERN = re.compile(r'systemd-update-helper mark-restart-system-units .*' + escaped_basename)
 
                 for line in pre.split('\n'):
-                    if PRE_POST_PATTERN.search(line):
+                    if PRE_PATTERN.search(line):
                         processed['pre'] = True
                         break
                 for line in post.split('\n'):
-                    if PRE_POST_PATTERN.search(line):
+                    if POST_PATTERN.search(line):
                         processed['post'] = True
                         break
                 for line in preun.split('\n'):

--- a/test/test_systemd_install.py
+++ b/test/test_systemd_install.py
@@ -2,7 +2,7 @@ import pytest
 from rpmlint.checks.SystemdInstallCheck import SystemdInstallCheck
 from rpmlint.filter import Filter
 
-from Testing import CONFIG, get_tested_package, IS_FEDORA_RELEASE
+from Testing import CONFIG, get_tested_package
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -14,7 +14,6 @@ def systemdinstallcheck():
 
 
 @pytest.mark.parametrize('package', ['binary/dnf-automatic'])
-@pytest.mark.skipif(IS_FEDORA_RELEASE, reason='Fedora does not define %{_unitdir} rpm macro')
 def test_systemd_service_without_service_macro(tmp_path, package, systemdinstallcheck):
     output, test = systemdinstallcheck
     test.check(get_tested_package(package, tmp_path))

--- a/test/test_systemd_install.py
+++ b/test/test_systemd_install.py
@@ -15,7 +15,7 @@ def systemdinstallcheck():
 
 @pytest.mark.parametrize('package', ['binary/dnf-automatic'])
 @pytest.mark.skipif(IS_FEDORA_RELEASE, reason='Fedora does not define %{_unitdir} rpm macro')
-def test_bashisms(tmp_path, package, systemdinstallcheck):
+def test_systemd_service_without_service_macro(tmp_path, package, systemdinstallcheck):
     output, test = systemdinstallcheck
     test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)


### PR DESCRIPTION
These macros used to call systemctl directly, but as of May 2023 they rely on systemd-update-helper in openSUSE. This results in false negatives for every package using these macros.