### PR TITLE
dbus-services: Drop old GDM whitelisting (bsc#1218922)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -66,16 +66,6 @@ hash = "00d25f898cf4c78cf45d68000ee00be27b0aa15b7ebe22c4ba86bc1b5f33b898"
 [[FileDigestGroup]]
 package  = "gdm"
 type     = "dbus"
-note     = "Legacy: provide old whitelisting during bsc#1218922 transition period"
-bugs     = ["bsc#1204052", "bsc#1218922"]
-[[FileDigestGroup.digests]]
-path     = "/usr/share/dbus-1/system.d/gdm.conf"
-digester = "xml"
-hash     = "620bf31e3c93b37a70e34f21a0a4cb61274d04a65939bd718a0c886a31c95673"
-
-[[FileDigestGroup]]
-package  = "gdm"
-type     = "dbus"
 note     = "D-Bus interface for managing GDM sessions"
 bugs     = ["bsc#1204052", "bsc#1218922"]
 [[FileDigestGroup.digests]]


### PR DESCRIPTION
GNOME 46 has been [merged](https://build.opensuse.org/request/show/1159526) and we can drop the legacy GDM whitelisting provided in https://github.com/rpm-software-management/rpmlint/pull/1211.

This reverts commit 4c399becce164810256beee4cd504a2ceefd94f5.