### PR TITLE
SpecCheck: Add patch-macro-old-format check

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -18,6 +18,8 @@ def re_tag_compile(tag):
 
 
 patch_regex = re_tag_compile(r'Patch(\d*)')
+# rpm 4.20 doesn't support %patchN anymore, we should warn about this
+applied_patch_rpm420_regex = re.compile(r'^%patch(\d+)')
 applied_patch_regex = re.compile(r'^%patch\s*(\d*)')
 applied_patch_p_regex = re.compile(r'\s-P\s*(\d+)\b')
 applied_patch_pipe_regex = re.compile(r'\s%\{PATCH(\d+)\}\s*\|\s*(%\{?__)?patch\b')
@@ -465,6 +467,10 @@ class SpecCheck(AbstractCheck):
         # Check for %patch -P
         res = applied_patch_regex.search(line)
         if res:
+            # Check for %patchN (not supported by rpm >= 4.20)
+            if applied_patch_rpm420_regex.match(line):
+                self.output.add_info('E', self.pkg, 'patch-macro-old-format')
+
             pnum = res.group(1) or 0
             for tmp in applied_patch_p_regex.findall(line) or [pnum]:
                 pnum = int(tmp)

--- a/rpmlint/descriptions/SpecCheck.toml
+++ b/rpmlint/descriptions/SpecCheck.toml
@@ -16,6 +16,14 @@ use a directory for building, use $RPM_BUILD_ROOT instead.
 patch-not-applied="""
 A patch is included in your package but was not applied.
 """
+patch-macro-old-format="""
+The usage of %patchN is not supported by RPM >= 4.20. The preferred way to
+apply patches are, in order:
+ * %autosetup -p1
+ * %autosetup -N / %autopatch -p1
+ * %setup / %patch -P <N> -p 1 (upper case P denotes patch number,
+   lower case is the usual patch -p<num> strip level)
+"""
 obsolete-tag="""
 The following tags are obsolete: Copyright and Serial. They must
 be replaced by License and Epoch respectively.

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -1069,6 +1069,34 @@ def test_check_patch_not_applied(package, speccheck):
     assert 'W: patch-not-applied' in out
 
 
+@pytest.mark.parametrize('package', [
+    'spec/SpecCheck',
+    'spec/%ifarch-applied-patch',
+    'spec/prereq_use',
+    'spec/mixed-use-of-spaces-and-tabs',
+])
+def test_check_patch_rpm_420(package, speccheck):
+    """Test if specfile uses %patchN."""
+    output, test = speccheck
+    pkg = get_tested_spec_package(package)
+    test.check_spec(pkg)
+    out = output.print_results(output.results)
+    assert 'E: patch-macro-old-format' in out
+
+
+@pytest.mark.parametrize('package', [
+    'spec/intltool',
+    'spec/ghc',
+    'spec/SpecCheckPatch',
+])
+def test_check_patch_rpm_not_420(package, speccheck):
+    output, test = speccheck
+    pkg = get_tested_spec_package(package)
+    test.check_spec(pkg)
+    out = output.print_results(output.results)
+    assert 'E: patch-macro-old-format' not in out
+
+
 @pytest.mark.parametrize('package', ['spec/mixed-use-of-spaces-and-tabs'])
 def test_check_patch_not_found(package, speccheck):
     """Test if specfile have all patch applied by %autopatch."""


### PR DESCRIPTION
This new check is to warning about the usage of %patchN format to apply patches that is not supported by rpm >= 4.20