### PR TITLE
dbus-services: systemd: keep the old whitelisting temporarily (bsc#1225317)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1092,11 +1092,25 @@ hash     = "7dd017f2535dabd623fdb59ecb6362ac60fa836e9a146243c2a450b04d9aee5d"
 package = "systemd-homed"
 type = "dbus"
 note = "systemd-homed helper service for providing portable home directory containers"
-bugs = ["bsc#1185285", "bsc#1213692", "bsc#1219916"]
+bugs = ["bsc#1185285", "bsc#1213692", "bsc#1219916", "bsc#1225317"]
 [[FileDigestGroup.digests]]
 path = "/usr/share/dbus-1/system.d/org.freedesktop.home1.conf"
 digester = "xml"
 hash = "0bdd8a388268b3c8d187433b2192ca1b682184881d4b4cb4056a81b757c5ab04"
+[[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system-services/org.freedesktop.home1.service"
+digester = "shell"
+hash = "c4281ad74af8c43a963806142e2770751b153df8c1217da4edf212b334ecddcf"
+
+[[FileDigestGroup]]
+package = "systemd-homed"
+type = "dbus"
+note = "TEMPORARY. REMOVE THIS FileDigestGroup once systemd-v256 is submitted."
+bugs = ["bsc#1185285", "bsc#1213692", "bsc#1219916", "bsc#1225317"]
+[[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system.d/org.freedesktop.home1.conf"
+digester = "xml"
+hash = "8bfb27085d0f465591b56f17b33c0f9100b917a0a592fe662eed52b039ac6737"
 [[FileDigestGroup.digests]]
 path = "/usr/share/dbus-1/system-services/org.freedesktop.home1.service"
 digester = "shell"


### PR DESCRIPTION
It will take a while until the new systemd version will get submitted. Whitelist both versions of `org.freedesktop.home1.conf` until then.

<https://bugzilla.suse.com/show_bug.cgi?id=1225317>