### PR TITLE
Provide legacy whitelisting during bsc#1218922 transition period

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -66,6 +66,16 @@ hash = "00d25f898cf4c78cf45d68000ee00be27b0aa15b7ebe22c4ba86bc1b5f33b898"
 [[FileDigestGroup]]
 package  = "gdm"
 type     = "dbus"
+note     = "Legacy: provide old whitelisting during bsc#1218922 transition period"
+bugs     = ["bsc#1204052", "bsc#1218922"]
+[[FileDigestGroup.digests]]
+path     = "/usr/share/dbus-1/system.d/gdm.conf"
+digester = "xml"
+hash     = "620bf31e3c93b37a70e34f21a0a4cb61274d04a65939bd718a0c886a31c95673"
+
+[[FileDigestGroup]]
+package  = "gdm"
+type     = "dbus"
 note     = "D-Bus interface for managing GDM sessions"
 bugs     = ["bsc#1204052", "bsc#1218922"]
 [[FileDigestGroup.digests]]


### PR DESCRIPTION
Follow-up to #1209 for the gdm whitelisting (bsc#1218922) .

As requested in https://build.opensuse.org/request/show/1155534#comment-1905827, provide both the old and the new whitelisting values for the interim period until GNOME 46 is released.