### PR TITLE
change pyproject ruff config to toplevel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,4 +79,4 @@ rpmlint = ["configdefaults.toml"]
 
 [tool.ruff]
 
-ignore = ["E501"]
+lint.ignore = ["E501"]


### PR DESCRIPTION
`ruff` now warns about not using top level namespace variables to config in pyproject.toml

See [action logs](https://github.com/rpm-software-management/rpmlint/actions/runs/7903043011/job/21582197573) and open `Run /github/home/.local/bin/ruff .`  

The warning should look something like this

```
Run /github/home/.local/bin/ruff .
  /github/home/.local/bin/ruff .
  shell: sh -e {0}
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
 ```

The only change I made should stop warning about this. 