### PR TITLE
PythonCheck: simplify requirement check using metadata

### DIFF
--- a/test/files/ipython-requires.txt
+++ b/test/files/ipython-requires.txt
@@ -1,0 +1,20 @@
+backcall
+decorator
+jedi>=0.16
+matplotlib-inline
+pickleshare
+prompt_toolkit!=3.0.37,<3.1.0,>=3.0.30
+pygments>=2.4.0
+stack_data
+traitlets>=5
+
+[:python_version < "3.10"]
+typing_extensions
+leftover>=3.0
+
+[:python_version > "3.11"]
+req312
+no-leftover
+
+[:sys_platform != "win32"]
+pexpect>4.3

--- a/test/mockdata/mock_python.py
+++ b/test/mockdata/mock_python.py
@@ -273,3 +273,17 @@ PythonSinglePYCMockPackage = get_tested_mock_package(
         '/usr/lib/python3.9/site-packages/blinker/__pycache__/_utilities.cpython-39.pyc',
     ]
 )
+
+
+IPythonMissingRequirePackage = get_tested_mock_package(
+    lazyload=True,
+    files={
+        '/usr/lib/python3.12/site-packages/ipython-8.14.0-py3.12.egg-info/requires.txt': {
+            'content-path': 'files/ipython-requires.txt',
+        },
+    },
+    header={'requires': [
+        'python-leftover',
+        'python-no-leftover',
+    ]},
+)

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -1,4 +1,5 @@
 from mockdata.mock_python import (
+    IPythonMissingRequirePackage,
     PythonDocFolderPackage,
     PythonDocModulePackage,
     PythonEggInfoFileackage,
@@ -224,3 +225,34 @@ def test_python_sphinx_doctrees_leftover_nowarn(package, output, test):
     test.check(package)
     out = output.print_results(output.results)
     assert 'W: python-sphinx-doctrees-leftover' not in out
+
+
+@pytest.mark.parametrize('package', [IPythonMissingRequirePackage])
+def test_python_dependencies_ipython(package, test, output):
+    test.check(package)
+    out = output.print_results(output.results)
+
+    requirements = [
+        'backcall',
+        'decorator',
+        'jedi',
+        'matplotlib-inline',
+        'pickleshare',
+        'prompt_toolkit',
+        'pygments',
+        'stack_data',
+        'traitlets',
+    ]
+
+    for req in requirements:
+        assert f'W: python-missing-require {req}' in out
+
+    # typing_extensions is in section [:python_version < "3.10"]
+    assert 'W: python-missing-require typing_extensions' not in out
+
+    # req312 is in section [:python_version > "3.11"]
+    assert 'W: python-missing-require req312' in out
+
+    # leftover is in section [:python_version < "3.10"]
+    assert 'W: python-leftover-require python-leftover' in out
+    assert 'W: python-leftover-require python-no-leftover' not in out


### PR DESCRIPTION
Improve the python package requires and leftover check using python importlib.metadata module.

Fix https://github.com/rpm-software-management/rpmlint/issues/1172