### PR TITLE
Synced /var/spool/mail entry with Factory filesystem package.

### DIFF
--- a/rpmlint/checks/FilesCheck.py
+++ b/rpmlint/checks/FilesCheck.py
@@ -144,7 +144,6 @@ STANDARD_DIRS = (
     '/var/opt',
     '/var/preserve',
     '/var/spool',
-    '/var/spool/mail',
     '/var/tmp',
 )
 


### PR DESCRIPTION
It appears that the list in `FilesCheck.py` is no longer in sync with filesystem package of openSUSE Factory.

In particular, error `standard-dir-owned-by-package` is emitted on path `/var/spool/mail` that is not provided by the filesystem package (see https://build.opensuse.org/projects/openSUSE:Factory/packages/filesystem/files/directory.list?expand=1), and is instead owned by optional packages like `postfix`, `sendmail`, `exim`, etc. (see https://bugzilla.opensuse.org/show_bug.cgi?id=1179574).

New packages that provide `smtp_daemon` would be expected to own that path.  If I see correctly, this is different topic from the topic of allowlisting the typical 1777 permissions that goes through a separate security review process and has a different check in `rpmlint`.

Therefore, I suggest the attached change. Thank you in advance for your consideration.