### PR TITLE
BuildRootAndDateCheck: More specific buildroot check

### DIFF
--- a/rpmlint/checks/BuildRootAndDateCheck.py
+++ b/rpmlint/checks/BuildRootAndDateCheck.py
@@ -17,7 +17,13 @@ class BuildRootAndDateCheck(AbstractFilesCheck):
         super().__init__(config, output, r'.*')
         self.looksliketime = re.compile('(2[0-3]|[01]?[0-9]):([0-5]?[0-9]):([0-5]?[0-9])')
         self.istoday = re.compile(time.strftime('%b %e %Y'))
-        self.prepare_regex(rpm.expandMacro('%{?buildroot}') or '/.{1,40}/BUILDROOT/')
+        # in rpm 4.20 the expandMacro will return an empty string and so we run
+        # into the "or" case.
+        # return a string that is modelled after the actual path that rpm 4.20
+        # is using so we can actually match what the rpm 4.20 path will be and
+        # not just any random string in a file that references buildroot.
+        # https://github.com/rpm-software-management/rpm/blob/rpm-4.20.1-release/build/parsePreamble.c#L1290
+        self.prepare_regex(rpm.expandMacro('%{?buildroot}') or '/%{NAME}-%{VERSION}-build/BUILDROOT/')
 
     def prepare_regex(self, buildroot):
         for m in ('name', 'version', 'release', 'NAME', 'VERSION', 'RELEASE'):


### PR DESCRIPTION
This patch makes the BUILDROOT regex more specific for rpm >= 4.20. In this case the expandMacro('%{?buildroot}') will return and empty string and the fallback match any path with "/BUILDROOT". The change convert the cheking path to "/.../rpmbuild/...-...-build/BUILDROOT/"

Fix https://github.com/rpm-software-management/rpmlint/issues/1350