### PR TITLE
zypper-plugins: match the new shebang (bsc#1212476)

### DIFF
--- a/configs/openSUSE/zypper-plugins.toml
+++ b/configs/openSUSE/zypper-plugins.toml
@@ -56,7 +56,7 @@ bug = "bsc#1204314"
 [[FileDigestGroup.digests]]
 path = "/usr/lib/zypp/plugins/commit/permissions.py"
 digester = "shell"
-hash = "db141ad0e17dd6c0b34a671159f95357914693c3ab5e23f64f3724f713bb7c5d"
+hash = "40ace802b2077815f693c9abfbcef21cd6fa3f316e892f9461f0d22b04135c53"
 
 [[FileDigestGroup]]
 package = "snapper-zypp-plugin"


### PR DESCRIPTION
see also:
- https://bugzilla.suse.com/show_bug.cgi?id=1212476
- https://build.opensuse.org/request/show/1129913

This new patch dynamically patches the shebang. In this case `/usr/bin/python3` gets changed to `/usr/bin/python3.11`.
