### PR TITLE
Add new check to detect links to scripts

### DIFF
--- a/rpmlint/descriptions/FilesCheck.toml
+++ b/rpmlint/descriptions/FilesCheck.toml
@@ -403,3 +403,9 @@ manual-page-in-subfolder="""
 Manual page should not be placed in a subfolder of a manual section
 directory.
 """
+
+symlink-to-binary-with-shebang="""
+A file in /usr/bin is a link to a script in a different place with a shebang.
+rpm won't be able to inject the needed interpreter as dependency, so it should
+be done manually.
+"""


### PR DESCRIPTION
This new check looks for links in /usr/bin that points to some script in a non bin path that contains a shebang, and checks if the needed interpreter is included as a requirement, because in that case rpm won't be able to inject the requirement by itself.

Fix https://github.com/rpm-software-management/rpmlint/issues/1120