### PR TITLE
Resolve `consider-using-in`

### DIFF
--- a/rpmlint/lint.py
+++ b/rpmlint/lint.py
@@ -260,7 +260,7 @@ class Lint:
 
     def validate_file(self, pname, is_last):
         try:
-            if pname.suffix == '.rpm' or pname.suffix == '.spm':
+            if pname.suffix in ('.rpm', '.spm'):
                 with Pkg(pname, self.config.configuration['ExtractDir'],
                          verbose=self.config.info) as pkg:
                     for k, v in pkg.timers.items():


### PR DESCRIPTION
This PR resolves [`consider-using-in / R1714`](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/consider-using-in.html). This change makes the code more consistent, cf.:
https://github.com/rpm-software-management/rpmlint/blob/9e2c9f145957c3f7bfe3634517db49a4b3d57677/rpmlint/lint.py#L255