### PR TITLE
Consider /usr/etc in checks

### DIFF
--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -99,3 +99,5 @@ zypperplugin-file-digest-mismatch = 10
 zypperplugin-file-ghost = 10
 zypperplugin-file-unauthorized = 10
 patch-macro-old-format = 10000
+# TODO: raise to 10,000 after we surveyed affected packages
+logrotate-user-writable-log-dir = 100

--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -147,7 +147,7 @@ class BinariesCheck(AbstractCheck):
 
         We suppose that the package is arch dependent.
         """
-        if bin_name.startswith('/etc/'):
+        if bin_name.startswith('/etc/') or bin_name.startswith('/usr/etc/'):
             self.output.add_info('E', pkg, 'binary-in-etc', bin_name)
 
     def _check_unstripped_binary(self, bin_name, pkg, pkgfile):

--- a/rpmlint/checks/LogrotateCheck.py
+++ b/rpmlint/checks/LogrotateCheck.py
@@ -15,7 +15,7 @@ class LogrotateCheck(AbstractCheck):
             if f in pkg.ghost_files:
                 continue
 
-            if f.startswith('/etc/logrotate.d/'):
+            if f.startswith('/etc/logrotate.d/') or f.startswith('/usr/etc/logrotate.d/'):
                 try:
                     for n, o in self.parselogrotateconf(pkg.dir_name(), f).items():
                         if n in dirs and dirs[n] != o:


### PR DESCRIPTION
Since this is not strictly limited to security whitelisting checks it might also be interesting for @danigm to have a look.