### PR TITLE
Improvements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Primarily we just need the offending rpm file (best the smallest you can
 find or we would soon take few GB to take a checkout) and some basic
 expectation of what should happen.
 
-### Building the tool
+### Building the installable rpm and installing
 This section focuses on how to build the tool as you develop it.
 
 To build the tool, we'll use a tool called `packit`. First, install `packit` on your system:

--- a/README.md
+++ b/README.md
@@ -53,15 +53,17 @@ Optional, for running the test suite:
 
 You will need to have all the required modules as listed on the Install section above.
 You will also need `pytest`,`pytest-cov` and `pytest-xdist`, 
-which you can install individually or by running `pip install -e ".[test]"`.
+which you can install individually or by running:
+
+    pip install -e ".[test]"
 
 If all the dependencies are present you can just execute tests using:
 
-`python3 -m pytest`
+    python3 -m pytest
 
 Or even pick one of the tests using `pytest`:
 
-`python3 -m pytest test/test_config.py`
+    python3 -m pytest test/test_config.py
 
 ## Bugfixing and contributing
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,24 @@ Primarily we just need the offending rpm file (best the smallest you can
 find or we would soon take few GB to take a checkout) and some basic
 expectation of what should happen.
 
-### Example workflow
+### Building the tool
+This section focuses on how to build the tool as you develop it.
+
+To build the tool, we'll use a tool called `packit`. First, install `packit` on your system:
+
+    dnf install packit
+
+Then, build the project using:
+
+    packit build locally
+
+If you encounter any errors, install the missing dependencies and run the same command again. Once the build is successful, you'll find a RPM file under the `noarch` directory. To install the package on your system, run:
+
+    dnf install <the_rpm_you_just_built>
+
+Alternatively, the built binary can be found in the `rpmlint` directory under the `.packit` directory, which you can run directly.
+
+### Example workflow for testing a functionality
 
 1) I have rpmfile that should report unreadable zip file
 2) I store this file in git under `test/binary/texlive-codepage-doc-2018.151.svn21126-38.1.noarch.rpm`


### PR DESCRIPTION
I have made minor changes in the documentation that make the README slightly more readable and user-friendly with a copy button.

Furthermore, I've recognized a gap in the documentation regarding building the tool during its development phase. While it may be apparent to most users due to the presence of the .packit directory, I believe it would be beneficial for beginners to have a dedicated section explaining how to build the RPMs for rpmlint during development.

@danigm, please let me know if this requirement seems reasonable, and I can draft a concise section for inclusion in the README.