### PR TITLE
SystemIstallCheck: Allow %service_del_postun_without_restart macro usage

### DIFF
--- a/rpmlint/checks/SystemdInstallCheck.py
+++ b/rpmlint/checks/SystemdInstallCheck.py
@@ -48,6 +48,10 @@ class SystemdInstallCheck(AbstractCheck):
                         processed['postun'] = True
                         break
 
+                # accept %service_del_postun_without_restart() macro
+                if not processed['postun'] and ':' == postun.strip():
+                    processed['postun'] = True
+
                 basename = Path(fname).name
                 if not processed['pre']:
                     self.output.add_info('E', pkg, 'systemd-service-without-service_add_pre', basename)

--- a/test/test_systemd_install.py
+++ b/test/test_systemd_install.py
@@ -2,7 +2,7 @@ import pytest
 from rpmlint.checks.SystemdInstallCheck import SystemdInstallCheck
 from rpmlint.filter import Filter
 
-from Testing import CONFIG, get_tested_package
+from Testing import CONFIG, get_tested_mock_package, get_tested_package
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -22,3 +22,40 @@ def test_systemd_service_without_service_macro(tmp_path, package, systemdinstall
     for scriptlet_type in ['add_pre', 'add_post', 'del_preun', 'del_postun']:
         message = f'systemd-service-without-service_{scriptlet_type} dnf-automatic-download.service'
         assert message in out
+
+
+@pytest.mark.parametrize('package,error', [
+    (get_tested_mock_package(
+        name='greetd',
+        files=['/usr/lib/systemd/system/greetd.service'],
+        header={
+            'PREIN': 'systemd-update-helper mark-install-system-units greetd.service',
+            'POSTIN': 'systemd-update-helper install-system-units greetd.service',
+            'PREUN': 'systemd-update-helper remove-system-units greetd.service',
+            'POSTUN': 'systemd-update-helper mark-restart-system-units greetd.service',
+        },
+    ), False),
+    (get_tested_mock_package(
+        name='greetd',
+        files=['/usr/lib/systemd/system/greetd.service'],
+        header={
+            'PREIN': 'systemd-update-helper mark-install-system-units greetd.service',
+            'POSTIN': 'systemd-update-helper install-system-units greetd.service',
+            'PREUN': 'systemd-update-helper remove-system-units greetd.service',
+            'POSTUN': '\n \n:',
+        },
+    ), False),
+    (get_tested_mock_package(
+        name='greetd',
+        files=['/usr/lib/systemd/system/greetd.service'],
+        header={},
+    ), True),
+])
+def test_systemd_service_without_service_macro2(package, error, systemdinstallcheck):
+    output, test = systemdinstallcheck
+    test.check(package)
+    out = output.print_results(output.results)
+
+    for scriptlet_type in ['add_pre', 'add_post', 'del_preun', 'del_postun']:
+        message = f'systemd-service-without-service_{scriptlet_type}'
+        assert (message in out) == error


### PR DESCRIPTION
The %service_del_postun_without_restart macro expands to "\n \n:". This patch check if the "postun" script is there and it's just ":".

Fix https://github.com/rpm-software-management/rpmlint/issues/1188