### PR TITLE
Run only once the validate_filters per call

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -67,6 +67,7 @@ class Lint:
         if self.options['explain']:
             self.print_explanation(self.options['explain'], self.config)
             return retcode
+
         # if there are installed arguments just load them up as extra
         # items to the rpmfile option
         if self.options['installed']:
@@ -222,8 +223,10 @@ class Lint:
         print('')
 
     def validate_installed_packages(self, packages):
+        # Do not run post checks if there are also plain rpm/spec files to validate
+        run_post_checks = not bool(self.options['rpmfile'])
         for pkg in packages:
-            self.run_checks(pkg, pkg == packages[-1])
+            self.run_checks(pkg, run_post_checks and pkg == packages[-1])
             self.reset_checks()
 
     def validate_files(self, files):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,11 +1,12 @@
 from pathlib import PosixPath
+from unittest.mock import Mock
 
 import pytest
 from rpmlint.cli import process_lint_args
 from rpmlint.config import Config
 from rpmlint.lint import Lint
 
-from Testing import HAS_CHECKBASHISMS, HAS_DASH
+from Testing import HAS_CHECKBASHISMS, HAS_DASH, HAS_RPMDB
 
 
 @pytest.mark.parametrize('test_arguments', [['-c', 'rpmlint/configs/thisdoesntexist.toml']])
@@ -92,3 +93,18 @@ def test_reset_check():
     lint.run()
     out = lint.output.print_results(lint.output.results, lint.config)
     assert 'more-than-one-%changelog-section' not in out
+
+
+@pytest.mark.skipif(not HAS_RPMDB, reason='No RPM database present')
+@pytest.mark.parametrize('args', [
+    ['test/spec/SpecCheck2.spec', 'test/spec/SpecCheck3.spec'],
+    ['-i', 'rpm', 'glibc'],
+    ['test/spec/SpecCheck2.spec', '-i', 'rpm'],
+    ['test/spec/SpecCheck2.spec', 'test/spec/SpecCheck3.spec', '-i', 'rpm', 'glibc'],
+])
+def test_validate_filters(args):
+    options = process_lint_args(args)
+    lint = Lint(options)
+    lint.output.validate_filters = Mock(wraps=lint.output.validate_filters)
+    lint.run()
+    lint.output.validate_filters.assert_called_once()


### PR DESCRIPTION
When the cli tool is called with "-i" option in combination with a list of spec/rpm files it runs the validate_installed_packages and also the validate_files. These methods check the list of packages to lint to just run post check function and validate used filters in rpmlintrc.

This patch makes sure to do not call the post check and validation twice, checking if there are also "files" during the validate_installed_packages. That way the is_last will be only true in the latter call inside validate_files.

Fix https://github.com/rpm-software-management/rpmlint/issues/1368