### PR TITLE
configs/openSUSE/users-groups.toml: add user and group alloy

### DIFF
--- a/configs/openSUSE/users-groups.toml
+++ b/configs/openSUSE/users-groups.toml
@@ -1,5 +1,6 @@
 StandardGroups = [
     'aegis',
+    'alloy',
     'antivir',
     'arangodb',
     'at',
@@ -226,6 +227,7 @@ StandardGroups = [
 
 StandardUsers = [
     'aegis',
+    'alloy',
     'amanda',
     'aodh',
     'arangodb',


### PR DESCRIPTION
User is defined here: https://build.opensuse.org/projects/openSUSE:Factory/packages/system-user-alloy/files/system-user-alloy.conf