### PR TITLE
[opensuse] dbus-services: whitelist kio-admin (bsc#1229913)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1412,3 +1412,17 @@ hash     = "f9c8290a4e53a251b5405f0a04676b222866c9d0463e0d5e16d020657ec335cb"
 path     = "/usr/share/dbus-1/system-services/org.kde.kameleonhelper.service"
 digester = "shell"
 hash     = "85e17072d140148cf4cb4186389f5dd6a24c56fbae76c5392504b9062560e0f6"
+
+[[FileDigestGroup]]
+package  = "kio-admin"
+note     = "privileged file operations helper for KDE (e.g. used in Dolphin)"
+bug      = "bsc#1229913"
+type     = "dbus"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/dbus-1/system.d/org.kde.kio.admin.conf"
+digester = "xml"
+hash     = "27fe3098931a301fcbe871e319f8fd6e50138447dec1080935151c41b29703c9"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/dbus-1/system-services/org.kde.kio.admin.service"
+digester = "shell"
+hash     = "ce9ed24db3c3654551bada756eb9aac5a58358364b41827b8154d0f73d6dc506"


### PR DESCRIPTION
There is a request to add this to Leap 16.0:

https://build.opensuse.org/request/show/1271698

Whitelisting needs to go to SLFO:Main for this.