### PR TITLE
dbus-services: gdm update (bsc#1230466)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -67,11 +67,11 @@ hash = "00d25f898cf4c78cf45d68000ee00be27b0aa15b7ebe22c4ba86bc1b5f33b898"
 package  = "gdm"
 type     = "dbus"
 note     = "D-Bus interface for managing GDM sessions"
-bugs     = ["bsc#1204052", "bsc#1218922"]
+bugs     = ["bsc#1204052", "bsc#1218922", "bsc#1230466"]
 [[FileDigestGroup.digests]]
 path     = "/usr/share/dbus-1/system.d/gdm.conf"
 digester = "xml"
-hash     = "127c6446350030991bd98c583eab96d7a5ff4b9301faa8e88bc7928c48dba0a8"
+hash     = "6c74cd8824a587ccd281886c655718dfecd1da530bb823e6625be4a22c5a09e6"
 
 [[FileDigestGroup]]
 package = "udisks2"


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1230466

### Diff
```
--- openSUSE:Factory/gdm/gdm-46.2/data/gdm.conf.in      2024-05-29 17:50:27.000000000 +0200
+++ GNOME:Next/gdm/gdm-47.rc/data/gdm.conf.in   2024-09-11 16:07:00.000000000 +0200
@@ -26,11 +26,6 @@
 
   </policy>
 
-  <policy user="gnome-remote-desktop">
-    <allow send_destination="org.gnome.DisplayManager"
-           send_interface="org.gnome.DisplayManager.RemoteDisplayFactory"/>
-  </policy>
-
   <policy context="default">
	 <deny send_destination="org.gnome.DisplayManager"
		   send_interface="org.gnome.DisplayManager.Display"/>
```

### Hash
The sources only contain `gdm.conf.in` that's processed in the build process. The actual `gdm.conf` can be found in `gdm-47.rc-1406.1.x86_64.rpm`.

```
$ get_whitelisting_digest.py --filter xml ./usr/share/dbus-1/system.d/gdm.conf
6c74cd8824a587ccd281886c655718dfecd1da530bb823e6625be4a22c5a09e6
```