### PR TITLE
dbus-services: systemd: remove outdated hashes (bsc#1225317)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1107,20 +1107,6 @@ digester = "shell"
 hash = "c4281ad74af8c43a963806142e2770751b153df8c1217da4edf212b334ecddcf"
 
 [[FileDigestGroup]]
-package = "systemd-homed"
-type = "dbus"
-note = "TEMPORARY. REMOVE THIS FileDigestGroup once systemd-v256 is submitted."
-bugs = ["bsc#1185285", "bsc#1213692", "bsc#1219916", "bsc#1225317"]
-[[FileDigestGroup.digests]]
-path = "/usr/share/dbus-1/system.d/org.freedesktop.home1.conf"
-digester = "xml"
-hash = "8bfb27085d0f465591b56f17b33c0f9100b917a0a592fe662eed52b039ac6737"
-[[FileDigestGroup.digests]]
-path = "/usr/share/dbus-1/system-services/org.freedesktop.home1.service"
-digester = "shell"
-hash = "c4281ad74af8c43a963806142e2770751b153df8c1217da4edf212b334ecddcf"
-
-[[FileDigestGroup]]
 package = "systemd-experimental"
 type = "dbus"
 note = "systemd-oomd out-of memory userspace handler based on control groups and PMI"


### PR DESCRIPTION
systemd v256 has since entered `openSUSE:Factory` and `SLFO:Main`.

<https://build.opensuse.org/projects/openSUSE:Factory/packages/systemd/files/systemd.changes?expand=1>