### PR TITLE
Fix Aeon/Kalpa whitelisting distinct filenames (bsc#1217706, bsc#1217707)

### DIFF
--- a/configs/openSUSE/polkit-rules-whitelist.toml
+++ b/configs/openSUSE/polkit-rules-whitelist.toml
@@ -154,12 +154,21 @@ path = "/usr/share/polkit-1/rules.d/50-org.freedesktop.GeoClue2.rules"
 hash = "685e010654c36f5fbb97fe78a1b7c681ea56df87395bcad2630264267ab884d1"
 
 [[FileDigestGroup]]
-packages = ["gnome-branding-Aeon", "plasma-branding-Kalpa"]
+package = "gnome-branding-Aeon"
 type = "polkit"
 note = "gives members of the wheel group admin privileges"
-bugs = ["bsc#1215276", "bsc#1217707"]
+bug = "bsc#1215276"
 [[FileDigestGroup.digests]]
 path = "/usr/share/polkit-1/rules.d/49-aeon.rules"
+hash = "d26cd444235c36d2270a4950b24e2aefbb772d5654232338289a4f2775aebb5d"
+
+[[FileDigestGroup]]
+package = "plasma-branding-Kalpa"
+type = "polkit"
+note = "gives members of the wheel group admin privileges"
+bug = "bsc#1217707"
+[[FileDigestGroup.digests]]
+path = "/usr/share/polkit-1/rules.d/49-kalpa.rules"
 hash = "d26cd444235c36d2270a4950b24e2aefbb772d5654232338289a4f2775aebb5d"
 
 [[FileDigestGroup]]

--- a/configs/openSUSE/sudoers-whitelist.toml
+++ b/configs/openSUSE/sudoers-whitelist.toml
@@ -69,11 +69,21 @@ digester = "shell"
 hash = "bdb2f32eb3285679a23b428303a3529b7d35978e7f29bcd93d711034953f2429"
 
 [[FileDigestGroup]]
-packages = ["gnome-branding-Aeon", "plasma-branding-Kalpa"]
+package = "gnome-branding-Aeon"
 type = "sudoers"
 note = "allow wheel group members to run commands as root by entering their own password"
-bugs = ["bsc#1215276", "bsc#1217706"]
+bug = "bsc#1215276"
 [[FileDigestGroup.digests]]
 path = "/etc/sudoers.d/50-aeon"
+digester = "shell"
+hash = "554ad7ffea09c0c9bed71f6ef7621e729d9d5368175b6e3b0e29214531d14c39"
+
+[[FileDigestGroup]]
+package = "plasma-branding-Kalpa"
+type = "sudoers"
+note = "allow wheel group members to run commands as root by entering their own password"
+bug = "bsc#1217706"
+[[FileDigestGroup.digests]]
+path = "/etc/sudoers.d/50-kalpa"
 digester = "shell"
 hash = "554ad7ffea09c0c9bed71f6ef7621e729d9d5368175b6e3b0e29214531d14c39"


### PR DESCRIPTION
In #1151, we erroneously whitelisted Kalpa versions of Aeon files with the Aeon name. We mistakenly assumed that since the file contents and whitelisting hashes were the same across the two distributions, that the filenames would be the same as well. This is unfortunately not the case, and I missed it in my review.