### PR TITLE
Fix libgpiod whitelisting package name (bsc#1244702)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1428,7 +1428,7 @@ digester = "shell"
 hash     = "ce9ed24db3c3654551bada756eb9aac5a58358364b41827b8154d0f73d6dc506"
 
 [[FileDigestGroup]]
-package  = "libgpiod"
+package  = "libgpiod-manager"
 note     = "GPIO character device management daemon"
 bug      = "bsc#1244702"
 type     = "dbus"


### PR DESCRIPTION
Fix package name oversight missed in #1360.

Cherry pick of 7aca591feff2418ea756d90038ed6a648e75c639 introduced in #1361 