### PR TITLE
[opensuse] SUIDPermissionsCheck: support new /usr/share/permissions/packages.d dir

### DIFF
--- a/configs/openSUSE/security.toml
+++ b/configs/openSUSE/security.toml
@@ -30,7 +30,8 @@ Locations = [
 FollowSymlinks = false
 Locations = [
     "/etc/permissions.d/",
-    "/usr/share/permissions/permissions.d/"
+    "/usr/share/permissions/permissions.d/",
+    "/usr/share/permissions/packages.d/"
 ]
 
 [FileDigestLocation.pam]


### PR DESCRIPTION
- use common constant to refer to /usr/share/permissions
- adjust comments to current situation
- consider the new packages.d directory as well (new chkstat from permissions package supports this).

Due to the generator used in `_paths_to()` this is getting a bit ugly to combine now. We should only consider `packages.d` in the /usr dir, not in /etc, where the name is too generic.