### PR TITLE
Resolve `no-else-raise`

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -273,8 +273,7 @@ class Lint:
             print_warning(f'(none): E: fatal error while reading {pname}: {e}')
             if self.config.info:
                 raise e
-            else:
-                sys.exit(3)
+            sys.exit(3)
 
     def run_checks(self, pkg, is_last):
         spec_checks = isinstance(pkg, FakePkg)


### PR DESCRIPTION
This PR resolves [`no-else-raise / R1720`](https://pylint.readthedocs.io/en/stable/user_guide/messages/refactor/no-else-raise.html).