### PR TITLE
Refactored `is_utf8_bytestr` function in `pkg.py` for improved readability and safety

### DIFF
--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -115,17 +115,16 @@ def is_utf8(fname):
 def is_utf8_bytestr(s):
     """Returns True whether the given text is UTF-8.
     Due to changes in rpm, needs to handle both bytes and unicode."""
+    if not isinstance(s, (bytes, str)):
+        unexpected = type(s).__name__
+        raise TypeError(f'Expected str/unicode/bytes, not {unexpected}')
+
     try:
-        if hasattr(s, 'decode'):
+        if isinstance(s, bytes):
             s.decode('utf-8')
-        elif hasattr(s, 'encode'):
-            s.encode('utf-8')
-        else:
-            unexpected = type(s).__name__
-            raise TypeError(
-                f'Expected str/unicode/bytes, not {unexpected}')
     except UnicodeError:
         return False
+
     return True
 
 

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -117,7 +117,7 @@ def is_utf8_bytestr(s):
     Due to changes in rpm, needs to handle both bytes and unicode."""
     if not isinstance(s, (bytes, str)):
         unexpected = type(s).__name__
-        raise TypeError(f'Expected str/unicode/bytes, not {unexpected}')
+        raise TypeError(f'Expected str/bytes, not {unexpected}')
 
     try:
         if isinstance(s, bytes):


### PR DESCRIPTION
Previously, the `is_utf8_bytestr` function looked like the following:

```python
def is_utf8_bytestr(s):
    """Returns True whether the given text is UTF-8.
    Due to changes in rpm, needs to handle both bytes and unicode."""
    try:
        if hasattr(s, 'decode'):
            s.decode('utf-8')
        elif hasattr(s, 'encode'):
            s.encode('utf-8')
        else:
            unexpected = type(s).__name__
            raise TypeError(
                f'Expected str/unicode/bytes, not {unexpected}')
    except UnicodeError:
        return False
    return True
```
Hypothetically, an object with any `type` passed to this function with an `encode`, or a `decode` method could return `True` instead of raising a `TypeError`. This may never happen in real life, but still I feel it can be written in a different way.

I've refactored the function to make it more **readable**, and **safer** by using the `isinstance` function in Python.

```python
def is_utf8_bytestr(s):
    """Returns True whether the given text is UTF-8.
    Due to changes in rpm, needs to handle both bytes and unicode."""
    if not isinstance(s, (bytes, str)):
        unexpected = type(s).__name__
        raise TypeError(f'Expected str/unicode/bytes, not {unexpected}')

    try:
        if isinstance(s, bytes):
            s.decode('utf-8')
    except UnicodeError:
        return False

    return True
```

All tests are passing on my machine.