### PR TITLE
dbus-services: sssd: temporarily whitelist old version (bsc#1230051)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -992,6 +992,21 @@ nodigests = [
     "/usr/share/dbus-1/system.d/org.freedesktop.portable1.conf",
 ]
 
+# TEMPORARY ENTRY FOR THE OLD VERSION. Remove after next major release.
+[[FileDigestGroup]]
+package = "sssd-dbus"
+type = "dbus"
+note = "sssd responder 'infopipe' service; D-Bus interface towards sssd"
+bugs = ["bsc#1157663", "bsc#1106600", "bsc#1207586", "bsc#1230051"]
+[[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system-services/org.freedesktop.sssd.infopipe.service"
+digester = "shell"
+hash = "a2631eb70e5cdc8392c97e19924dc9aca4ddcf4b38a44ada079dbfd5f3b5c873"
+[[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system.d/org.freedesktop.sssd.infopipe.conf"
+digester = "xml"
+hash = "d9304d507aced6bfd7f14eb5dcc93689ccf2a8b61d346718677fcd97a8b67feb"
+
 [[FileDigestGroup]]
 package = "sssd-dbus"
 type = "dbus"


### PR DESCRIPTION
This package will probably receive a minor update with the old D-Bus service in place, so we need to keep the old hashes intact. They can be removed after the next major update.

<https://bugzilla.suse.com/show_bug.cgi?id=1230051#c10>