### PR TITLE
FilesCheck: Fix zero perm check with binaries

### DIFF
--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -339,12 +339,18 @@ def find_perm_in_tmpfiles(pkg, fname):
     fname = os.path.realpath(fname)
 
     for k, v in pkg.files.items():
-        if 'tmpfiles.d' not in k:
+        if 'tmpfiles.d' not in k or not k.endswith('.conf'):
             continue
         if not os.path.exists(v.path) or os.path.isdir(v.path):
             continue
+
         with open(v.path) as f:
-            tmpd += f.readlines()
+            try:
+                tmpd += f.readlines()
+            except ValueError:
+                # Can't read this file, so we are not trying to read definition
+                # from there
+                pass
 
     for line in tmpd:
         if f' {fname} ' not in line:

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -376,6 +376,7 @@ f /run/netconfig/yp.conf 0644 root root -
 """
             },
             '/etc/tmpfiles.d': {'is_dir': True},
+            '/etc/tmpfiles.d/binary.zip': {'content': b'\xa0\x1b'},
         },
     ),
 ])


### PR DESCRIPTION
Try to read tmpfiles.d configuration just from .conf files. This patch also wrap the readline with try/except to make it not crash if there's any special file there that we try to read.

Fix https://github.com/rpm-software-management/rpmlint/issues/1257