### PR TITLE
openSUSE: strict policy to ERR on patch-macro-old-format

### DIFF
--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -38,3 +38,4 @@ deprecated-boot-script = 10000
 executable-stack = 10000
 binary-or-shlib-defines-rpath = 10000
 patchable-function-entry-in-archive = 10000
+patch-macro-old-format = 10000


### PR DESCRIPTION
Fix https://github.com/rpm-software-management/rpmlint/issues/1272