### PR TITLE
SUIDPermissionsCheck: Check for permctl instead of chkstat

### DIFF
--- a/rpmlint/checks/SUIDPermissionsCheck.py
+++ b/rpmlint/checks/SUIDPermissionsCheck.py
@@ -81,7 +81,8 @@ class SUIDPermissionsCheck(AbstractCheck):
             found = False
             if script:
                 for line in script.split('\n'):
-                    if '/chkstat' in line and path in line:
+                    escaped = re.escape(path)
+                    if re.search(fr'(chkstat|permctl) -n .* {escaped}', line):
                         found = True
                         break
 

--- a/test/test_suid_permissions.py
+++ b/test/test_suid_permissions.py
@@ -156,11 +156,21 @@ PERMCTL_PKG = get_tested_mock_package(
     /usr/bin/permctl -n --set --system /var/lib/perms/test || : \
   fi \
 """,
+        'VERIFYSCRIPT': """
+  if [ -x /usr/bin/permctl ]; then \
+    /usr/bin/permctl -n --set --system /var/lib/perms/test || : \
+  fi \
+""",
     },
 )
 CHKSTAT_PKG = PERMCTL_PKG.clone(
     header={
         'POSTIN': """
+  if [ -x /usr/bin/chkstat ]; then \
+    /usr/bin/chkstat -n --set --system /var/lib/perms/test || : \
+  fi \
+""",
+        'VERIFYSCRIPT': """
   if [ -x /usr/bin/chkstat ]; then \
     /usr/bin/chkstat -n --set --system /var/lib/perms/test || : \
   fi \
@@ -175,3 +185,4 @@ def test_permissions_permctl(package, permissions_check):
     test.check(package)
     out = output.print_results(output.results)
     assert 'permissions-missing-postin' not in out
+    assert 'permissions-missing-verifyscript' not in out


### PR DESCRIPTION
W: permissions-missing-verifyscript is incorrectly reported.

Related to https://github.com/rpm-software-management/rpmlint/issues/1292