### PR TITLE
PythonCheck: Check for python deps like python3.12dist(foo)

### DIFF
--- a/rpmlint/checks/PythonCheck.py
+++ b/rpmlint/checks/PythonCheck.py
@@ -201,6 +201,8 @@ class PythonCheck(AbstractFilesCheck):
 
         # Add pythonX-foo variants
         names += [f'python\\d*-{re.escape(i)}' for i in names]
+        # Add python3.12dist(foo) variants
+        names += [f'python\\d+(\\.\\d+)?dist\\({re.escape(i)}\\)' for i in names]
         regex = '|'.join(names)
         # Support complex requirements like
         # (python310-jupyter-server >= 1.15 with python310-jupyter-server < 3)

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -240,6 +240,22 @@ def test_python_tests_in_site_packages(package, test, output):
             ],
         },
     ),
+    get_tested_mock_package(
+        files={
+            '/usr/lib/python3.10/site-packages/flit-3.8.0.dist-info/METADATA': {
+                'content-path': 'files/python-flit-metadata.txt',
+                'create_dirs': True,
+            },
+        },
+        header={
+            'requires': [
+                'python3.12dist(docutils)',
+                'python3.12dist(flit-core) >= 3.8',
+                'python3.12dist(requests)',
+                'python3.12dist(tomli-w)',
+            ],
+        },
+    ),
 ])
 def test_python_dependencies_metadata(package, test, output):
     test.check(package)


### PR DESCRIPTION
Fix https://github.com/rpm-software-management/rpmlint/issues/1171