### PR TITLE
test: Allow list of files in get_tested_mock_package

### DIFF
--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -809,17 +809,29 @@ class FakePkg(AbstractPkg):
         self.files[name] = pkgfile
         return pkgfile
 
+    def _mock_file(self, path, attrs, real_files=False):
+        metadata = None
+        if attrs.get('create_dirs', False):
+            for i in PurePath(path).parents[:attrs.get('include_dirs', -1)]:
+                self.add_dir(str(i))
+        metadata = attrs.get('metadata', None)
+        content = attrs.get('content', '')
+        self.add_file_with_content(path, content, real_files=real_files, metadata=metadata)
+
     def create_files(self, files, real_files=None):
-        """ This is a helper method to create files(real files);
-         not PkgFile objects. """
-        for path, file in files.items():
-            metadata = None
-            if file.get('create_dirs', False):
-                for i in PurePath(path).parents[:file.get('include_dirs', -1)]:
-                    self.add_dir(str(i))
-            if file.get('metadata'):
-                metadata = file.get('metadata')
-            self.add_file_with_content(path, file.get('content', ''), real_files=real_files, metadata=metadata)
+        """
+        This is a helper method to create files(real files); not PkgFile
+        objects.
+        """
+
+        # files can be just a list
+        if isinstance(files, list) or isinstance(files, tuple):
+            for path in files:
+                self._mock_file(path, {}, real_files)
+        # list of files with attributes and content
+        elif isinstance(files, dict):
+            for path, file in files.items():
+                self._mock_file(path, file, real_files)
 
     def add_dir(self, path):
         pkgdir = PkgFile(path)

--- a/test/README.md
+++ b/test/README.md
@@ -58,6 +58,10 @@ def test_python_doc_in_site_packages(package, pythoncheck):
 **`files`**:
 `files` argument takes each file's path and a dictionary as shown above `'/usr/lib/python2.7/site-packages/doc': {}` the value part is again a dictionary with file related data such as `create_dirs`, `metadata` and `include_dirs`. `metadata` is yet versatile it can assign any rpm related options or simply rpm file meta data unique to file.
 
+If the content or metadata of the files in the package is not important, it's
+possible to use just a list of paths and the files will be created with default
+empty content and default flags.
+
 
 **`real_files`**:
 Each of the above file is converted into a `PkgFile` object by default, and into real file only if `real_file` is passed with `True` parameter.

--- a/test/Testing.py
+++ b/test/Testing.py
@@ -65,6 +65,12 @@ def get_tested_spec_package(name):
 def get_tested_mock_package(files=None, real_files=None, header=None):
     mockPkg = FakePkg('mockPkg')
     if files is not None:
+        if isinstance(files, dict):
+            # full path for test files
+            for attrs in files.values():
+                if 'content-path' in attrs:
+                    attrs['content-path'] = get_tested_path(attrs['content-path'])
+
         mockPkg.create_files(files, real_files)
     if header is not None:
         mockPkg.add_header(header)

--- a/test/files/python-flit-metadata.txt
+++ b/test/files/python-flit-metadata.txt
@@ -1,0 +1,110 @@
+Metadata-Version: 2.1
+Name: flit
+Version: 3.8.0
+Summary: A simple packaging tool for simple packages.
+Author-email: Thomas Kluyver <thomas@kluyver.me.uk>
+Requires-Python: >=3.6
+Description-Content-Type: text/x-rst
+Classifier: Intended Audience :: Developers
+Classifier: License :: OSI Approved :: BSD License
+Classifier: Programming Language :: Python :: 3
+Classifier: Topic :: Software Development :: Libraries :: Python Modules
+Requires-Dist: flit_core >=3.8.0
+Requires-Dist: requests
+Requires-Dist: docutils
+Requires-Dist: tomli-w
+Requires-Dist: sphinx ; extra == "doc"
+Requires-Dist: sphinxcontrib_github_alt ; extra == "doc"
+Requires-Dist: pygments-github-lexers ; extra == "doc"
+Requires-Dist: testpath ; extra == "test"
+Requires-Dist: responses ; extra == "test"
+Requires-Dist: pytest>=2.7.3 ; extra == "test"
+Requires-Dist: pytest-cov ; extra == "test"
+Requires-Dist: tomli ; extra == "test"
+Project-URL: Changelog, https://flit.pypa.io/en/stable/history.html
+Project-URL: Documentation, https://flit.pypa.io
+Project-URL: Source, https://github.com/pypa/flit
+Provides-Extra: doc
+Provides-Extra: test
+
+**Flit** is a simple way to put Python packages and modules on PyPI.
+It tries to require less thought about packaging and help you avoid common
+mistakes.
+See `Why use Flit? <https://flit.readthedocs.io/en/latest/rationale.html>`_ for
+more about how it compares to other Python packaging tools.
+
+Install
+-------
+
+::
+
+    $ python3 -m pip install flit
+
+Flit requires Python 3 and therefore needs to be installed using the Python 3
+version of pip.
+
+Python 2 modules can be distributed using Flit, but need to be importable on
+Python 3 without errors.
+
+Usage
+-----
+
+Say you're writing a module ``foobar`` — either as a single file ``foobar.py``,
+or as a directory — and you want to distribute it.
+
+1. Make sure that foobar's docstring starts with a one-line summary of what
+   the module is, and that it has a ``__version__``:
+
+   .. code-block:: python
+
+       """An amazing sample package!"""
+
+       __version__ = "0.1"
+
+2. Install flit if you don't already have it::
+
+       python3 -m pip install flit
+
+3. Run ``flit init`` in the directory containing the module to create a
+   ``pyproject.toml`` file. It will look something like this:
+
+   .. code-block:: ini
+
+       [build-system]
+       requires = ["flit_core >=3.2,<4"]
+       build-backend = "flit_core.buildapi"
+
+       [project]
+       name = "foobar"
+       authors = [{name = "Sir Robin", email = "robin@camelot.uk"}]
+       dynamic = ["version", "description"]
+
+       [project.urls]
+       Home = "https://github.com/sirrobin/foobar"
+
+   You can edit this file to add other metadata, for example to set up
+   command line scripts. See the
+   `pyproject.toml page <https://flit.readthedocs.io/en/latest/pyproject_toml.html#scripts-section>`_
+   of the documentation.
+
+   If you have already got a ``flit.ini`` file to use with older versions of
+   Flit, convert it to ``pyproject.toml`` by running ``python3 -m flit.tomlify``.
+
+4. Run this command to upload your code to PyPI::
+
+       flit publish
+
+Once your package is published, people can install it using *pip* just like
+any other package. In most cases, pip will download a 'wheel' package, a
+standard format it knows how to install. If you specifically ask pip to install
+an 'sdist' package, it will install and use Flit in a temporary environment.
+
+
+To install a package locally for development, run::
+
+    flit install [--symlink] [--python path/to/python]
+
+Flit packages a single importable module or package at a time, using the import
+name as the name on PyPI. All subpackages and data files within a package are
+included automatically.
+

--- a/test/files/python-jupyter-events-metadata.txt
+++ b/test/files/python-jupyter-events-metadata.txt
@@ -1,0 +1,128 @@
+Metadata-Version: 2.1
+Name: jupyter-events
+Version: 0.6.3
+Summary: Jupyter Event System library
+Project-URL: Homepage, http://jupyter.org
+Author-email: Jupyter Development Team <jupyter@googlegroups.com>
+License: # Licensing terms
+
+        This project is licensed under the terms of the Modified BSD License
+        (also known as New or Revised or 3-Clause BSD), as follows:
+
+        - Copyright (c) 2022-, Jupyter Development Team
+
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+
+        Redistributions of source code must retain the above copyright notice, this
+        list of conditions and the following disclaimer.
+
+        Redistributions in binary form must reproduce the above copyright notice, this
+        list of conditions and the following disclaimer in the documentation and/or
+        other materials provided with the distribution.
+
+        Neither the name of the Jupyter Development Team nor the names of its
+        contributors may be used to endorse or promote products derived from this
+        software without specific prior written permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+        FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+        DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+        OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+        OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+        ## About the Jupyter Development Team
+
+        The Jupyter Development Team is the set of all contributors to the Jupyter project.
+        This includes all of the Jupyter subprojects.
+
+        The core team that coordinates development on GitHub can be found here:
+        https://github.com/jupyter/.
+
+        ## Our Copyright Policy
+
+        Jupyter uses a shared copyright model. Each contributor maintains copyright
+        over their contributions to Jupyter. But, it is important to note that these
+        contributions are typically only changes to the repositories. Thus, the Jupyter
+        source code, in its entirety is not the copyright of any single person or
+        institution. Instead, it is the collective copyright of the entire Jupyter
+        Development Team. If individual contributors want to maintain a record of what
+        changes/contributions they have specific copyright on, they should indicate
+        their copyright in the commit message of the change, when they commit the
+        change to one of the Jupyter repositories.
+
+        With this in mind, the following banner should be used in any source code file
+        to indicate the copyright and license terms:
+
+        ```
+        # Copyright (c) Jupyter Development Team.
+        # Distributed under the terms of the Modified BSD License.
+        ```
+License-File: COPYING.md
+Keywords: Jupyter,JupyterLab
+Classifier: Intended Audience :: Developers
+Classifier: Intended Audience :: Science/Research
+Classifier: Intended Audience :: System Administrators
+Classifier: License :: OSI Approved :: BSD License
+Classifier: Programming Language :: Python
+Classifier: Programming Language :: Python :: 3
+Requires-Python: >=3.7
+Requires-Dist: jsonschema[format-nongpl]>=3.2.0
+Requires-Dist: python-json-logger>=2.0.4
+Requires-Dist: pyyaml>=5.3
+Requires-Dist: rfc3339-validator
+Requires-Dist: rfc3986-validator>=0.1.1
+Requires-Dist: traitlets>=5.3
+Provides-Extra: cli
+Requires-Dist: click; extra == 'cli'
+Requires-Dist: rich; extra == 'cli'
+Provides-Extra: docs
+Requires-Dist: jupyterlite-sphinx; extra == 'docs'
+Requires-Dist: myst-parser; extra == 'docs'
+Requires-Dist: pydata-sphinx-theme; extra == 'docs'
+Requires-Dist: sphinxcontrib-spelling; extra == 'docs'
+Provides-Extra: test
+Requires-Dist: click; extra == 'test'
+Requires-Dist: coverage; extra == 'test'
+Requires-Dist: pre-commit; extra == 'test'
+Requires-Dist: pytest-asyncio>=0.19.0; extra == 'test'
+Requires-Dist: pytest-console-scripts; extra == 'test'
+Requires-Dist: pytest-cov; extra == 'test'
+Requires-Dist: pytest>=7.0; extra == 'test'
+Requires-Dist: rich; extra == 'test'
+Description-Content-Type: text/markdown
+
+# Jupyter Events
+
+[![Build Status](https://github.com/jupyter/jupyter_events/actions/workflows/python-tests.yml/badge.svg?query=branch%3Amain++)](https://github.com/jupyter/jupyter_events/actions/workflows/python-tests.yml/badge.svg?query=branch%3Amain++)
+[![codecov](https://codecov.io/gh/jupyter/jupyter_events/branch/main/graph/badge.svg?token=S9WiBg2iL0)](https://codecov.io/gh/jupyter/jupyter_events)
+[![Documentation Status](https://readthedocs.org/projects/jupyter-events/badge/?version=latest)](http://jupyter-events.readthedocs.io/en/latest/?badge=latest)
+
+_An event system for Jupyter Applications and extensions._
+
+Jupyter Events enables Jupyter Python Applications (e.g. Jupyter Server, JupyterLab Server, JupyterHub, etc.) to emit **events**—structured data describing things happening inside the application. Other software (e.g. client applications like JupyterLab) can _listen_ and respond to these events.
+
+## Install
+
+Install Jupyter Events directly from PyPI:
+
+```
+pip install jupyter_events
+```
+
+or conda-forge:
+
+```
+conda install -c conda-forge jupyter_events
+```
+
+## Documentation
+
+Documentation is available at [jupyter-events.readthedocs.io](https://jupyter-events.readthedocs.io).

--- a/test/files/python-jupyter_server_fileid-metadata.txt
+++ b/test/files/python-jupyter_server_fileid-metadata.txt
@@ -1,0 +1,146 @@
+Metadata-Version: 2.1
+Name: jupyter_server_fileid
+Version: 0.9.0
+Project-URL: Home, https://github.com/jupyter-server/jupyter_server_fileid
+Author-email: "David L. Qiu" <david@qiu.dev>
+License: BSD 3-Clause License
+
+        Copyright (c) 2022, David L. Qiu
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+
+        1. Redistributions of source code must retain the above copyright notice, this
+           list of conditions and the following disclaimer.
+
+        2. Redistributions in binary form must reproduce the above copyright notice,
+           this list of conditions and the following disclaimer in the documentation
+           and/or other materials provided with the distribution.
+
+        3. Neither the name of the copyright holder nor the names of its
+           contributors may be used to endorse or promote products derived from
+           this software without specific prior written permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+        FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+        DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+        OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+        OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+License-File: LICENSE
+Keywords: Extension,Jupyter
+Classifier: Framework :: Jupyter
+Classifier: License :: OSI Approved :: BSD License
+Classifier: Programming Language :: Python
+Classifier: Programming Language :: Python :: 3
+Classifier: Programming Language :: Python :: 3.7
+Classifier: Programming Language :: Python :: 3.8
+Classifier: Programming Language :: Python :: 3.9
+Classifier: Programming Language :: Python :: 3.10
+Requires-Python: >=3.7
+Requires-Dist: jupyter-events>=0.5.0
+Requires-Dist: jupyter-server<3,>=1.15
+Provides-Extra: cli
+Requires-Dist: click; extra == 'cli'
+Provides-Extra: test
+Requires-Dist: jupyter-server[test]<3,>=1.15; extra == 'test'
+Requires-Dist: pytest; extra == 'test'
+Requires-Dist: pytest-cov; extra == 'test'
+Description-Content-Type: text/markdown
+
+# jupyter_server_fileid
+
+[![Github Actions Status](https://github.com/jupyter-server/jupyter_server_fileid/workflows/Build/badge.svg)](https://github.com/jupyter-server/jupyter_server_fileid/actions/workflows/build.yml)
+
+A Jupyter Server extension providing an implementation of the File ID service.
+
+## Requirements
+
+- Jupyter Server
+
+## Install
+
+To install the extension, execute:
+
+```bash
+pip install jupyter_server_fileid
+```
+
+## Uninstall
+
+To remove the extension, execute:
+
+```bash
+pip uninstall jupyter_server_fileid
+```
+
+## Troubleshoot
+
+If you are seeing the frontend extension, but it is not working, check
+that the server extension is enabled:
+
+```bash
+jupyter server extension list
+```
+
+## Contributing
+
+### Development install
+
+```bash
+# Clone the repo to your local environment
+# Change directory to the jupyter_server_fileid directory
+# Install package in development mode - will automatically enable
+# The server extension.
+pip install -e .
+```
+
+
+You can watch the source directory and run your Jupyter Server-based application at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.  For example,
+when running JupyterLab:
+
+```bash
+jupyter lab --autoreload
+```
+
+If your extension does not depend a particular frontend, you can run the
+server directly:
+
+```bash
+jupyter server --autoreload
+```
+
+### Running Tests
+
+Install dependencies:
+
+```bash
+pip install -e ".[test]"
+```
+
+To run the python tests, use:
+
+```bash
+pytest
+
+# To test a specific file
+pytest jupyter_server_fileid/tests/test_handlers.py
+
+# To run a specific test
+pytest jupyter_server_fileid/tests/test_handlers.py -k "test_get"
+```
+
+### Development uninstall
+
+```bash
+pip uninstall jupyter_server_fileid
+```
+
+### Packaging the extension
+
+See [RELEASE](RELEASE.md)

--- a/test/files/python-scikit_build-metadata.txt
+++ b/test/files/python-scikit_build-metadata.txt
@@ -1,0 +1,242 @@
+Metadata-Version: 2.1
+Name: scikit-build
+Version: 0.17.2
+Summary: Improved build system generator for Python C/C++/Fortran/Cython extensions
+Project-URL: Bug Tracker, https://github.com/scikit-build/scikit-build/issues
+Project-URL: Changelog, https://scikit-build.readthedocs.io/en/latest/changes.html
+Project-URL: Discussions, https://github.com/orgs/scikit-build/discussions
+Project-URL: Documentation, https://scikit-build.readthedocs.io/
+Project-URL: Examples, https://github.com/scikit-build/scikit-build-sample-projects
+Project-URL: Homepage, https://github.com/scikit-build/scikit-build
+Author: The scikit-build team
+License-Expression: MIT
+License-File: AUTHORS.rst
+License-File: LICENSE
+Keywords: scikit-build
+Classifier: Development Status :: 2 - Pre-Alpha
+Classifier: Intended Audience :: Developers
+Classifier: License :: OSI Approved :: MIT License
+Classifier: Natural Language :: English
+Classifier: Programming Language :: Python :: 3 :: Only
+Classifier: Programming Language :: Python :: 3.7
+Classifier: Programming Language :: Python :: 3.8
+Classifier: Programming Language :: Python :: 3.9
+Classifier: Programming Language :: Python :: 3.10
+Classifier: Programming Language :: Python :: 3.11
+Classifier: Typing :: Typed
+Requires-Python: >=3.7
+Requires-Dist: distro
+Requires-Dist: packaging
+Requires-Dist: setuptools>=42.0.0
+Requires-Dist: tomli; python_version < '3.11'
+Requires-Dist: typing-extensions>=3.7; python_version < '3.8'
+Requires-Dist: wheel>=0.32.0
+Provides-Extra: cov
+Requires-Dist: coverage[toml]>=4.2; extra == 'cov'
+Requires-Dist: pytest-cov>=2.7.1; extra == 'cov'
+Provides-Extra: docs
+Requires-Dist: pygments; extra == 'docs'
+Requires-Dist: sphinx-issues; extra == 'docs'
+Requires-Dist: sphinx-rtd-theme>=1.0; extra == 'docs'
+Requires-Dist: sphinx>=4; extra == 'docs'
+Requires-Dist: sphinxcontrib-moderncmakedomain>=3.19; extra == 'docs'
+Provides-Extra: doctest
+Requires-Dist: ubelt>=0.8.2; extra == 'doctest'
+Requires-Dist: xdoctest>=0.10.0; extra == 'doctest'
+Provides-Extra: test
+Requires-Dist: build>=0.7; extra == 'test'
+Requires-Dist: cython>=0.25.1; extra == 'test'
+Requires-Dist: importlib-metadata; python_version < '3.8' and extra == 'test'
+Requires-Dist: pytest-mock>=1.10.4; extra == 'test'
+Requires-Dist: pytest-virtualenv>=1.2.5; extra == 'test'
+Requires-Dist: pytest>=6.0.0; extra == 'test'
+Requires-Dist: requests; extra == 'test'
+Requires-Dist: virtualenv; extra == 'test'
+Description-Content-Type: text/x-rst
+
+===============================
+scikit-build
+===============================
+
+.. image:: https://github.com/scikit-build/scikit-build/actions/workflows/ci.yml/badge.svg
+    :target: https://github.com/scikit-build/scikit-build/actions/workflows/ci.yml
+
+.. image:: https://dev.azure.com/scikit-build/scikit-build/_apis/build/status/scikit-build.scikit-build?branchName=main
+   :target: https://dev.azure.com/scikit-build/scikit-build/_build/latest?definitionId=1&branchName=main
+
+.. image:: https://codecov.io/gh/scikit-build/scikit-build/branch/main/graph/badge.svg
+    :target: https://codecov.io/gh/scikit-build/scikit-build
+    :alt: Code coverage status
+
+.. image:: https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github
+    :target: https://github.com/orgs/scikit-build/discussions
+    :alt: GitHub Discussion
+
+Improved build system generator for CPython C/C++/Fortran/Cython extensions.
+
+Better support is available for additional compilers, build systems, cross
+compilation, and locating dependencies and determining their build
+requirements.
+
+The **scikit-build** package is fundamentally just glue between
+the ``setuptools`` Python module and `CMake <https://cmake.org/>`_.
+
+To get started, see `this example <https://scikit-build.readthedocs.io/en/latest/usage.html#example-of-setup-py-cmakelists-txt-and-pyproject-toml>`_ and `scikit-build-sample-projects <https://github.com/scikit-build/scikit-build-sample-projects>`_.
+
+
+Latest Release
+--------------
+
+.. table::
+
+  +-----------------------------------------------------------------------------+-------------------------------------------------------------------------------+
+  | Versions                                                                    | Downloads                                                                     |
+  +=============================================================================+===============================================================================+
+  | .. image:: https://img.shields.io/pypi/v/scikit-build.svg                   | .. image:: https://img.shields.io/pypi/dm/scikit-build                        |
+  |     :target: https://pypi.python.org/pypi/scikit-build                      |     :target: https://pypi.python.org/pypi/scikit-build                        |
+  +-----------------------------------------------------------------------------+-------------------------------------------------------------------------------+
+  | .. image:: https://anaconda.org/conda-forge/scikit-build/badges/version.svg | .. image:: https://anaconda.org/conda-forge/scikit-build/badges/downloads.svg |
+  |     :target: https://anaconda.org/conda-forge/scikit-build                  |     :target: https://anaconda.org/conda-forge/scikit-build                    |
+  +-----------------------------------------------------------------------------+-------------------------------------------------------------------------------+
+
+
+
+Scikit-build 0.17.2
+===================
+
+Another small release with fixes for non-MSVC Windows platforms.
+
+Bug fixes
+---------
+
+* RPM spec fix by `@LecrisUT <https://github.com/LecrisUT>`_ in `#937 <https://github.com/scikit-build/scikit-build/pull/937>`_.
+* Validate value before returning library path by `@dlech <https://github.com/dlech>`_ in `#942 <https://github.com/scikit-build/scikit-build/pull/942>`_.
+* Only add ``Python_LIBRARY`` on Windows MSVC in `#943 <https://github.com/scikit-build/scikit-build/pull/943>`_ and `#944 <https://github.com/scikit-build/scikit-build/pull/944>`_.
+* Slightly nicer traceback for failed compiler in `#947 <https://github.com/scikit-build/scikit-build/pull/947>`_.
+
+Testing
+-------
+* Hide a few warnings that are expected in `#948 <https://github.com/scikit-build/scikit-build/pull/948>`_.
+
+Scikit-build 0.17.1
+===================
+
+This is a small release fixing a few bugs; the primary one being a change that
+was triggering a bug in older FindPython. The unused variable messages have
+been deactivated to simplify output, as well.
+
+Bug fixes
+---------
+
+* Older (<3.24) CMake breaks when lib specified in `#932 <https://github.com/scikit-build/scikit-build/pull/932>`_.
+* An error output was missing formatting in `#931 <https://github.com/scikit-build/scikit-build/pull/931>`_.
+* Make empty ``CMAKE_OSX_DEPLOYMENT_TARGET`` a warning (bug in conda-forge's
+  clang activation fixed upstream) in `#934 <https://github.com/scikit-build/scikit-build/pull/934>`_.
+* Remove unused variable warnings by in `#930 <https://github.com/scikit-build/scikit-build/pull/930>`_.
+
+Testing
+-------
+
+* Add Fedora packaging with packit automation by `@LecrisUT <https://github.com/LecrisUT>`_ in `#928 <https://github.com/scikit-build/scikit-build/pull/928>`_.
+* Fix codecov ci by `@LecrisUT <https://github.com/LecrisUT>`_ in `#929 <https://github.com/scikit-build/scikit-build/pull/929>`_.
+* Update some coverage settings in `#933 <https://github.com/scikit-build/scikit-build/pull/933>`_.
+
+
+
+Scikit-build 0.17.0
+===================
+
+A lot of bug fixes are present in this release, focusing on Windows, PyPy, and
+cross compiling. We've also improved the compatibility with default setuptools
+behaviors a little, and enabled some things that were previously unavailable,
+like overriding the build type via the cmake argument environment variables.
+We've expanded our CI matrix to include Windows and macOS PyPy and some Fortran
+tests on Linux. This release requires Python 3.7+.
+
+Bug fixes
+---------
+
+* Match setuptools behavior for ``include_package_data`` default. by `@vyasr <https://github.com/vyasr>`_ in `#873 <https://github.com/scikit-build/scikit-build/pull/873>`_.
+* Misc. fixes for F2PY and PythonExtensions modules by `@benbovy <https://github.com/benbovy>`_ in `#495 <https://github.com/scikit-build/scikit-build/pull/495>`_.
+* Provide more useful error if user provides ``CMAKE_INSTALL_PREFIX`` by `@vyasr <https://github.com/vyasr>`_ in `#872 <https://github.com/scikit-build/scikit-build/pull/872>`_.
+* Stop assuming that ``.pyx`` files are in the same directory as ``CMakeLists.txt`` by `@vyasr <https://github.com/vyasr>`_ in `#871 <https://github.com/scikit-build/scikit-build/pull/871>`_.
+* Allow build type overriding in `#902 <https://github.com/scikit-build/scikit-build/pull/902>`_.
+* Detect PyPy library correctly on Windows by user:`gershnik` in `#904 <https://github.com/scikit-build/scikit-build/pull/904>`_.
+* Include library for FindPython for better Windows cross-compiles in `#913 <https://github.com/scikit-build/scikit-build/pull/913>`_. Thanks to user:`maxbachmann` for testing.
+* Fix logic for default generator when cross-compiling for ARM on Windows in `#917 <https://github.com/scikit-build/scikit-build/pull/917>`_ by `@dlech <https://github.com/dlech>`_.
+* Use f2py's ``get_include`` if present in `#877 <https://github.com/scikit-build/scikit-build/pull/877>`_.
+* Fix support for cross-compilation exception using ``targetLinkLibrariesWithDynamicLookup`` by `@erykoff <https://github.com/erykoff>`_ in `#901 <https://github.com/scikit-build/scikit-build/pull/901>`_.
+* Treat empty ``MACOSX_DEPLOYMENT_TARGET`` as if it was unset in `#918 <https://github.com/scikit-build/scikit-build/pull/918>`_.
+
+Testing
+-------
+
+* Add hello fortran sample package + tests by `@benbovy <https://github.com/benbovy>`_ in `#493 <https://github.com/scikit-build/scikit-build/pull/493>`_.
+* Add sdist check & fix in `#906 <https://github.com/scikit-build/scikit-build/pull/906>`_.
+* Fix some setuptools types in `#888 <https://github.com/scikit-build/scikit-build/pull/888>`_.
+* Add PyPy Win & macOS to the CI in `#907 <https://github.com/scikit-build/scikit-build/pull/907>`_.
+* Add tests for Python 3.12 Linux alphas in `#922 <https://github.com/scikit-build/scikit-build/pull/922>`_.
+
+Miscellaneous
+-------------
+
+* Drop Python 3.6 in `#862 <https://github.com/scikit-build/scikit-build/pull/862>`_.
+* Move building backend to hatchling in `#870 <https://github.com/scikit-build/scikit-build/pull/870>`_.
+* Avoid mutating function input parameters in `#899 <https://github.com/scikit-build/scikit-build/pull/899>`_.
+* Use _compat/typing name in `#869 <https://github.com/scikit-build/scikit-build/pull/869>`_.
+
+
+
+Publications
+------------
+
+Please use the first citation when referencing scikit-build in scientific publications.
+
+* Jean-Christophe Fillion-Robin, Matt McCormick, Omar Padron, Max Smolens, Michael Grauer, & Michael Sarahan. (2018, July 13). jcfr/scipy_2018_scikit-build_talk: SciPy 2018 Talk | scikit-build: A Build System Generator for CPython C/C++/Fortran/Cython Extensions. Zenodo. https://doi.org/10.5281/zenodo.2565368
+
+* Schreiner, Henry, Rickerby, Joe, Grosse-Kunstleve, Ralf, Jakob, Wenzel, Darbois, Matthieu, Gokaslan, Aaron, Fillion-Robin, Jean-Christophe, & McCormick, Matt. (2022, August 1). Building Binary Extensions with pybind11, scikit-build, and cibuildwheel. https://doi.org/10.25080/majora-212e5952-033
+
+
+History
+-------
+
+PyCMake was created at SciPy 2014 in response to general difficulties building
+C++ and Fortran based Python extensions across platforms.  It was renamed to
+"scikit-build" in 2016.
+
+
+Known Issues
+------------
+
+These issues are likely to be addressed in upcoming releases.
+
+* Editable installs do not work with the latest versions of Setuptools (and had
+  issues with older versions, too).
+* Configuration scikit-build cares about _must_ be specified in ``setup()``
+  currently.
+* The cache directory (``_skbuild``) may need to be deleted between builds in
+  some cases (like rebuilding with a different Python interpreter).
+
+We are also working on improving scikit-build, so there are some upcoming
+changes and deprecations:
+
+
+* All deprecated setuptools/distutils features are also deprecated in
+  scikit-build, like the ``test`` command, ``easy_install``, etc.
+* Older versions of CMake (<3.15) are not recommended; a future version will
+  remove support for older CMake's (along with providing a better mechanism for
+  ensuring a proper CMake is available).
+
+If you need any of these features, please open or find an issue explaining what
+and why you need something.
+
+Miscellaneous
+-------------
+
+* Free software: MIT license
+* Documentation: http://scikit-build.readthedocs.org
+* Source code: https://github.com/scikit-build/scikit-build
+* Discussions: https://github.com/orgs/scikit-build/discussions
+
+
+Support for this work was provided by NSF cooperative agreement `OAC-2209877 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=2209877>`_.

--- a/test/test_binaries.py
+++ b/test/test_binaries.py
@@ -280,9 +280,7 @@ def test_patchable_function_entry_archive(tmp_path, package, binariescheck):
 
 
 @pytest.mark.parametrize('package', [
-    get_tested_mock_package(files={
-        '/usr/lib/systemd/system/yast-timesync.service': {'content': ''}
-    })
+    get_tested_mock_package(files=['/usr/lib/systemd/system/yast-timesync.service']),
 ])
 def test_systemd_unit_file(package, binariescheck):
     output, test = binariescheck

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -26,16 +26,16 @@ def test(pythoncheck):
 
 
 @pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        '/usr/lib/python2.7/site-packages/python-mypackage/doc': {},
-        '/usr/lib/python2.7/site-packages/python-mypackage/docs': {},
-        '/usr/lib/python3.10/site-packages/python-mypackage/doc': {},
-        '/usr/lib/python3.10/site-packages/python-mypackage/docs': {},
-        '/usr/lib64/python2.7/site-packages/python-mypackage/doc': {},
-        '/usr/lib64/python2.7/site-packages/python-mypackage/docs': {},
-        '/usr/lib64/python3.10/site-packages/python-mypackage/doc': {},
-        '/usr/lib64/python3.10/site-packages/python-mypackage/docs': {}
-    }
+    files=[
+        '/usr/lib/python2.7/site-packages/python-mypackage/doc',
+        '/usr/lib/python2.7/site-packages/python-mypackage/docs',
+        '/usr/lib/python3.10/site-packages/python-mypackage/doc',
+        '/usr/lib/python3.10/site-packages/python-mypackage/docs',
+        '/usr/lib64/python2.7/site-packages/python-mypackage/doc',
+        '/usr/lib64/python2.7/site-packages/python-mypackage/docs',
+        '/usr/lib64/python3.10/site-packages/python-mypackage/doc',
+        '/usr/lib64/python3.10/site-packages/python-mypackage/docs',
+    ]
 )])
 def test_python_doc_in_package(package, pythoncheck):
     output, test = pythoncheck
@@ -60,7 +60,7 @@ def test_python_doc_in_package(package, pythoncheck):
         '/usr/lib/python3.10/site-packages/python-mypackage/doc/__init__.py': {'create_dirs': True, 'include_dirs': 2},
         '/usr/lib/python3.10/site-packages/python-mypackage/docs/__init__.py': {'create_dirs': True, 'include_dirs': 1},
         '/usr/lib64/python3.10/site-packages/python-mypackage/doc/__init__.py': {'create_dirs': True, 'include_dirs': 2},
-        '/usr/lib64/python3.10/site-packages/python-mypackage/docs/__init__.py': {'create_dirs': True, 'include_dirs': 1}
+        '/usr/lib64/python3.10/site-packages/python-mypackage/docs/__init__.py': {'create_dirs': True, 'include_dirs': 1},
     }
 )])
 def test_python_doc_module_in_package(package, pythoncheck):
@@ -79,10 +79,10 @@ def test_python_doc_module_in_package(package, pythoncheck):
 
 @pytest.mark.parametrize('package', [get_tested_mock_package(
     files={
-        '/usr/lib/python2.7/site-packages/mydistutilspackage.egg-info': {'content': 'Metadata-Version: 2.1\nName: pythoncheck', 'create_dirs': False},
-        '/usr/lib/python3.10/site-packages/mydistutilspackage.egg-info': {'content': 'Metadata-Version: 2.1\nName: pythoncheck', 'create_dirs': False},
-        '/usr/lib64/python2.7/site-packages/mydistutilspackage.egg-info': {'content': 'Metadata-Version: 2.1\nName: pythoncheck', 'create_dirs': False},
-        '/usr/lib64/python3.10/site-packages/mydistutilspackage.egg-info': {'content': 'Metadata-Version: 2.1\nName: pythoncheck', 'create_dirs': False}
+        '/usr/lib/python2.7/site-packages/mydistutilspackage.egg-info': {'content': 'Metadata-Version: 2.1\nName: pythoncheck'},
+        '/usr/lib/python3.10/site-packages/mydistutilspackage.egg-info': {'content': 'Metadata-Version: 2.1\nName: pythoncheck'},
+        '/usr/lib64/python2.7/site-packages/mydistutilspackage.egg-info': {'content': 'Metadata-Version: 2.1\nName: pythoncheck'},
+        '/usr/lib64/python3.10/site-packages/mydistutilspackage.egg-info': {'content': 'Metadata-Version: 2.1\nName: pythoncheck'},
     },
     real_files=True
 )])
@@ -97,16 +97,16 @@ def test_python_distutils_egg_info(package, pythoncheck):
 
 
 @pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        '/usr/lib/python2.7/site-packages/doc': {},
-        '/usr/lib/python2.7/site-packages/docs': {},
-        '/usr/lib/python3.10/site-packages/doc': {},
-        '/usr/lib/python3.10/site-packages/docs': {},
-        '/usr/lib64/python2.7/site-packages/doc': {},
-        '/usr/lib64/python2.7/site-packages/docs': {},
-        '/usr/lib64/python3.10/site-packages/doc': {},
-        '/usr/lib64/python3.10/site-packages/docs': {}
-    }
+    files=[
+        '/usr/lib/python2.7/site-packages/doc',
+        '/usr/lib/python2.7/site-packages/docs',
+        '/usr/lib/python3.10/site-packages/doc',
+        '/usr/lib/python3.10/site-packages/docs',
+        '/usr/lib64/python2.7/site-packages/doc',
+        '/usr/lib64/python2.7/site-packages/docs',
+        '/usr/lib64/python3.10/site-packages/doc',
+        '/usr/lib64/python3.10/site-packages/docs',
+    ]
 )])
 def test_python_doc_in_site_packages(package, pythoncheck):
     output, test = pythoncheck
@@ -123,12 +123,12 @@ def test_python_doc_in_site_packages(package, pythoncheck):
 
 
 @pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        '/usr/lib/python2.7/site-packages/src': {},
-        '/usr/lib/python3.10/site-packages/src': {},
-        '/usr/lib64/python2.7/site-packages/src': {},
-        '/usr/lib64/python3.10/site-packages/src': {}
-    }
+    files=[
+        '/usr/lib/python2.7/site-packages/src',
+        '/usr/lib/python3.10/site-packages/src',
+        '/usr/lib64/python2.7/site-packages/src',
+        '/usr/lib64/python3.10/site-packages/src',
+    ]
 )])
 def test_python_src_in_site_packages(package, pythoncheck):
     output, test = pythoncheck
@@ -141,16 +141,16 @@ def test_python_src_in_site_packages(package, pythoncheck):
 
 
 @pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        '/usr/lib/python2.7/site-packages/test': {},
-        '/usr/lib/python2.7/site-packages/tests': {},
-        '/usr/lib/python3.10/site-packages/test': {},
-        '/usr/lib/python3.10/site-packages/tests': {},
-        '/usr/lib64/python2.7/site-packages/test': {},
-        '/usr/lib64/python2.7/site-packages/tests': {},
-        '/usr/lib64/python3.10/site-packages/test': {},
-        '/usr/lib64/python3.10/site-packages/tests': {}
-    }
+    files=[
+        '/usr/lib/python2.7/site-packages/test',
+        '/usr/lib/python2.7/site-packages/tests',
+        '/usr/lib/python3.10/site-packages/test',
+        '/usr/lib/python3.10/site-packages/tests',
+        '/usr/lib64/python2.7/site-packages/test',
+        '/usr/lib64/python2.7/site-packages/tests',
+        '/usr/lib64/python3.10/site-packages/test',
+        '/usr/lib64/python3.10/site-packages/tests',
+    ]
 )])
 def test_python_tests_in_site_packages(package, pythoncheck):
     output, test = pythoncheck
@@ -528,20 +528,20 @@ def test_python_dependencies_leftover2(package, pythoncheck):
 
 
 @pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/base.cpython-310.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/base.cpython-39.opt-1.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/base.cpython-39.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/__init__.cpython-310.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/__init__.cpython-39.opt-1.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/__init__.cpython-39.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/_saferef.cpython-310.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/_saferef.cpython-39.opt-1.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/_saferef.cpython-39.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-310.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.opt-1.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.pyc': {},
-    }
+    files=[
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/base.cpython-310.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/base.cpython-39.opt-1.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/base.cpython-39.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/__init__.cpython-310.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/__init__.cpython-39.opt-1.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/__init__.cpython-39.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/_saferef.cpython-310.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/_saferef.cpython-39.opt-1.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/_saferef.cpython-39.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-310.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.opt-1.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.pyc',
+    ]
 )])
 def test_python_pyc_multiple_versions(package, pythoncheck):
     output, test = pythoncheck
@@ -551,16 +551,16 @@ def test_python_pyc_multiple_versions(package, pythoncheck):
 
 
 @pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/base.cpython-39.opt-1.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/base.cpython-39.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/__init__.cpython-39.opt-1.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/__init__.cpython-39.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/_saferef.cpython-39.opt-1.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/_saferef.cpython-39.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.opt-1.pyc': {},
-        'usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.pyc': {},
-    }
+    files=[
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/base.cpython-39.opt-1.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/base.cpython-39.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/__init__.cpython-39.opt-1.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/__init__.cpython-39.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/_saferef.cpython-39.opt-1.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/_saferef.cpython-39.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.opt-1.pyc',
+        '/usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.pyc',
+    ]
 )])
 def test_python_pyc_single_version(package, pythoncheck):
     output, test = pythoncheck

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -37,8 +37,7 @@ def test(pythoncheck):
         '/usr/lib64/python3.10/site-packages/python-mypackage/docs',
     ]
 )])
-def test_python_doc_in_package(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_doc_in_package(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-doc-in-package /usr/lib/python2.7/site-packages/python-mypackage/doc' in out
@@ -63,8 +62,7 @@ def test_python_doc_in_package(package, pythoncheck):
         '/usr/lib64/python3.10/site-packages/python-mypackage/docs/__init__.py': {'create_dirs': True, 'include_dirs': 1},
     }
 )])
-def test_python_doc_module_in_package(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_doc_module_in_package(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-doc-in-package /usr/lib/python2.7/site-packages/python-mypackage/doc' not in out
@@ -86,8 +84,7 @@ def test_python_doc_module_in_package(package, pythoncheck):
     },
     real_files=True
 )])
-def test_python_distutils_egg_info(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_distutils_egg_info(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'E: python-egg-info-distutils-style /usr/lib/python2.7/site-packages/mydistutilspackage.egg-info' in out
@@ -108,8 +105,7 @@ def test_python_distutils_egg_info(package, pythoncheck):
         '/usr/lib64/python3.10/site-packages/docs',
     ]
 )])
-def test_python_doc_in_site_packages(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_doc_in_site_packages(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'E: python-doc-in-site-packages /usr/lib/python2.7/site-packages/doc' in out
@@ -130,8 +126,7 @@ def test_python_doc_in_site_packages(package, pythoncheck):
         '/usr/lib64/python3.10/site-packages/src',
     ]
 )])
-def test_python_src_in_site_packages(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_src_in_site_packages(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'E: python-src-in-site-packages /usr/lib/python2.7/site-packages/src' in out
@@ -152,8 +147,7 @@ def test_python_src_in_site_packages(package, pythoncheck):
         '/usr/lib64/python3.10/site-packages/tests',
     ]
 )])
-def test_python_tests_in_site_packages(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_tests_in_site_packages(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'E: python-tests-in-site-packages /usr/lib/python2.7/site-packages/test' in out
@@ -166,31 +160,93 @@ def test_python_tests_in_site_packages(package, pythoncheck):
     assert 'E: python-tests-in-site-packages /usr/lib64/python3.10/site-packages/tests' in out
 
 
-@pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        '/usr/lib/python3.10/site-packages/flit-3.8.0.dist-info/METADATA': {
-            'content': """
-Requires-Dist: flit_core >=3.8.0
-Requires-Dist: requests
-Requires-Dist: docutils
-Requires-Dist: tomli-w
-Requires-Dist: sphinx ; extra == "doc"
-""",
-            'create_dirs': True
+@pytest.mark.parametrize('package', [
+    get_tested_mock_package(
+        files={
+            '/usr/lib/python3.10/site-packages/flit-3.8.0.dist-info/METADATA': {
+                'content-path': 'files/python-flit-metadata.txt',
+                'create_dirs': True,
+            },
         },
-    },
-    real_files=True,
-    header={
-        'requires': [
-            'python-flit_core',
-            'python-requests',
-            'python-tomli-w',
-            'python310-docutils',
-        ],
-    },
-)])
-def test_python_dependencies_metadata(package, pythoncheck):
-    output, test = pythoncheck
+        real_files=True,
+        header={
+            'requires': [
+                'python-flit_core',
+                'python-requests',
+                'python-tomli-w',
+                'python310-docutils',
+            ],
+        },
+    ),
+    get_tested_mock_package(
+        files={
+            '/usr/lib/python3.10/site-packages/jupyter_server_fileid-0.9.0.dist-info/METADATA': {
+                'content-path': 'files/python-jupyter_server_fileid-metadata.txt',
+                'create_dirs': True
+            },
+        },
+        real_files=True,
+        header={
+            'requires': [
+                'python-jupyter-events',
+                'python-click',
+                'python-jupyter-server',
+            ],
+        },
+    ),
+    get_tested_mock_package(
+        files={
+            '/usr/lib/python3.10/site-packages/jupyter_events-0.6.3.dist-info/METADATA': {
+                'content-path': 'files/python-jupyter-events-metadata.txt',
+                'create_dirs': True
+            },
+        },
+        real_files=True,
+        header={
+            'requires': [
+                'python-jsonschema',
+                'python-python-json-logger',
+                'python-pyyaml',
+                'python-rfc3339-validator',
+                'python-rfc3986-validator',
+                'python-traitlets',
+                'python-click',
+                'python-rich',
+                'python-jupyterlite-sphinx',
+                'python-myst-parser',
+                'python-pydata-sphinx-theme',
+                'python-sphinxcontrib-spelling',
+                'python-click',
+                'python-coverage',
+                'python-pre-commit',
+                'python-pytest-asyncio',
+                'python-pytest-console-scripts',
+                'python-pytest-cov',
+                'python-pytest',
+                'python-rich',
+            ],
+        },
+    ),
+    get_tested_mock_package(
+        files={
+            '/usr/lib/python3.10/site-packages/scikit_build-0.17.2.dist-info/METADATA': {
+                'content-path': 'files/python-scikit_build-metadata.txt',
+                'create_dirs': True
+            },
+        },
+        real_files=True,
+        header={
+            'requires': [
+                'python-distro',
+                'python-packaging',
+                'python-setuptools',
+                'python-wheel',
+                'python-tomli',
+            ],
+        },
+    ),
+])
+def test_python_dependencies_metadata(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-missing-require' not in out
@@ -219,176 +275,7 @@ pygments>=2.2.0
         ],
     },
 )])
-def test_python_dependencies_requires(package, pythoncheck):
-    output, test = pythoncheck
-    test.check(package)
-    out = output.print_results(output.results)
-    assert 'W: python-missing-require' not in out
-    assert 'W: python-leftover-require' not in out
-
-
-@pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        '/usr/lib/python3.10/site-packages/jupyter_server_fileid-0.9.0.dist-info/METADATA': {
-            'content': """
-Requires-Python: >=3.7
-Requires-Dist: jupyter-events>=0.5.0
-Requires-Dist: jupyter-server<3,>=1.15
-Requires-Dist: click; extra == 'cli'
-Requires-Dist: jupyter-server[test]<3,>=1.15; extra == 'test'
-Requires-Dist: pytest; extra == 'test'
-Requires-Dist: pytest-cov; extra == 'test'
-""",
-            'create_dirs': True
-        },
-    },
-    real_files=True,
-    header={
-        'requires': [
-            'python-jupyter-events',
-            'python-jupyter-server',
-            'python-click',
-            'python-jupyter-server',
-            'python-pytest',
-            'python-pytest-cov',
-        ],
-    },
-)])
-def test_python_dependencies_metadata2(package, pythoncheck):
-    output, test = pythoncheck
-    test.check(package)
-    out = output.print_results(output.results)
-    assert 'W: python-missing-require' not in out
-    assert 'W: python-leftover-require' not in out
-
-
-@pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        '/usr/lib/python3.10/site-packages/jupyter_server_fileid-0.9.0.dist-info/METADATA': {
-            'content': """
-Requires-Dist: distro
-Requires-Dist: packaging
-Requires-Dist: setuptools>=42.0.0
-Requires-Dist: tomli; python_version < '3.11'
-Requires-Dist: typing-extensions>=3.7; python_version < '3.8'
-Requires-Dist: wheel>=0.32.0
-Requires-Dist: coverage[toml]>=4.2; extra == 'cov'
-Requires-Dist: pytest-cov>=2.7.1; extra == 'cov'
-Requires-Dist: pygments; extra == 'docs'
-Requires-Dist: sphinx-issues; extra == 'docs'
-Requires-Dist: sphinx-rtd-theme>=1.0; extra == 'docs'
-Requires-Dist: sphinx>=4; extra == 'docs'
-Requires-Dist: sphinxcontrib-moderncmakedomain>=3.19; extra == 'docs'
-Requires-Dist: ubelt>=0.8.2; extra == 'doctest'
-Requires-Dist: xdoctest>=0.10.0; extra == 'doctest'
-Requires-Dist: build>=0.7; extra == 'test'
-Requires-Dist: cython>=0.25.1; extra == 'test'
-Requires-Dist: importlib-metadata; python_version < '3.8' and extra == 'test'
-Requires-Dist: pytest-mock>=1.10.4; extra == 'test'
-Requires-Dist: pytest-virtualenv>=1.2.5; extra == 'test'
-Requires-Dist: pytest>=6.0.0; extra == 'test'
-Requires-Dist: requests; extra == 'test'
-Requires-Dist: virtualenv; extra == 'test'
-""",
-            'create_dirs': True
-        },
-    },
-    real_files=True,
-    header={
-        'requires': [
-            'python-distro',
-            'python-packaging',
-            'python-setuptools',
-            'python-tomli',
-            'python-typing-extensions',
-            'python-wheel',
-            'python-coverage',
-            'python-pytest-cov',
-            'python-pygments',
-            'python-sphinx-issues',
-            'python-sphinx-rtd-theme',
-            'python-sphinx',
-            'python-sphinxcontrib-moderncmakedomain',
-            'python-ubelt',
-            'python-xdoctest',
-            'python-build',
-            'python-cython',
-            'python-importlib-metadata',
-            'python-pytest-mock',
-            'python-pytest-virtualenv',
-            'python-pytest',
-            'python-requests',
-            'python-virtualenv',
-        ],
-    },
-)])
-def test_python_dependencies_metadata3(package, pythoncheck):
-    output, test = pythoncheck
-    test.check(package)
-    out = output.print_results(output.results)
-    assert 'W: python-missing-require' not in out
-    assert 'W: python-leftover-require' not in out
-
-
-@pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        '/usr/lib/python3.10/site-packages/jupyter_server_fileid-0.9.0.dist-info/METADATA': {
-            'content': """
-Requires-Dist: jsonschema[format-nongpl]>=3.2.0
-Requires-Dist: python-json-logger>=2.0.4
-Requires-Dist: pyyaml>=5.3
-Requires-Dist: rfc3339-validator
-Requires-Dist: rfc3986-validator>=0.1.1
-Requires-Dist: traitlets>=5.3
-Provides-Extra: cli
-Requires-Dist: click; extra == 'cli'
-Requires-Dist: rich; extra == 'cli'
-Provides-Extra: docs
-Requires-Dist: jupyterlite-sphinx; extra == 'docs'
-Requires-Dist: myst-parser; extra == 'docs'
-Requires-Dist: pydata-sphinx-theme; extra == 'docs'
-Requires-Dist: sphinxcontrib-spelling; extra == 'docs'
-Provides-Extra: test
-Requires-Dist: click; extra == 'test'
-Requires-Dist: coverage; extra == 'test'
-Requires-Dist: pre-commit; extra == 'test'
-Requires-Dist: pytest-asyncio>=0.19.0; extra == 'test'
-Requires-Dist: pytest-console-scripts; extra == 'test'
-Requires-Dist: pytest-cov; extra == 'test'
-Requires-Dist: pytest>=7.0; extra == 'test'
-Requires-Dist: rich; extra == 'test'
-""",
-            'create_dirs': True
-        },
-    },
-    real_files=True,
-    header={
-        'requires': [
-            'python-jsonschema',
-            'python-python-json-logger',
-            'python-pyyaml',
-            'python-rfc3339-validator',
-            'python-rfc3986-validator',
-            'python-traitlets',
-            'python-click',
-            'python-rich',
-            'python-jupyterlite-sphinx',
-            'python-myst-parser',
-            'python-pydata-sphinx-theme',
-            'python-sphinxcontrib-spelling',
-            'python-click',
-            'python-coverage',
-            'python-pre-commit',
-            'python-pytest-asyncio',
-            'python-pytest-console-scripts',
-            'python-pytest-cov',
-            'python-pytest',
-            'python-rich',
-        ],
-    },
-)])
-def test_python_dependencies_metadata4(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_dependencies_requires(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-missing-require' not in out
@@ -416,8 +303,7 @@ pygments>=2.2.0
         ],
     },
 )])
-def test_python_dependencies_missing_requires(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_dependencies_missing_requires(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-missing-require' in out
@@ -426,20 +312,7 @@ def test_python_dependencies_missing_requires(package, pythoncheck):
 @pytest.mark.parametrize('package', [get_tested_mock_package(
     files={
         '/usr/lib/python3.10/site-packages/flit-3.8.0.dist-info/METADATA': {
-            'content': """
-Requires-Dist: flit_core >=3.8.0
-Requires-Dist: requests
-Requires-Dist: docutils
-Requires-Dist: tomli-w
-Requires-Dist: sphinx ; extra == "doc"
-Requires-Dist: sphinxcontrib_github_alt ; extra == "doc"
-Requires-Dist: pygments-github-lexers ; extra == "doc"
-Requires-Dist: testpath ; extra == "test"
-Requires-Dist: responses ; extra == "test"
-Requires-Dist: pytest>=2.7.3 ; extra == "test"
-Requires-Dist: pytest-cov ; extra == "test"
-Requires-Dist: tomli ; extra == "test"
-""",
+            'content-path': 'files/python-flit-metadata.txt',
             'create_dirs': True
         },
     },
@@ -452,76 +325,56 @@ Requires-Dist: tomli ; extra == "test"
         ],
     },
 )])
-def test_python_dependencies_missing_metadata(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_dependencies_missing_metadata(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-missing-require' in out
 
 
-@pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        '/usr/lib/python3.10/site-packages/icecream-2.1.3-py3.10.egg-info/requires.txt': {
-            'content': """
+@pytest.mark.parametrize('package', [
+    get_tested_mock_package(
+        files={
+            '/usr/lib/python3.10/site-packages/icecream-2.1.3-py3.10.egg-info/requires.txt': {
+                'content': """
 asttokens>=2.0.1
 colorama>=0.3.9
 executing>=0.3.1
 pygments>=2.2.0
 """,
-            'create_dirs': True
+                'create_dirs': True
+            },
         },
-    },
-    real_files=True,
-    header={
-        'requires': [
-            'python3-asttokens >= 2.0.1',
-            'python3-colorama >= 0.3.9',
-            'python3-executing >= 0.3.1',
-            'python3-poetry',
-            'python3-pygments >= 2.2.0',
-        ],
-    },
-)])
-def test_python_dependencies_leftover1(package, pythoncheck):
-    output, test = pythoncheck
-    test.check(package)
-    out = output.print_results(output.results)
-    assert 'W: python-leftover-require' in out
-
-
-@pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        '/usr/lib/python3.10/site-packages/flit-3.8.0.dist-info/METADATA': {
-            'content': """
-Requires-Dist: flit_core >=3.8.0
-Requires-Dist: requests
-Requires-Dist: docutils
-Requires-Dist: tomli-w
-Requires-Dist: sphinx ; extra == "doc"
-Requires-Dist: sphinxcontrib_github_alt ; extra == "doc"
-Requires-Dist: pygments-github-lexers ; extra == "doc"
-Requires-Dist: testpath ; extra == "test"
-Requires-Dist: responses ; extra == "test"
-Requires-Dist: pytest>=2.7.3 ; extra == "test"
-Requires-Dist: pytest-cov ; extra == "test"
-Requires-Dist: tomli ; extra == "test"
-""",
-            'create_dirs': True
+        real_files=True,
+        header={
+            'requires': [
+                'python3-asttokens >= 2.0.1',
+                'python3-colorama >= 0.3.9',
+                'python3-executing >= 0.3.1',
+                'python3-poetry',
+                'python3-pygments >= 2.2.0',
+            ],
         },
-    },
-    real_files=True,
-    header={
-        'requires': [
-            'python3-docutils',
-            'python3-flit-core',
-            'python3-poetry',
-            'python3-requests',
-            'python3-tomli-w',
-        ],
-    },
-)])
-def test_python_dependencies_leftover2(package, pythoncheck):
-    output, test = pythoncheck
+    ),
+    get_tested_mock_package(
+        files={
+            '/usr/lib/python3.10/site-packages/flit-3.8.0.dist-info/METADATA': {
+                'content-path': 'files/python-flit-metadata.txt',
+                'create_dirs': True
+            },
+        },
+        real_files=True,
+        header={
+            'requires': [
+                'python3-docutils',
+                'python3-flit-core',
+                'python3-poetry',
+                'python3-requests',
+                'python3-tomli-w',
+            ],
+        },
+    ),
+])
+def test_python_dependencies_leftover(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-leftover-require' in out
@@ -543,8 +396,7 @@ def test_python_dependencies_leftover2(package, pythoncheck):
         '/usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.pyc',
     ]
 )])
-def test_python_pyc_multiple_versions(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_pyc_multiple_versions(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-pyc-multiple-versions expected: 310' in out
@@ -562,8 +414,7 @@ def test_python_pyc_multiple_versions(package, pythoncheck):
         '/usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.pyc',
     ]
 )])
-def test_python_pyc_single_version(package, pythoncheck):
-    output, test = pythoncheck
+def test_python_pyc_single_version(package, test, output):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-pyc-multiple-versions' not in out


### PR DESCRIPTION
This patch allows to use just a list of paths to define the files for the mock package to use when it's not needed to specify the content or file properties.