### PR TITLE
dbus-services: power-profiles-daemon (bsc#1219956)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1187,7 +1187,15 @@ nodigests = [
 package = "power-profiles-daemon"
 type = "dbus"
 note = "a daemon dealing with system power settings"
-bugs = [ "bsc#1189900", "bsc#1201125" ]
+bugs = ["bsc#1189900", "bsc#1201125", "bsc#1219957"]
+[[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service"
+digester = "shell"
+hash = "68b263d55c5512e9dfedb536e003cde51d416c6fbd4913ec0f77abc6c6baa32b"
+[[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf"
+digester = "xml"
+hash = "a1b1dda54405102f4a297c836a32a0843dcca50e09b0ac995fa61f0e24977f15"
 [[FileDigestGroup.digests]]
 path = "/usr/share/dbus-1/system-services/net.hadess.PowerProfiles.service"
 digester = "shell"


### PR DESCRIPTION
The service was renamed from `net.hadess.PowerProfiles`, however the old service is being kept to ensure backwards compatibility for a while.
https://bugzilla.suse.com/show_bug.cgi?id=1219956#c2