### PR TITLE
Remove post-without-tmpfile-creation warning

### DIFF
--- a/rpmlint/checks/TmpFilesCheck.py
+++ b/rpmlint/checks/TmpFilesCheck.py
@@ -30,7 +30,6 @@ class TmpFilesCheck(AbstractCheck):
                 continue
 
             self._check_pre_tmpfile(fname, pkg)
-            self._check_post_tmpfile(fname, pkg)
             self._check_tmpfile_in_filelist(pkgfile, pkg)
 
     def _check_pre_tmpfile(self, fname, pkg):
@@ -48,22 +47,6 @@ class TmpFilesCheck(AbstractCheck):
 
         if pre and tmpfiles_regex.search(pre):
             self.output.add_info('W', pkg, 'pre-with-tmpfile-creation', fname)
-
-    def _check_post_tmpfile(self, fname, pkg):
-        """
-        Check if the %post section contains 'systemd-tmpfiles --create' call.
-
-        Print a warning if there is no such call in the %post section.
-        """
-        post = pkg[rpm.RPMTAG_POSTIN]
-
-        basename = Path(fname).name
-        tmpfiles_regex = re.compile(r'systemd-tmpfiles --create .*%s'
-                                    % re.escape(basename))
-
-        if post and tmpfiles_regex.search(post):
-            return
-        self.output.add_info('W', pkg, 'post-without-tmpfile-creation', fname)
 
     def _check_tmpfile_in_filelist(self, pkgfile, pkg):
         """

--- a/rpmlint/descriptions/TmpFilesCheck.toml
+++ b/rpmlint/descriptions/TmpFilesCheck.toml
@@ -2,11 +2,6 @@ pre-with-tmpfile-creation="""
 %pre section contains %tmpfiles_create macro that should be in the
 %post section instead.
 """
-post-without-tmpfile-creation="""
-Please use the %tmpfiles_create macro in %post for each of your
-tmpfiles.d files if you expect this file or directory to be
-available after package installation (and before reboot).
-"""
 tmpfile-not-regular-file="""
 Files in tmpfiles.d need to be regular files.
 """

--- a/test/test_tmp_files.py
+++ b/test/test_tmp_files.py
@@ -25,7 +25,6 @@ def test_tmpfiles(package, tmpfilescheck):
     out = output.print_results(output.results)
 
     assert 'W: pre-with-tmpfile-creation ' not in out
-    assert 'W: post-without-tmpfile-creation /usr/lib/tmpfiles.d/krb5.conf' in out
     assert 'W: tmpfile-not-in-filelist /var/lib/kerberos' in out
     assert 'W: tmpfile-not-regular-file /usr/lib/tmpfiles.d/symlink.conf' in out
 
@@ -37,7 +36,6 @@ def test_tmpfiles2(package, tmpfilescheck):
     out = output.print_results(output.results)
 
     assert 'W: pre-with-tmpfile-creation /usr/lib/tmpfiles.d/systemd-tmpfiles.conf' in out
-    assert 'W: post-without-tmpfile-creation' in out
     assert 'W: tmpfile-not-in-filelist /run/my_new_directory' in out
     assert 'W: tmpfile-not-regular-file' not in out
 
@@ -49,6 +47,5 @@ def test_tmpfiles_correct(package, tmpfilescheck):
     out = output.print_results(output.results)
 
     assert 'W: pre-with-tmpfile-creation' not in out
-    assert 'W: post-without-tmpfile-creation' not in out
     assert 'W: tmpfile-not-regular-file' not in out
     assert 'W: tmpfile-not-in-filelist' not in out


### PR DESCRIPTION
This warning is not needed anymore. %tmpfiles macro nowadays is a noop since it is done via triggers in the systemd package.

Fix https://github.com/rpm-software-management/rpmlint/issues/1374