### PR TITLE
test: Extend tag tests to check 'W: missing-dependency-on'

### DIFF
--- a/test/Testing.py
+++ b/test/Testing.py
@@ -62,8 +62,8 @@ def get_tested_spec_package(name):
     return FakePkg(candidates[0])
 
 
-def get_tested_mock_package(files=None, header=None):
-    mockPkg = FakePkg('mockPkg')
+def get_tested_mock_package(files=None, header=None, name='mockPkg'):
+    mockPkg = FakePkg(name)
     if files is not None:
         if isinstance(files, dict):
             # full path for test files


### PR DESCRIPTION
See https://github.com/rpm-software-management/rpmlint/pull/1152