### PR TITLE
SUIDPermissionsCheck: chkstat to permctl rename

### DIFF
--- a/rpmlint/checks/SUIDPermissionsCheck.py
+++ b/rpmlint/checks/SUIDPermissionsCheck.py
@@ -1,4 +1,5 @@
 import os
+import re
 import stat
 
 import rpm
@@ -59,7 +60,7 @@ class SUIDPermissionsCheck(AbstractCheck):
 
         if script:
             for line in script.split('\n'):
-                if 'chkstat -n' in line and path in line:
+                if re.search(fr'(chkstat|permctl) -n .* {path}', line):
                     found = True
                     break
 


### PR DESCRIPTION
This patch checks for `permctl` or `chkstat` commands in the `POSTIN`, so it should be compatible with the new name and also the old one.

Fix https://github.com/rpm-software-management/rpmlint/issues/1292