### PR TITLE
Use python-magic API when available

### DIFF
--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -354,10 +354,25 @@ def parse_deps(line):
     return prcos
 
 
+def _get_magic_libmagic(path):
+    return magic.detect_from_filename(path).name
+
+
+def _get_magic_python_magic(path):
+    return magic.from_file(path)
+
+
 def get_magic(path):
+    # python-magic & libmagic compatibility code
+    # https://github.com/ahupp/python-magic/blob/master/COMPAT.md
+    detect_magic = _get_magic_python_magic
+    if not hasattr(magic, 'from_file'):
+        # libmagic python bindings
+        detect_magic = _get_magic_libmagic
+
     try:
-        return magic.detect_from_filename(path).name
-    except ValueError:
+        return detect_magic(path)
+    except (ValueError, FileNotFoundError):
         return ''
 
 


### PR DESCRIPTION
The usage of the python-magic -> libmagic API comatibility [1] raises a deprecation warning. This patch uses the python-magic default API when it's available and in other case it uses the libmagic default API.

Fix https://github.com/rpm-software-management/rpmlint/issues/1083

[1] https://github.com/ahupp/python-magic/blob/master/COMPAT.md