### PR TITLE
Revert "pam-modules: whitelist pam_lastlog2 now moved to util-linux (…

### DIFF
--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -558,15 +558,6 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
-package = "util-linux-systemd"
-type = "pam"
-note = "Logs user session information to an sqlite3 database"
-bugs = ["bsc#1209238", "bsc#1222329"]
-nodigests = [
-    "glob:*/security/pam_lastlog2.so",
-]
-
-[[FileDigestGroup]]
 package = "wtmpdb"
 type = "pam"
 note = "Keeps Y2038 safe login records in a sqlite database"


### PR DESCRIPTION
…bsc#1222329)"

This reverts commit d7183d8ac721236353eb52e2fa7dae8ad5972113.

The packagers found that they need to keep the old package name for smooth migration reasons.