### PR TITLE
sendmail: permissions moved from /etc to /usr (bsc#1219339)

### DIFF
--- a/configs/openSUSE/permissions-whitelist.toml
+++ b/configs/openSUSE/permissions-whitelist.toml
@@ -36,15 +36,18 @@ hash = "d5e51380e7ec868a42d336c868fc012ab95cac771d95361504cc6040b8d86221"
 
 [[FileDigestGroup]]
 package = "sendmail"
+bugs = ["bsc#1219339"]
 type = "permissions"
 note = """Be careful about calculating digest sums here, the sendmail package
       replaces file contents during RPM build time with architecture dependent
-      values"""
+      values.
+      The globbing is due to the UsrMerge. We can remove /etc once the dust has
+      settled."""
 [[FileDigestGroup.digests]]
-path = "/etc/permissions.d/sendmail"
+path = "glob:{/etc,/usr/share/permissions}/permissions.d/sendmail"
 hash = "e09ca5efebd0b3c123afc2364f9745f4d85c4327fa83f709bccbaa64da764486"
 [[FileDigestGroup.digests]]
-path = "/etc/permissions.d/sendmail.paranoid"
+path = "glob:{/etc,/usr/share/permissions}/permissions.d/sendmail.paranoid"
 hash = "2d5c56cdfb00ec169c182de791cf2934331159842f1849c5f2d7059f0086bd2c"
 
 [[FileDigestGroup]]


### PR DESCRIPTION
The contents has not changed, just the location. Also I decided to keep the old /etc entries temporarily, in order to avoid problems, just in case the permissions package is not updated simultaneously with sendmail. We can remove these entries once the dust has settled.

