### PR TITLE
check: Implement reset method in checks

### DIFF
--- a/rpmlint/checks/AbstractCheck.py
+++ b/rpmlint/checks/AbstractCheck.py
@@ -28,6 +28,9 @@ class AbstractCheck:
     def after_checks(self):
         return
 
+    def reset(self):
+        return
+
 
 class AbstractFilesCheck(AbstractCheck):
     def __init__(self, config, output, file_regexp):
@@ -59,6 +62,9 @@ class AbstractFilesCheck(AbstractCheck):
             for filename in filenames:
                 self.check_file(pkg, filename)
         self.checked_files += len(filenames)
+
+    def reset(self):
+        self.checked_files = None
 
     def check_file(self, pkg, filename):
         """Virtual method called for each file that match the regexp passed

--- a/rpmlint/checks/BashismsCheck.py
+++ b/rpmlint/checks/BashismsCheck.py
@@ -12,6 +12,10 @@ class BashismsCheck(AbstractFilesCheck):
         self._detect_early_fail_option()
         self.file_cache = {}
 
+    def reset(self):
+        super().reset()
+        self.file_cache = {}
+
     def _detect_early_fail_option(self):
         output = subprocess.check_output('checkbashisms --help',
                                          shell=True, encoding='utf8')

--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -80,6 +80,9 @@ class BinariesCheck(AbstractCheck):
                                 self._check_hash_sections,
                                 self._check_no_patchable_function_entries_in_archive]
 
+    def reset(self):
+        self.checked_files = 0
+
     @staticmethod
     def create_nonlibc_regexp_call(call):
         r = r'(%s)\s?.*$' % call

--- a/rpmlint/checks/LibraryDependencyCheck.py
+++ b/rpmlint/checks/LibraryDependencyCheck.py
@@ -16,6 +16,13 @@ class LibraryDependencyCheck(AbstractCheck):
         self.package_arch_mapping = {}
         self.isa = expandMacro('%{_isa}')
 
+    def reset(self):
+        self.package_requires = {}
+        self.package_so_symlinks = {}
+        self.package_so_files = {}
+        self.package_arch_mapping = {}
+        self.isa = expandMacro('%{_isa}')
+
     def check_binary(self, pkg):
         if pkg.is_source:
             return

--- a/rpmlint/checks/SourceCheck.py
+++ b/rpmlint/checks/SourceCheck.py
@@ -30,6 +30,9 @@ class SourceCheck(AbstractCheck):
         }
         self.output.error_details.update(source_details_dict)
 
+    def reset(self):
+        self.spec_file = None
+
     def check_source(self, pkg):
         # process file list
         for fname, pkgfile in pkg.files.items():

--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -115,6 +115,9 @@ class SpecCheck(AbstractCheck):
                                          '%s'.""" % ', '.join(self.valid_groups)})
         self.hardcoded_lib_path_exceptions_regex = re.compile(config.configuration['HardcodedLibPathExceptions'])
 
+        self._default_state()
+
+    def _default_state(self):
         # Default state
         self.patches = {}
         self.applied_patches = []
@@ -139,6 +142,11 @@ class SpecCheck(AbstractCheck):
         # None == main package
         self.current_package = None
         self.package_noarch = {}
+
+    def reset(self):
+        self._spec_file = None
+        self._spec_name = None
+        self._default_state()
 
     def check_source(self, pkg):
         """Find specfile in SRPM and run spec file related checks."""

--- a/rpmlint/checks/SysVInitOnSystemdCheck.py
+++ b/rpmlint/checks/SysVInitOnSystemdCheck.py
@@ -10,6 +10,11 @@ class SysVInitOnSystemdCheck(AbstractCheck):
         self.bootscripts = set()
         self.systemdscripts = set()
 
+    def reset(self):
+        self.initscripts = set()
+        self.bootscripts = set()
+        self.systemdscripts = set()
+
     def check(self, pkg):
         if pkg.is_source:
             return

--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -337,9 +337,8 @@ class Lint:
         """
         Reset all check objects to set to the default state
         """
-        to_reset = self.checks.keys()
-        for check in to_reset:
-            self.checks[check] = self.load_check(check)
+        for check in self.checks.values():
+            check.reset()
 
     def load_check(self, name):
         """Load a (check) module by its name, unless it is already loaded."""


### PR DESCRIPTION
Instead of just recreate the check object the new method `reset` provides a way to reset the check state between different packages call.

This patch defines the reset state for checks that store some kind of state in the object.

See https://github.com/rpm-software-management/rpmlint/issues/1161