### PR TITLE
Update users-groups.toml

### DIFF
--- a/configs/openSUSE/users-groups.toml
+++ b/configs/openSUSE/users-groups.toml
@@ -218,6 +218,7 @@ StandardGroups = [
     'woodpecker',
     'www',
     'xok',
+    'xpra',
     'xrootd',
     'xymon',
     'zabbix',


### PR DESCRIPTION
Adding 'xpra' to 'StandardGroups' as suggested by rpmlint "A file in this package is owned by an unregistered group id."