### PR TITLE
Fix false positive missing-dependency-on warnings for packages with epoch

### DIFF
--- a/rpmlint/checks/TagsCheck.py
+++ b/rpmlint/checks/TagsCheck.py
@@ -393,6 +393,8 @@ class TagsCheck(AbstractCheck):
                             dep = d
                             break
                     if dep and version:
+                        if epoch is not None:
+                            epoch = str(epoch)
                         exp = (epoch, version, None)
                         sexp = Pkg.versionToString(exp)
                         if not dep[1]:


### PR DESCRIPTION
Before change:
```
ellert@ellert:~/Code/github/rpmlint$ rpmlint -i xrootd-devel
============================ rpmlint session starts ============================
rpmlint: 2.4.0
configuration:
    /usr/lib/python3.12/site-packages/rpmlint/configdefaults.toml
    /etc/xdg/rpmlint/fedora-legacy-licenses.toml
    /etc/xdg/rpmlint/fedora-spdx-licenses.toml
    /etc/xdg/rpmlint/fedora.toml
    /etc/xdg/rpmlint/scoring.toml
    /etc/xdg/rpmlint/users-groups.toml
    /etc/xdg/rpmlint/warn-on-functions.toml
checks: 31, packages: 1

xrootd-devel.x86_64: W: no-manual-page-for-binary xrootd-config
xrootd-devel.x86_64: W: no-documentation
xrootd-devel.x86_64: W: missing-dependency-on xrootd*/xrootd-libs/libxrootd* = 1:5.6.3
 1 packages and 0 specfiles checked; 0 errors, 3 warnings, 0 badness; has taken 0.1 s 
```
After change:
```
$ rpmlint -i xrootd-devel
============================ rpmlint session starts ============================
rpmlint: 2.4.0
configuration:
    /usr/lib/python3.12/site-packages/rpmlint/configdefaults.toml
    /etc/xdg/rpmlint/fedora-legacy-licenses.toml
    /etc/xdg/rpmlint/fedora-spdx-licenses.toml
    /etc/xdg/rpmlint/fedora.toml
    /etc/xdg/rpmlint/scoring.toml
    /etc/xdg/rpmlint/users-groups.toml
    /etc/xdg/rpmlint/warn-on-functions.toml
checks: 31, packages: 1

xrootd-devel.x86_64: W: no-manual-page-for-binary xrootd-config
xrootd-devel.x86_64: W: no-documentation
 1 packages and 0 specfiles checked; 0 errors, 2 warnings, 0 badness; has taken 0.1 s 
```
With the change the false positive missing-dependency-on warning is no longer there. The dependency is there in the package, but due the the epoch rpmlint doesn't find it:
```
$ rpm -q --requires xrootd-devel | grep ^xrootd
xrootd-libs(x86-64) = 1:5.6.3-2.fc39
```
