### PR TITLE
dbus-services: power-profiles-daemon: reinstate legacy D-Bus whitelis…

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1289,6 +1289,14 @@ type = "dbus"
 note = "a daemon dealing with system power settings"
 bugs = ["bsc#1189900", "bsc#1201125", "bsc#1219957"]
 [[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system-services/net.hadess.PowerProfiles.service"
+digester = "shell"
+hash = "7d481c410356e61dc0ca7e9ed7725bb5a69c37aab2f51e6a36720894f6c1152f"
+[[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system.d/net.hadess.PowerProfiles.conf"
+digester = "xml"
+hash = "3c9b773133201b3ecc7469dd9bc93253a992045e5cee5447def1d99f5b1e6ed5"
+[[FileDigestGroup.digests]]
 path = "/usr/share/dbus-1/system-services/org.freedesktop.UPower.PowerProfiles.service"
 digester = "shell"
 hash = "68b263d55c5512e9dfedb536e003cde51d416c6fbd4913ec0f77abc6c6baa32b"


### PR DESCRIPTION
…ting (bsc#1219957)

The daemon actively still registers the old interface names and fails if this is not possible. Thus bring back the original whitelisting. Keep one entry for both legacy and current since these are actively used by the current package.