### PR TITLE
Revert "whitelistings: systemd v256 (bsc#1225317)"

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1096,7 +1096,7 @@ bugs = ["bsc#1185285", "bsc#1213692", "bsc#1219916"]
 [[FileDigestGroup.digests]]
 path = "/usr/share/dbus-1/system.d/org.freedesktop.home1.conf"
 digester = "xml"
-hash = "0bdd8a388268b3c8d187433b2192ca1b682184881d4b4cb4056a81b757c5ab04"
+hash = "8bfb27085d0f465591b56f17b33c0f9100b917a0a592fe662eed52b039ac6737"
 [[FileDigestGroup.digests]]
 path = "/usr/share/dbus-1/system-services/org.freedesktop.home1.service"
 digester = "shell"


### PR DESCRIPTION
This reverts commit 729e9ff9e5ac2c1d28b86185eb6bd146acdc340c.

Just after the whitelisting, the maintainer told us it will take at least 2 weeks until the new systemd version is submitted.

https://bugzilla.suse.com/show_bug.cgi?id=1225317