### PR TITLE
users-groups: add groups for usbauth-notifier

### DIFF
--- a/configs/openSUSE/users-groups.toml
+++ b/configs/openSUSE/users-groups.toml
@@ -199,6 +199,8 @@ StandardGroups = [
     'ts-shell',
     'tty',
     'unbound',
+    'usbauth',
+    'usbauth-notifier',
     'users',
     'utmp',
     'uucp',


### PR DESCRIPTION
https://build.opensuse.org/package/live_build_log/security/usbauth-notifier/openSUSE_Tumbleweed/x86_64
> [   26s] usbauth-notifier.x86_64: W: non-standard-gid /usr/libexec/usbauth-notifier usbauth-notifier
> [   26s] usbauth-notifier.x86_64: W: non-standard-gid /usr/libexec/usbauth-notifier/usbauth-notifier usbauth
> [   26s] usbauth-notifier.x86_64: W: non-standard-gid /usr/libexec/usbauth-npriv usbauth

Previously reviewed in bsc#1066877