### PR TITLE
AlternativesCheck: detect update-alternatives on Fedora

### DIFF
--- a/rpmlint/checks/AlternativesCheck.py
+++ b/rpmlint/checks/AlternativesCheck.py
@@ -22,7 +22,7 @@ class AlternativesCheck(AbstractCheck):
       Requires(post) and Requires(postun) must depend on update-alternatives
     """
     # Regex to match anything that can be in requires for update-alternatives
-    re_requirement = re.compile(r'^(/usr/sbin/|%{?_sbindir}?/)?update-alternatives$')
+    re_requirement = re.compile(r'^(/usr/s?bin/|%{?_s?bindir}?/)?update-alternatives$')
     re_install = re.compile(r'--install\s+(?P<link>\S+)\s+(?P<name>\S+)\s+(\S+)\s+(\S+)')
     re_slave = re.compile(r'--slave\s+(?P<link>\S+)\s+(\S+)\s+(\S+)')
     command = 'update-alternatives'


### PR DESCRIPTION
Update the update-alternatives-requirement-missing check to also detect "update-alternatives" on Fedora.

On such systems, update-alternatives is installed under /usr/bin. Thus the requirement may also be expressed as /usr/bin/update-alternatives or %{_bindir}/update-alternatives.