### PR TITLE
Resolve `use-implicit-booleaness-not-len`

### DIFF
--- a/test/test_files.py
+++ b/test/test_files.py
@@ -153,7 +153,7 @@ def test_makefile_junk(package, filescheck):
 def test_sphinx_inv_files(package, filescheck):
     output, test = filescheck
     test.check(package)
-    assert not len(output.results)
+    assert not output.results
 
 
 @pytest.mark.parametrize('package', [FileChecksPackage])


### PR DESCRIPTION
This change resolves [`use-implicit-booleaness-not-len / C1802`](https://pylint.readthedocs.io/en/latest/user_guide/messages/convention/use-implicit-booleaness-not-len.html).