### PR TITLE
FileDigestCheck: Filter minor versions in shebangs.

### DIFF
--- a/rpmlint/checks/FileDigestCheck.py
+++ b/rpmlint/checks/FileDigestCheck.py
@@ -2,6 +2,7 @@ import contextlib
 from fnmatch import fnmatch
 import hashlib
 from pathlib import Path
+import re
 import stat
 import xml.etree.ElementTree as ET
 
@@ -74,8 +75,9 @@ class ShellDigester(DefaultDigester):
                     # skip empty lines
                     continue
                 elif line_nr == 0 and stripped.startswith('#!'):
-                    # keep shebang lines instact
-                    pass
+                    # keep shebang lines mostly intact,
+                    # but ignore minor interpreter versions
+                    line = re.sub(r'\bpython3\.\d+\b', 'python3', line)
                 elif stripped.startswith('#'):
                     # skip comments
                     # NOTE: we don't strip trailing comments like in

--- a/test/configs/digests_filtered.config
+++ b/test/configs/digests_filtered.config
@@ -16,6 +16,11 @@ path = "/shell/test.sh"
 algorithm = "sha256"
 digester = "shell"
 hash = "44c0c33ec06bb5c82bc1d2cefe697db8d3ec20c5d4bc49c90988251fb57e0e19"
+[[FileDigestGroup.digests]]
+path = "/shell/test.py"
+algorithm = "sha256"
+digester = "shell"
+hash = "d374524a4eca6a12cc3897095bae74d2712116270af68fa81cfbf8332411f0b7"
 
 [[FileDigestGroup]]
 package = "xmlpkg"

--- a/test/data/shell_digest_shebang.py
+++ b/test/data/shell_digest_shebang.py
@@ -1,0 +1,2 @@
+#!/usr/bin/python3
+print('Hello, World')

--- a/test/test_file_digest.py
+++ b/test/test_file_digest.py
@@ -249,6 +249,47 @@ def test_shell_digest_filter():
         assert len(output.results) == 1
 
 
+def test_shell_digest_filter_shebang():
+    with open(get_tested_path('data/shell_digest_shebang.py')) as f:
+        python_script = f.read()
+
+    output, test = get_digestcheck('digests_filtered.config')
+    with FakePkg('shellpkg') as pkg:
+        pkg.add_file_with_content('/shell/test.py', python_script)
+        test.check(pkg)
+        assert len(output.results) == 0
+
+    # These shebangs should yield the same hash
+    equivalent_shebangs = [
+        '#!/usr/bin/python3',
+        '#!/usr/bin/python3.11',
+    ]
+    # These should yield a different hash
+    different_shebangs = [
+        '#!/usr/bin/python3 -v',
+        '#!/usr/bin/python3.11 -v',
+        '#!/usr/bin/python3.z'
+    ]
+
+    for shebang in equivalent_shebangs:
+        output, test = get_digestcheck('digests_filtered.config')
+        with FakePkg('shellpkg') as pkg:
+            changed_script = f'{shebang}\n' + \
+                '\n'.join(python_script.splitlines()[1:])
+            pkg.add_file_with_content('/shell/test.py', changed_script)
+            test.check(pkg)
+            assert len(output.results) == 0
+
+    for shebang in different_shebangs:
+        output, test = get_digestcheck('digests_filtered.config')
+        with FakePkg('shellpkg') as pkg:
+            changed_script = f'{shebang}\n' + \
+                '\n'.join(python_script.splitlines()[1:])
+            pkg.add_file_with_content('/shell/test.py', changed_script)
+            test.check(pkg)
+            assert len(output.results) == 1
+
+
 def test_xml_digest_filter():
     with open(get_tested_path('data/xml_digest.xml')) as f:
         xml_data = f.read()


### PR DESCRIPTION
openSUSE is now dynamically patching shebangs of Python script in order to specify the exact minor version, instead of just the major version, e.g. `#!/usr/bin/python3` will be substituted with `#!/usr/bin/python3.11`. This not only alters existing whitelistings but will also require us to update whitelistings for every minor version bump of the Python interpreter.

This commit makes the shell filter ignore minor interpreter versions in shebangs, e.g.  python3.11 will be read as python3. Arguments are supported: `#!/usr/bin/python3.11 -v` will be read as `#!/usr/bin/python3 -v`

See also:
https://bugzilla.suse.com/show_bug.cgi?id=1200664
https://bugzilla.suse.com/show_bug.cgi?id=1212476
https://build.opensuse.org/request/show/1129913/changes