### PR TITLE
FilesCheck: Fix zero permission check with folder

### DIFF
--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -341,7 +341,7 @@ def find_perm_in_tmpfiles(pkg, fname):
     for k, v in pkg.files.items():
         if 'tmpfiles.d' not in k:
             continue
-        if not os.path.exists(v.path):
+        if not os.path.exists(v.path) or os.path.isdir(v.path):
             continue
         with open(v.path) as f:
             tmpd += f.readlines()

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -375,6 +375,7 @@ f /run/netconfig/resolv.conf 0644 root root -
 f /run/netconfig/yp.conf 0644 root root -
 """
             },
+            '/etc/tmpfiles.d': {'is_dir': True},
         },
     ),
 ])


### PR DESCRIPTION
The zero permission check tries to read tmpfiles.d entries, but if a package has a folder with that name it crashes trying to open the folder as a file to read.

This patch fix the issue and check if the file is a directory before trying to open it for reading.

Fix https://github.com/rpm-software-management/rpmlint/issues/1257