### PR TITLE
pam-modules: pam_limits.so moved from `pam` to `pam-extra` (bsc#1230447)

### DIFF
--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -150,7 +150,6 @@ nodigests = [
     "glob:*/security/pam_group.so",
     "glob:*/security/pam_keyinit.so",
     "glob:*/security/pam_lastlog.so",
-    "glob:*/security/pam_limits.so",
     "glob:*/security/pam_listfile.so",
     "glob:*/security/pam_localuser.so",
     "glob:*/security/pam_loginuid.so",
@@ -216,10 +215,11 @@ nodigests = [
 package = "pam-extra"
 type = "pam"
 note = "imported from rpmlint1 PAMModules.WhiteList, moved to new sub-package"
-bugs = ["bsc#1210371"]
+bugs = ["bsc#1210371", "bsc#1230447"]
 nodigests = [
     "glob:*/security/pam_timestamp.so",
     "glob:*/security/pam_issue.so",
+    "glob:*/security/pam_limits.so",
 ]
 
 [[FileDigestGroup]]


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1230447

see also:
https://bugzilla.suse.com/show_bug.cgi?id=1210371