### PR TITLE
[opensuse] sysctl-whitelist: adjust 50-coredump.conf digest for systemd (bsc#1243959)

### DIFF
--- a/configs/openSUSE/sysctl-whitelist.toml
+++ b/configs/openSUSE/sysctl-whitelist.toml
@@ -56,7 +56,7 @@ bugs = ["bsc#1174722", "bsc#1226865"]
 [[FileDigestGroup.digests]]
 path = "/usr/lib/sysctl.d/50-coredump.conf"
 digester = "shell"
-hash = "167ec7922affa2b784540a0d755f02a270cd5d816aea402db2e6489cee293bad"
+hash = "54f2f502708e2b70ac5b6994b4162641fcdee4b834d8eba928d066e4795c4f04"
 
 [[FileDigestGroup]]
 package = "aaa_base"


### PR DESCRIPTION
…3959)