### PR TITLE
[opensuse] document review bug for systemd sysctl coredump file 

### DIFF
--- a/configs/openSUSE/sysctl-whitelist.toml
+++ b/configs/openSUSE/sysctl-whitelist.toml
@@ -52,7 +52,7 @@ hash = "e70681a232f129648465d4aa036f37e3da8dcbfa611b1380baa5bd98030c6b61"
 package = "systemd"
 type = "sysctl"
 note = "sets core pattern, core pipe limit and suid_dumpable"
-bugs = ["bsc#1174722", "bsc#1226865"]
+bugs = ["bsc#1174722", "bsc#1226865", "bsc#1243959"]
 [[FileDigestGroup.digests]]
 path = "/usr/lib/sysctl.d/50-coredump.conf"
 digester = "shell"


### PR DESCRIPTION
I forgot to add this when I made the change to the digest previously.