### PR TITLE
[opensuse SLFO:main] Handle the missing buildroot in rpm 4.20 gracefully

### DIFF
--- a/rpmlint/checks/BuildRootAndDateCheck.py
+++ b/rpmlint/checks/BuildRootAndDateCheck.py
@@ -17,7 +17,7 @@ class BuildRootAndDateCheck(AbstractFilesCheck):
         super().__init__(config, output, r'.*')
         self.looksliketime = re.compile('(2[0-3]|[01]?[0-9]):([0-5]?[0-9]):([0-5]?[0-9])')
         self.istoday = re.compile(time.strftime('%b %e %Y'))
-        self.prepare_regex(rpm.expandMacro('%buildroot'))
+        self.prepare_regex(rpm.expandMacro('%{?buildroot}') or '^/.*/BUILDROOT/')
 
     def prepare_regex(self, buildroot):
         for m in ('name', 'version', 'release', 'NAME', 'VERSION', 'RELEASE'):


### PR DESCRIPTION
Cerry-pick of 2a5b7a4de4d7c0723f5b76064e8adf6f7f2977f8 from https://github.com/rpm-software-management/rpmlint/pull/1304