### PR TITLE
dbus-services: deepin-system-monitor (bsc#1230018)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1179,6 +1179,20 @@ nodigests = [
 ]
 
 [[FileDigestGroup]]
+package = "deepin-system-monitor"
+type = "dbus"
+note = "a system monitor for the DDE"
+bugs = ["bsc#1230018"]
+[[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system.d/org.deepin.SystemMonitorSystemServer.conf"
+digester = "xml"
+hash = "910464704ef1645092e83911aa4d4650a14f4421a770594da42d2f4c3c4626e0"
+[[FileDigestGroup.digests]]
+path = "/usr/share/dbus-1/system-services/org.deepin.SystemMonitorSystemServer.service"
+digester = "shell"
+hash = "ff69b41130cbec4d2682f3c9ff31c8fc7f1a16271a8f5fbfff003030f116f85a"
+
+[[FileDigestGroup]]
 package = "low-memory-monitor"
 type = "dbus"
 note = "a system wide daemon monitoring low memory situations and sending out signals"


### PR DESCRIPTION
Note to reviewer:

The hash for the XML `.conf` differs from the one mentioned in the bug report.
I downloaded the latest binaries from the devel project and re-calculated the hash:

```
$ get_whitelisting_digest.py --filter=xml ./share/dbus-1/system.d/org.deepin.SystemMonitorSystemServer.conf
910464704ef1645092e83911aa4d4650a14f4421a770594da42d2f4c3c4626e0
```