### PR TITLE
Fix time report function output string creation

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -133,9 +133,9 @@ class Lint:
         total_checked_files = max(checked_files) if checked_files else ''
         print(f'{Color.Bold}Check time report{Color.Reset} (>{PERCENT_THRESHOLD}% & >{TIME_THRESHOLD}s):')
 
-        check = format('Check', ':32s')
-        duration = format('Duration (in s)', ':>12')
-        fraction = format('Fraction (in %)', ':>17')
+        check = format('Check', '32s')
+        duration = format('Duration (in s)', '>12')
+        fraction = format('Fraction (in %)', '>17')
         print(f'{Color.Bold}    {check} {duration} {fraction}  Checked files{Color.Reset}')
 
         for check, duration in sorted(self.check_duration.items(), key=operator.itemgetter(1), reverse=True):

--- a/test/test_lint.py
+++ b/test/test_lint.py
@@ -85,6 +85,19 @@ def test_configoutput(capsys):
     assert not err
 
 
+def test_time_report(capsys):
+    additional_options = {
+        'time_report': True,
+    }
+    options = {**options_preset, **additional_options}
+    linter = Lint(options)
+    linter.run()
+    out, err = capsys.readouterr()
+    assert out
+    assert 'Duration' in out
+    assert 'TOTAL' in out
+
+
 def test_explain_unknown(capsys):
     message = ['bullcrap']
     additional_options = {


### PR DESCRIPTION
The format builtin function receives the format spec as second value, but the `:` was a mistake from the refactoring done before, those colon are not correct in the format and produces an Exception.

This patch also introduces a test to avoid regressions.