### PR TITLE
test: Remove real_files opotional parameter

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -9,7 +9,7 @@ In this new test suite, we will utilize a `FakePkg` class, which acts as a mock 
 The `get_tested_mock_package` function's interface is as follows:
 
 ```python
-def get_tested_mock_package(files=None, real_files=None, header=None)
+def get_tested_mock_package(files=None, header=None)
 ```
 
 For each new test, we employ the `get_tested_mock_package` function, a helper from `test/Testing.py`. This function leverages the `FakePkg` class to create a mock package named `mockPkg`.
@@ -17,10 +17,10 @@ For each new test, we employ the `get_tested_mock_package` function, a helper fr
 The current implementation of the `get_tested_mock_package` function is as follows:
 
 ```python
-def get_tested_mock_package(files=None, real_files=None, header=None):
+def get_tested_mock_package(files=None, header=None):
     mockPkg = FakePkg('mockPkg')
     if files is not None:
-        mockPkg.create_files(files, real_files)
+        mockPkg.create_files(files)
     if header is not None:
         mockPkg.add_header(header)
     mockPkg.initiate_files_base_data()
@@ -29,7 +29,6 @@ def get_tested_mock_package(files=None, real_files=None, header=None):
 
 The `get_tested_mock_package` function can accept arguments
 - `files`
-- `real_files`
 - `header`
 
 See the example test function below to get basic idea
@@ -61,10 +60,6 @@ def test_python_doc_in_site_packages(package, pythoncheck):
 If the content or metadata of the files in the package is not important, it's
 possible to use just a list of paths and the files will be created with default
 empty content and default flags.
-
-
-**`real_files`**:
-Each of the above file is converted into a `PkgFile` object by default, and into real file only if `real_file` is passed with `True` parameter.
 
 **`header`**:
 Header is dictionary object that is specific to rpm file. We can pass specific rpm file header information with this parameter. See [`test_python.py`](https://github.com/afrid18/rpmlint/blob/c7e36548742f94acc9e102dc328605fdea06329c/test/test_python.py#L183) tests for more info

--- a/test/Testing.py
+++ b/test/Testing.py
@@ -62,7 +62,7 @@ def get_tested_spec_package(name):
     return FakePkg(candidates[0])
 
 
-def get_tested_mock_package(files=None, real_files=None, header=None):
+def get_tested_mock_package(files=None, header=None):
     mockPkg = FakePkg('mockPkg')
     if files is not None:
         if isinstance(files, dict):
@@ -71,7 +71,7 @@ def get_tested_mock_package(files=None, real_files=None, header=None):
                 if 'content-path' in attrs:
                     attrs['content-path'] = get_tested_path(attrs['content-path'])
 
-        mockPkg.create_files(files, real_files)
+        mockPkg.create_files(files)
     if header is not None:
         mockPkg.add_header(header)
     mockPkg.initiate_files_base_data()

--- a/test/test_config_files.py
+++ b/test/test_config_files.py
@@ -1,4 +1,5 @@
 import pytest
+from rpm import RPMFILE_CONFIG, RPMFILE_NOREPLACE
 from rpmlint.checks.ConfigFilesCheck import ConfigFilesCheck
 from rpmlint.filter import Filter
 
@@ -15,9 +16,9 @@ def configfilescheck():
 
 @pytest.mark.parametrize('package', [get_tested_mock_package(
     files={
-        '/etc/conffile1': {'content': '# Conffile1', 'metadata': {'flags': 1}},
-        '/var/conffile2': {'content': '# Conffile2', 'metadata': {'flags': 1}},
-        '/usr/share/conffile3': {'content': '# Conffile3', 'metadata': {'flags': 1}},
+        '/etc/conffile1': {'metadata': {'flags': RPMFILE_CONFIG}},
+        '/var/conffile2': {'metadata': {'flags': RPMFILE_CONFIG}},
+        '/usr/share/conffile3': {'metadata': {'flags': RPMFILE_CONFIG}},
     }
 )])
 def test_config_files1(package, configfilescheck):
@@ -30,16 +31,22 @@ def test_config_files1(package, configfilescheck):
     assert 'conffile-without-noreplace-flag /usr/share/conffile3' in out
 
 
-@pytest.mark.parametrize('package', [get_tested_mock_package(
-    files={
-        'tmp/foo/my.log': {'content': '', 'metadata': {'flags': 0}},
-        'tmp/foo2': {'content': '', 'metadata': {'flags': 0}},
-        'tmp/foo2/my.log': {'content': '', 'metadata': {'flags': 0}},
-        'etc/logrotate.d': {'content': '', 'metadata': {'flags': 0}},
-        'etc/logrotate.d/logrotate2.conf': {'content': '', 'metadata': {'flags': 0}},
-        'etc/logrotate.d/logrotate.conf': {'content': '', 'metadata': {'flags': 0}},
-    }
-)])
+@pytest.mark.parametrize('package', [
+    get_tested_mock_package(
+        files=[
+            'tmp/foo/my.log',
+            'tmp/foo2/my.log',
+            'etc/logrotate.d/logrotate2.conf',
+            'etc/logrotate.d/logrotate.conf',
+        ]
+    ),
+    get_tested_mock_package(
+        files={
+            '/etc/conffile1': {'metadata': {'flags': RPMFILE_CONFIG & RPMFILE_NOREPLACE}},
+            '/var/conffile2': {'metadata': {'flags': RPMFILE_CONFIG & RPMFILE_NOREPLACE}},
+        }
+    )
+])
 def test_config_files_correct1(package, configfilescheck):
     output, test = configfilescheck
     test.check(package)

--- a/test/test_duplicates.py
+++ b/test/test_duplicates.py
@@ -27,7 +27,6 @@ def duplicatescheck():
         '/var/foo': {'content': 'Foo file', 'metadata': {'mode': 33188, 'inode': 10}},
         '/var/foo2': {'content': 'Foo 2 file', 'metadata': {'mode': 33188, 'flags': 1, 'inode': 5}}
     },
-    real_files=True
 )])
 def test_duplicates1(package, duplicatescheck):
     output, test = duplicatescheck
@@ -47,7 +46,6 @@ def test_duplicates1(package, duplicatescheck):
         '/usr/share/bad-crc.zip': {'content': 'this is a zip file', 'metadata': {'mode': 33188, 'flags': 1}},
         '/usr/share/uncompressed.zip': {'content': 'this is an another zip file', 'metadata': {'mode': 33188, 'flags': 1}},
     },
-    real_files=True
 )])
 def test_duplicates_correct(package, duplicatescheck):
     output, test = duplicatescheck

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -82,7 +82,6 @@ def test_python_doc_module_in_package(package, test, output):
         '/usr/lib64/python2.7/site-packages/mydistutilspackage.egg-info': {'content': 'Metadata-Version: 2.1\nName: pythoncheck'},
         '/usr/lib64/python3.10/site-packages/mydistutilspackage.egg-info': {'content': 'Metadata-Version: 2.1\nName: pythoncheck'},
     },
-    real_files=True
 )])
 def test_python_distutils_egg_info(package, test, output):
     test.check(package)
@@ -168,7 +167,6 @@ def test_python_tests_in_site_packages(package, test, output):
                 'create_dirs': True,
             },
         },
-        real_files=True,
         header={
             'requires': [
                 'python-flit_core',
@@ -185,7 +183,6 @@ def test_python_tests_in_site_packages(package, test, output):
                 'create_dirs': True
             },
         },
-        real_files=True,
         header={
             'requires': [
                 'python-jupyter-events',
@@ -201,7 +198,6 @@ def test_python_tests_in_site_packages(package, test, output):
                 'create_dirs': True
             },
         },
-        real_files=True,
         header={
             'requires': [
                 'python-jsonschema',
@@ -234,7 +230,6 @@ def test_python_tests_in_site_packages(package, test, output):
                 'create_dirs': True
             },
         },
-        real_files=True,
         header={
             'requires': [
                 'python-distro',
@@ -265,7 +260,6 @@ pygments>=2.2.0
             'create_dirs': True
         },
     },
-    real_files=True,
     header={
         'requires': [
             'asttokens>=2.0.1',
@@ -294,7 +288,6 @@ pygments>=2.2.0
             'create_dirs': True
         },
     },
-    real_files=True,
     header={
         'requires': [
             'asttokens>=2.0.1',
@@ -316,7 +309,6 @@ def test_python_dependencies_missing_requires(package, test, output):
             'create_dirs': True
         },
     },
-    real_files=True,
     header={
         'requires': [
             'python3-flit-core',
@@ -344,7 +336,6 @@ pygments>=2.2.0
                 'create_dirs': True
             },
         },
-        real_files=True,
         header={
             'requires': [
                 'python3-asttokens >= 2.0.1',
@@ -362,7 +353,6 @@ pygments>=2.2.0
                 'create_dirs': True
             },
         },
-        real_files=True,
         header={
             'requires': [
                 'python3-docutils',


### PR DESCRIPTION
Do not create the FakePkg files could make tests run faster, but it's safer, and simpler, to just create the files because some checks expects the files to exists, so it's a better default option.