### PR TITLE
Replace bin in test_mixed_ownership.py

### DIFF
--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -877,14 +877,15 @@ class FakePkg(AbstractPkg):
                 self._mock_file(path, file)
 
     def add_dir(self, path, metadata=None):
-        pkgdir = PkgFile(path)
+        name = path
+        pkgdir = PkgFile(name)
         pkgdir.magic = 'directory'
 
         path = os.path.join(self.dir_name(), path.lstrip('/'))
         os.makedirs(Path(path), exist_ok=True)
 
         pkgdir.path = path
-        self.files[path] = pkgdir
+        self.files[name] = pkgdir
 
         if metadata:
             for k, v in metadata.items():

--- a/test/mockdata/mock_mixed_ownership.py
+++ b/test/mockdata/mock_mixed_ownership.py
@@ -1,0 +1,15 @@
+from Testing import get_tested_mock_package
+
+MixedOwnership = get_tested_mock_package(
+files={
+'/usr/bin/noproblem': {},
+    '/var/lib/badfolder': {
+        'metadata': {'user': 'nobody'},
+        'is_dir': True},
+    '/var/lib/badfolder/broken1': {
+        'metadata': {'user': 'root'}},
+    '/var/lib/badfolder/correctperms': {
+        'metadata': {'user': 'root'},
+        'is_dir': True},
+    '/var/lib/badfolder/correctperms/broken2': {},
+})

--- a/test/test_mixed_ownership.py
+++ b/test/test_mixed_ownership.py
@@ -1,8 +1,9 @@
+from mockdata.mock_mixed_ownership import MixedOwnership
 import pytest
 from rpmlint.checks.MixedOwnershipCheck import MixedOwnershipCheck
 from rpmlint.filter import Filter
 
-from Testing import CONFIG, get_tested_package
+from Testing import CONFIG
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -13,10 +14,10 @@ def mixedownershipcheck():
     return output, test
 
 
-@pytest.mark.parametrize('package', ['binary/mixed-ownership'])
-def test_mixed_ownership(tmp_path, package, mixedownershipcheck):
+@pytest.mark.parametrize('package', [MixedOwnership])
+def test_mixed_ownership(package, mixedownershipcheck):
     output, test = mixedownershipcheck
-    test.check(get_tested_package(package, tmp_path))
+    test.check(package)
     out = output.print_results(output.results)
     assert 'noproblem' not in out
     assert 'file-parent-ownership-mismatch Path "/var/lib/badfolder/broken1" owned by "root" is stored in directory owned by "nobody"' in out


### PR DESCRIPTION
Also, creating a mock file to improve code cleanup of the test_mixed_ownership.py file. Some necessary changes are made to the pkg.py file.