### PR TITLE
README: added test coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Build and Test 2](https://github.com/rpm-software-management/rpmlint/actions/workflows/main.yml/badge.svg?branch=opensuse)](https://github.com/rpm-software-management/rpmlint/actions/workflows/main.yml)
 [![build result](https://build.opensuse.org/projects/devel:openSUSE:Factory:rpmlint/packages/rpmlint/badge.svg?type=default)](https://build.opensuse.org/package/show/devel:openSUSE:Factory:rpmlint/rpmlint)
 [![repology](https://repology.org/badge/latest-versions/rpmlint.svg)](https://repology.org/project/rpmlint/versions)
+[![Coverage Status](https://coveralls.io/repos/github/rpm-software-management/rpmlint/badge.svg)](https://coveralls.io/github/rpm-software-management/rpmlint)
 
 `rpmlint` is a tool for checking common errors in RPM packages.
 `rpmlint` can be used to test individual packages before uploading or to check


### PR DESCRIPTION
A new test coverage badge has been added to README.
Preview: 
<img width="106" alt="image" src="https://github.com/rpm-software-management/rpmlint/assets/59523682/b1262ae8-5dad-4336-b16c-6e80c56c4cbd">

Coverage data sync is provided by [Coveralls](https://coveralls.io/), For RPMLint repo