### PR TITLE
Adding support for RPM packages containing files greater than 4GB

### DIFF
--- a/rpmlint/helpers.py
+++ b/rpmlint/helpers.py
@@ -1,7 +1,7 @@
 # File containing various helper functions used across rpmlint
 
-import os
 from contextlib import contextmanager
+import os
 from shutil import get_terminal_size
 import sys
 

--- a/rpmlint/helpers.py
+++ b/rpmlint/helpers.py
@@ -1,8 +1,8 @@
 # File containing various helper functions used across rpmlint
 
 import os
-from shutil import get_terminal_size
 from contextlib import contextmanager
+from shutil import get_terminal_size
 import sys
 
 from rpmlint.color import Color

--- a/rpmlint/helpers.py
+++ b/rpmlint/helpers.py
@@ -2,6 +2,7 @@
 
 import os
 from shutil import get_terminal_size
+from contextlib import contextmanager
 import sys
 
 from rpmlint.color import Color
@@ -53,3 +54,16 @@ def readlines(path):
     with open(path, 'rb') as fobj:
         for line in fobj:
             yield byte_to_string(line)
+
+
+@contextmanager
+def pushd(new_dir):
+    """
+    Mimics Unix pushd/popd
+    """
+    cwd = os.getcwd()
+    os.chdir(new_dir)
+    try:
+        yield
+    finally:
+        os.chdir(cwd)

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -577,11 +577,16 @@ class Pkg(AbstractPkg):
             filename = Path(self.filename).resolve()
             with pushd(dirname):
                 stderr = None if verbose else subprocess.DEVNULL
-                stdout = subprocess.check_output(['cat', str(filename)], env=ENGLISH_ENVIROMENT,
-                                                 stderr=stderr)
-                subprocess.check_output('rpm2archive - | tar -xz; chmod -R +rX .', shell=True, env=ENGLISH_ENVIROMENT,
-                                        stderr=stderr, input=stdout)
-
+                if shutil.which('rpm2archive'):
+                    stdout = subprocess.check_output(['cat', str(filename)], env=ENGLISH_ENVIROMENT,
+                                                     stderr=stderr)
+                    subprocess.check_output('rpm2archive - | tar -xz && chmod -R +rX .', shell=True, env=ENGLISH_ENVIROMENT,
+                                            stderr=stderr, input=stdout)
+                else:
+                    stdout = subprocess.check_output(['rpm2cpio', str(filename)], env=ENGLISH_ENVIROMENT,
+                                                     stderr=stderr)
+                    subprocess.check_output('cpio -id && chmod -R +rX .', shell=True, env=ENGLISH_ENVIROMENT,
+                                            stderr=stderr, input=stdout)
             self.extracted = True
         return dirname
 

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -576,10 +576,9 @@ class Pkg(AbstractPkg):
             with pushd(dirname):
                 stderr = None if verbose else subprocess.DEVNULL
                 if shutil.which('rpm2archive'):
-                    stdout = subprocess.check_output(['cat', str(filename)], env=ENGLISH_ENVIROMENT,
-                                                     stderr=stderr)
-                    subprocess.check_output('rpm2archive - | tar -xz && chmod -R +rX .', shell=True, env=ENGLISH_ENVIROMENT,
-                                            stderr=stderr, input=stdout)
+                    with open(filename, 'rb') as rpm_data:
+                        subprocess.check_output('rpm2archive - | tar -xz && chmod -R +rX .', shell=True, env=ENGLISH_ENVIROMENT,
+                                                stderr=stderr, stdin=rpm_data)
                 else:
                     stdout = subprocess.check_output(['rpm2cpio', str(filename)], env=ENGLISH_ENVIROMENT,
                                                      stderr=stderr)

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -569,8 +569,6 @@ class Pkg(AbstractPkg):
                 prefix='rpmlint.%s.' % Path(self.filename).name, dir=dirname
             )
             dirname = self.__tmpdir.name
-            # TODO: sequence based command invocation
-            # TODO: warn some way if this fails (e.g. rpm2archive not installed)
 
             # BusyBox' cpio does not support '-D' argument and the only safe
             # usage is doing chdir before invocation.

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -571,22 +571,16 @@ class Pkg(AbstractPkg):
             )
             dirname = self.__tmpdir.name
             # TODO: sequence based command invocation
-            # TODO: warn some way if this fails (e.g. rpm2cpio not installed)
+            # TODO: warn some way if this fails (e.g. rpm2archive not installed)
 
             # BusyBox' cpio does not support '-D' argument and the only safe
             # usage is doing chdir before invocation.
             filename = Path(self.filename).resolve()
             with pushd(dirname):
-                command_str = f'rpm2cpio {quote(str(filename))} | cpio -id ; chmod -R +rX .'
-                res = subprocess.run(command_str, check=True, shell=True, env=ENGLISH_ENVIROMENT,
-                                     stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-                if verbose:
-                    print(res.stderr.decode())
-                if b"rpm2archive" in res.stderr:
-                    command_str = f'(cat {quote(str(filename))} | rpm2archive - | tar -xz); chmod -R +rX .'
-                    stderr = None if verbose else subprocess.DEVNULL
-                    subprocess.check_output(command_str, shell=True, env=ENGLISH_ENVIROMENT,
-                                            stderr=stderr)
+                command_str = f'(cat {quote(str(filename))} | rpm2archive - | tar -xz); chmod -R +rX .'
+                stderr = None if verbose else subprocess.DEVNULL
+                subprocess.check_output(command_str, shell=True, env=ENGLISH_ENVIROMENT,
+                                        stderr=stderr)
             self.extracted = True
         return dirname
 

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -9,7 +9,6 @@ import mmap
 import os
 from pathlib import Path, PurePath
 import re
-from shlex import quote
 import shutil
 import stat
 import subprocess
@@ -577,10 +576,12 @@ class Pkg(AbstractPkg):
             # usage is doing chdir before invocation.
             filename = Path(self.filename).resolve()
             with pushd(dirname):
-                command_str = f'(cat {quote(str(filename))} | rpm2archive - | tar -xz); chmod -R +rX .'
                 stderr = None if verbose else subprocess.DEVNULL
-                subprocess.check_output(command_str, shell=True, env=ENGLISH_ENVIROMENT,
-                                        stderr=stderr)
+                stdout = subprocess.check_output(['cat', str(filename)], env=ENGLISH_ENVIROMENT,
+                                                 stderr=stderr)
+                subprocess.check_output('rpm2archive - | tar -xz; chmod -R +rX .', shell=True, env=ENGLISH_ENVIROMENT,
+                                        stderr=stderr, input=stdout)
+
             self.extracted = True
         return dirname
 


### PR DESCRIPTION
Hi,

This is enhancement to be able to work with rpms, which contains big files (> 4GB). Currently, **rpmlint** produce the following for those, for example:

```
$ ./lint.py --verbose /srv/bee/builder/oracle/firefox-debuginfo-115.6.0-1.0.1.el8_9.x86_64.rpm 
files over 4GB not supported by cpio, use rpm2archive instead
cpio: premature end of archive
(none): E: fatal error while reading /srv/bee/builder/oracle/firefox-debuginfo-115.6.0-1.0.1.el8_9.x86_64.rpm: list index out of range
Traceback (most recent call last):
  File "/home/sandman/projects/rpmlint_to_review/rpmlint/./lint.py", line 5, in <module>
    lint()
  File "/home/sandman/projects/rpmlint_to_review/rpmlint/rpmlint/cli.py", line 176, in lint
    sys.exit(lint.run())
  File "/home/sandman/projects/rpmlint_to_review/rpmlint/rpmlint/lint.py", line 108, in run
    return self._run()
  File "/home/sandman/projects/rpmlint_to_review/rpmlint/rpmlint/lint.py", line 76, in _run
    self.validate_files(self.options['rpmfile'])
  File "/home/sandman/projects/rpmlint_to_review/rpmlint/rpmlint/lint.py", line 246, in validate_files
    self.validate_file(pkg, pkg == packages[-1])
  File "/home/sandman/projects/rpmlint_to_review/rpmlint/rpmlint/lint.py", line 272, in validate_file
    raise e
  File "/home/sandman/projects/rpmlint_to_review/rpmlint/rpmlint/lint.py", line 261, in validate_file
    with Pkg(pname, self.config.configuration['ExtractDir'],
  File "/home/sandman/projects/rpmlint_to_review/rpmlint/rpmlint/pkg.py", line 514, in __init__
    self.files = self._gather_files_info()
  File "/home/sandman/projects/rpmlint_to_review/rpmlint/rpmlint/pkg.py", line 667, in _gather_files_info
    pkgfile.size = sizes[idx]
IndexError: list index out of range
```

This may greatly help in detecting defects with incorrectly stripped large binaries during rpm build.