### PR TITLE
FileDigestCheck: Filter minor versions in shebangs.

### DIFF
--- a/rpmlint/checks/FileDigestCheck.py
+++ b/rpmlint/checks/FileDigestCheck.py
@@ -4,6 +4,7 @@ import hashlib
 from pathlib import Path
 import stat
 import xml.etree.ElementTree as ET
+import re
 
 from rpmlint.checks.AbstractCheck import AbstractCheck
 
@@ -74,8 +75,11 @@ class ShellDigester(DefaultDigester):
                     # skip empty lines
                     continue
                 elif line_nr == 0 and stripped.startswith('#!'):
-                    # keep shebang lines instact
-                    pass
+                    # keep shebang lines mostly intact,
+                    # but ignore minor interpreter versions
+                    shebang = re.sub(r'\bpython3\.\d+\b', 'python3', line)
+                    yield(shebang.encode())
+                    continue
                 elif stripped.startswith('#'):
                     # skip comments
                     # NOTE: we don't strip trailing comments like in

--- a/test/configs/digests_filtered.config
+++ b/test/configs/digests_filtered.config
@@ -16,6 +16,11 @@ path = "/shell/test.sh"
 algorithm = "sha256"
 digester = "shell"
 hash = "44c0c33ec06bb5c82bc1d2cefe697db8d3ec20c5d4bc49c90988251fb57e0e19"
+[[FileDigestGroup.digests]]
+path = "/shell/test.py"
+algorithm = "sha256"
+digester = "shell"
+hash = "e9428178423e76cd2287ae34eb4b47a03a53eb670d3bd303572a1a462e3fe0e8"
 
 [[FileDigestGroup]]
 package = "xmlpkg"

--- a/test/data/shell_digest_shebang.py
+++ b/test/data/shell_digest_shebang.py
@@ -1,0 +1,2 @@
+#!/usr/bin/python3
+print("Hello, World")


### PR DESCRIPTION
openSUSE is now dynamically patching shebangs of Python script in order to specify the exact minor version, instead of just the major version, e.g. !/usr/bin/python3 will be substituted with !/usr/bin/python3.11. This not only alters existing whitelistings but will also require us to update whitelistings for every minor version bump of the Python interpreter.

This commit makes the shell filter ignore minor interpreter versions in shebangs, e.g.  python3.11 will be read as python3. Arguments are supported: !/usr/bin/python3.11 -v
will be read as
!/usr/bin/python3 -v

See also:
https://bugzilla.suse.com/show_bug.cgi?id=1212476