### PR TITLE
Add a new warning for `setup.py install` usage

### DIFF
--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -83,6 +83,7 @@ pkgname_regex = re.compile(r'\s+(?:-n\s+)?(\S+)')
 tarball_regex = re.compile(r'\.(?:t(?:ar|[glx]z|bz2?)|zip)\b', re.IGNORECASE)
 
 python_setup_test_regex = re.compile(r'^[^#]*(setup.py test)')
+python_setup_install_regex = re.compile(r'^[^#]*(setup.py install|%\{?python\d*_install)')
 python_module_def_regex = re.compile(r'^[^#]*%{\?!python_module:%define python_module()')
 python_sitelib_glob_regex = re.compile(r'^[^#]*%{python_site(lib|arch)}/\*\s*$')
 
@@ -393,6 +394,7 @@ class SpecCheck(AbstractCheck):
         self._checkline_valid_groups(line)
         self._checkline_macros_in_comments(line)
         self._checkline_python_setup_test(line)
+        self._checkline_python_setup_install(line)
         self._checkline_python_module_def(line)
         self._checkline_python_sitelib_glob(line)
         self._checkline_shared_dir_glob(line)
@@ -793,6 +795,11 @@ class SpecCheck(AbstractCheck):
         # Test if the "python setup.py test" deprecated subcommand is used
         if self.current_section == 'check' and python_setup_test_regex.search(line):
             self.output.add_info('W', self.pkg, 'python-setup-test', line[:-1])
+
+    def _checkline_python_setup_install(self, line):
+        # Test if the "python setup.py install" deprecated subcommand is used
+        if self.current_section == 'install' and python_setup_install_regex.search(line):
+            self.output.add_info('W', self.pkg, 'python-setup-install', line[:-1])
 
     def _checkline_python_module_def(self, line):
         """

--- a/rpmlint/checks/SpecCheck.py
+++ b/rpmlint/checks/SpecCheck.py
@@ -83,7 +83,7 @@ pkgname_regex = re.compile(r'\s+(?:-n\s+)?(\S+)')
 tarball_regex = re.compile(r'\.(?:t(?:ar|[glx]z|bz2?)|zip)\b', re.IGNORECASE)
 
 python_setup_test_regex = re.compile(r'^[^#]*(setup.py test)')
-python_setup_install_regex = re.compile(r'^[^#]*(setup.py install|%\{?python\d*_install)')
+python_setup_install_regex = re.compile(r'^[^#]*(setup.py install|%\{?py(thon)?\d*_install)')
 python_module_def_regex = re.compile(r'^[^#]*%{\?!python_module:%define python_module()')
 python_sitelib_glob_regex = re.compile(r'^[^#]*%{python_site(lib|arch)}/\*\s*$')
 

--- a/rpmlint/descriptions/SpecCheck.toml
+++ b/rpmlint/descriptions/SpecCheck.toml
@@ -207,6 +207,10 @@ python-setup-test="""
 The python setup.py test subcommand is deprecated and should be replaced with a
 modern testing tool like %pytest or %pyunittest discover -v.
 """
+python-setup-install="""
+The python setup.py install subcommand is deprecated and should be replaced with
+macros %pyproject_wheel, %pyproject_install or with "pip"
+"""
 python-module-def="""
 The spec file contains a conditional definition of python_module macro, this
 macro is present in recent versions of python-rpm-macros.

--- a/test/spec/python-setup-install.spec
+++ b/test/spec/python-setup-install.spec
@@ -1,0 +1,29 @@
+Name:           python-setup-install
+Version:        1.0
+Release:        0
+Summary:        python-setup-install warning
+License:        MIT
+URL:            https://www.example.com
+Source:         Source.tar.gz
+BuildRequires:  gcc
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+%description
+A test specfile with python setup.py test that is deprecated.
+
+%prep
+%setup -q
+
+%build
+python3 setup.py build
+
+%install
+python3 setup.py install
+
+%check
+
+%files
+%license COPYING
+%doc ChangeLog README
+
+%changelog

--- a/test/spec/python-setup-python_install.spec
+++ b/test/spec/python-setup-python_install.spec
@@ -21,6 +21,8 @@ A test specfile with python setup.py test that is deprecated.
 %python_install
 %python3_install
 %python312_install
+# old fedora version
+%py3_install
 
 %check
 

--- a/test/spec/python-setup-python_install.spec
+++ b/test/spec/python-setup-python_install.spec
@@ -1,0 +1,31 @@
+Name:           python-setup-python_install
+Version:        1.0
+Release:        0
+Summary:        python-setup-install warning
+License:        MIT
+URL:            https://www.example.com
+Source:         Source.tar.gz
+BuildRequires:  gcc
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+%description
+A test specfile with python setup.py test that is deprecated.
+
+%prep
+%setup -q
+
+%build
+%python_build
+
+%install
+%python_install
+%python3_install
+%python312_install
+
+%check
+
+%files
+%license COPYING
+%doc ChangeLog README
+
+%changelog

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -1172,7 +1172,7 @@ def test_python_setup_test(package, speccheck):
 
 @pytest.mark.parametrize('package,lines', [
     ('spec/python-setup-install', ['setup.py install']),
-    ('spec/python-setup-python_install', ['python_install', 'python3_install', 'python312_install']),
+    ('spec/python-setup-python_install', ['python_install', 'python3_install', 'python312_install', 'py3_install']),
 ])
 def test_python_setup_install(package, lines, speccheck):
     """Test if specfile has deprecated use of 'setup.py install'."""

--- a/test/test_speccheck.py
+++ b/test/test_speccheck.py
@@ -1170,6 +1170,21 @@ def test_python_setup_test(package, speccheck):
     assert 'W: python-setup-test' in out
 
 
+@pytest.mark.parametrize('package,lines', [
+    ('spec/python-setup-install', ['setup.py install']),
+    ('spec/python-setup-python_install', ['python_install', 'python3_install', 'python312_install']),
+])
+def test_python_setup_install(package, lines, speccheck):
+    """Test if specfile has deprecated use of 'setup.py install'."""
+    output, test = speccheck
+    pkg = get_tested_spec_package(package)
+    test.check_spec(pkg)
+    out = output.print_results(output.results)
+    assert 'W: python-setup-install' in out
+    for line in lines:
+        assert line in out
+
+
 @pytest.mark.parametrize('package', ['spec/python-module-def'])
 def test_python_module_definition(package, speccheck):
     """Test if python_module macro is defined in the spec file."""

--- a/test/test_spellchecking.py
+++ b/test/test_spellchecking.py
@@ -51,7 +51,7 @@ def test_spellchecking():
     result = spell.spell_check(text, 'Description({}):')
     assert len(result) == 2
     assert result['tihs'].startswith('Description(en_US): tihs -> ')
-    assert get_suggestions(result['tihs']) == ['hits', 'this', 'ties']
+    assert get_suggestions(result['tihs']) == ["Ti's", 'this', "ti's"]
 
     # different language, one typo
     text = 'Příčerně žluťoučký kůň'

--- a/test/test_spellchecking.py
+++ b/test/test_spellchecking.py
@@ -51,7 +51,7 @@ def test_spellchecking():
     result = spell.spell_check(text, 'Description({}):')
     assert len(result) == 2
     assert result['tihs'].startswith('Description(en_US): tihs -> ')
-    assert get_suggestions(result['tihs']) == ["Ti's", 'this', "ti's"]
+    assert 'this' in get_suggestions(result['tihs'])
 
     # different language, one typo
     text = 'Příčerně žluťoučký kůň'


### PR DESCRIPTION
[Setuptools](https://setuptools.pypa.io/en/latest/history.html#id6) added a deadline of Oct 31 to the setup.py install deprecation.

The usage of `setup.py install` should be replaced with `pip`. This PR adds a new warning when this command is found in the spec file or if the usage of the `%python_install` macro is found.