### PR TITLE
PythonCheck: Add python-sphinx-doctrees-leftover

### DIFF
--- a/rpmlint/checks/PythonCheck.py
+++ b/rpmlint/checks/PythonCheck.py
@@ -8,6 +8,7 @@ from rpmlint.checks.AbstractCheck import AbstractFilesCheck
 # Warning messages
 WARNS = {
     'doc': 'python-doc-in-package',
+    'sphinx': 'python-sphinx-doctrees-leftover',
 }
 
 # Error messages
@@ -32,6 +33,7 @@ ERR_PATHS = [
 # sufficiently special circumstances.
 WARN_PATHS = [
     (re.compile(f'{SITELIB_RE}/[^/]+/docs?$'), 'doc'),
+    (re.compile(r'.*/\.doctrees$'), 'sphinx'),
 ]
 
 

--- a/rpmlint/descriptions/PythonCheck.toml
+++ b/rpmlint/descriptions/PythonCheck.toml
@@ -33,3 +33,8 @@ python-pyc-multiple-versions="""
 There are .pyc files in the rpm that are from the different Python
 interperters. Please, verify that all files are needed for this package.
 """
+
+python-sphinx-doctrees-leftover="""
+Cache Sphinx build folder found in the package ".doctrees". Please, make sure
+to do not include any build files in the final package.
+"""

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -418,3 +418,24 @@ def test_python_pyc_single_version(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-pyc-multiple-versions' not in out
+
+
+@pytest.mark.parametrize('package', [
+    get_tested_mock_package(files=['/usr/share/doc/packages/python-blinker-doc/.doctrees']),
+    get_tested_mock_package(files=['/usr/lib/python3.11/site-packages/python-blinker/.doctrees']),
+])
+def test_python_sphinx_doctrees_leftover_warn(package, output, test):
+    test.check(package)
+    out = output.print_results(output.results)
+    assert 'W: python-sphinx-doctrees-leftover' in out
+
+
+@pytest.mark.parametrize('package', [
+    get_tested_mock_package(files=['/usr/lib/python3.11/site-packages/python-blinker/doctrees.py']),
+    get_tested_mock_package(files=['/usr/share/doc/packages/python-blinker-doc/doctrees']),
+    get_tested_mock_package(files=['/usr/share/doc/packages/python-blinker-doc/.doctrees.html']),
+])
+def test_python_sphinx_doctrees_leftover_nowarn(package, output, test):
+    test.check(package)
+    out = output.print_results(output.results)
+    assert 'W: python-sphinx-doctrees-leftover' not in out


### PR DESCRIPTION
This check will warn about Sphinx `.doctrees` cache folder found in the package.

Fix https://github.com/rpm-software-management/rpmlint/issues/1092