### PR TITLE
sysctl-whitelist: remove outdated microos-tools entry

### DIFF
--- a/configs/openSUSE/sysctl-whitelist.toml
+++ b/configs/openSUSE/sysctl-whitelist.toml
@@ -29,16 +29,6 @@ digester = "shell"
 hash = "7642699dc64ccba77154ede500b8657989cbe0e82c67753a3df8c334efa0a8f8"
 
 [[FileDigestGroup]]
-package = "microos-tools"
-type = "sysctl"
-note = "sets a basic core_pattern for /var/tmp"
-bug = "bsc#1174722"
-[[FileDigestGroup.digests]]
-path = "/usr/lib/sysctl.d/30-corefiles.conf"
-digester = "shell"
-hash = "76b113d7e9bad9585437a32fb4b28d701ca945bdbc4697018e2f29e04e00f920"
-
-[[FileDigestGroup]]
 package = "owncloud-client"
 type = "sysctl"
 note = "increases inotify max user watches"


### PR DESCRIPTION
This file does not exist anymore. See also:
- https://build.opensuse.org/request/show/1079104/changes
- https://github.com/openSUSE/microos-tools/commit/2a43cdb3220241f02b8cae551976aa1776c69b38

OBS submission is NOT NECESSARY. Simply merging will suffice.