### PR TITLE
scoring: raise badness for logrotate-user-writable-log-dir (bsc#1245961)

### DIFF
--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -99,5 +99,4 @@ zypperplugin-file-digest-mismatch = 10
 zypperplugin-file-ghost = 10
 zypperplugin-file-unauthorized = 10
 patch-macro-old-format = 10000
-# TODO: raise to 10,000 after we surveyed affected packages
-logrotate-user-writable-log-dir = 100
+logrotate-user-writable-log-dir = 10000


### PR DESCRIPTION
Since this finding is security related it should fail the build by default.

There is no difference between the strict and non-strict scoring here, as is the case with whitelisting related diagnostics. This finding can be fixed by packagers on their own and no help from the security team is needed. Thus it should fail the build right away, not only in strict build configurations.