### PR TITLE
sysctl-whitelist: move 50-coredump.conf to systemd main package (bsc#…

### DIFF
--- a/configs/openSUSE/sysctl-whitelist.toml
+++ b/configs/openSUSE/sysctl-whitelist.toml
@@ -49,10 +49,10 @@ digester = "shell"
 hash = "e70681a232f129648465d4aa036f37e3da8dcbfa611b1380baa5bd98030c6b61"
 
 [[FileDigestGroup]]
-package = "systemd-coredump"
+package = "systemd"
 type = "sysctl"
 note = "sets core pattern, core pipe limit and suid_dumpable"
-bug = "bsc#1174722"
+bugs = ["bsc#1174722", "bsc#1226865"]
 [[FileDigestGroup.digests]]
 path = "/usr/lib/sysctl.d/50-coredump.conf"
 digester = "shell"


### PR DESCRIPTION
…1226865)