### PR TITLE
pam-modules: whitelist pam_lastlog2 now moved to util-linux (bsc#1222…

### DIFF
--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -558,6 +558,15 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
+package = "util-linux-systemd"
+type = "pam"
+note = "Logs user session information to an sqlite3 database"
+bugs = ["bsc#1209238", "bsc#1222329"]
+nodigests = [
+    "glob:*/security/pam_lastlog2.so",
+]
+
+[[FileDigestGroup]]
 package = "wtmpdb"
 type = "pam"
 note = "Keeps Y2038 safe login records in a sqlite database"


### PR DESCRIPTION
…329)

Keep the old whitelisting in place for a bit longer until the old package is deleted from Factory.