### PR TITLE
[opensuse] systemd v258 partial whitelisting

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -78,18 +78,7 @@ hash     = "6c74cd8824a587ccd281886c655718dfecd1da530bb823e6625be4a22c5a09e6"
 package  = "gdm"
 type     = "dbus"
 note     = "D-Bus interface for managing GDM sessions"
-bugs     = ["bsc#1204052", "bsc#1218922", "bsc#1230466"]
-[[FileDigestGroup.digests]]
-path     = "/usr/share/dbus-1/system.d/gdm.conf"
-digester = "xml"
-hash     = "127c6446350030991bd98c583eab96d7a5ff4b9301faa8e88bc7928c48dba0a8"
-
-# TODO: merge with entry above once GNOME 49 enters Factory
-[[FileDigestGroup]]
-package  = "gdm"
-note     = "GNOME 49 beta changes to entry above"
-bug      = "bsc#1248881"
-type     = "dbus"
+bugs     = ["bsc#1204052", "bsc#1218922", "bsc#1230466", "bsc#1248881"]
 [[FileDigestGroup.digests]]
 path     = "/usr/share/dbus-1/system.d/gdm.conf"
 digester = "xml"

--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1130,6 +1130,21 @@ path = "/usr/share/dbus-1/system-services/org.freedesktop.home1.service"
 digester = "shell"
 hash = "c4281ad74af8c43a963806142e2770751b153df8c1217da4edf212b334ecddcf"
 
+# TODO: merge with entry above once v258 reaches Factory
+[[FileDigestGroup]]
+package  = "systemd-homed"
+note     = "systemd-homed v258 changes"
+bug      = "bsc#1250884"
+type     = "dbus"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/dbus-1/system.d/org.freedesktop.home1.conf"
+digester = "xml"
+hash     = "1f5955ba5955830ca518f206d751401adb6caec36d82c6434b60ab5398d17a0b"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/dbus-1/system-services/org.freedesktop.home1.service"
+digester = "shell"
+hash     = "c4281ad74af8c43a963806142e2770751b153df8c1217da4edf212b334ecddcf"
+
 [[FileDigestGroup]]
 package = "systemd-experimental"
 type = "dbus"

--- a/configs/openSUSE/polkit-rules-whitelist.toml
+++ b/configs/openSUSE/polkit-rules-whitelist.toml
@@ -227,3 +227,13 @@ type     = "polkit"
 path     = "/usr/share/polkit-1/rules.d/20-gdm.rules"
 digester = "default"
 hash     = "38aaac33cd24fca2db1bdf35389b0d52bc17741ae55f0de4ea35d16d5817cd24"
+
+[[FileDigestGroup]]
+package  = "systemd"
+note     = "This is just an example file that will not be active by default"
+bug      = "bsc#1250844"
+type     = "polkit"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/polkit-1/rules.d/10-systemd-logind-root-ignore-inhibitors.rules.example"
+digester = "default"
+hash     = "0dcb4cdb6a4b43f23c4dc798e729ab605c3c0c470fe1c90f2db6351e4ae47418"

--- a/configs/openSUSE/polkit-rules-whitelist.toml
+++ b/configs/openSUSE/polkit-rules-whitelist.toml
@@ -102,21 +102,10 @@ hash = "6daefe0a835dc1b34513302f393e98089c137602823f41fd0c3dd984c40902d8"
 package = "gnome-initial-setup"
 type = "polkit"
 note = "Follow-up whitelisting, upstream added org.fedoraproject.thirdparty.* to the rules"
-bug = "bsc#1192542"
+bugs  = ["bsc#1192542", "bsc#1249067"]
 [[FileDigestGroup.digests]]
 path = "/usr/share/polkit-1/rules.d/20-gnome-initial-setup.rules"
-hash = "e8d930c2f4ef56727ab4e64ebe21c98e3ab7aaf3a4079d15ddc6acf324a5a412"
-
-# TODO: merge the three GIS entries once GNOME49 enters Factory
-[[FileDigestGroup]]
-package  = "gnome-initial-setup"
-note     = "GNOME49 Beta changes"
-bug      = "bsc#1249067"
-type     = "polkit"
-[[FileDigestGroup.digests]]
-path     = "/usr/share/polkit-1/rules.d/20-gnome-initial-setup.rules"
-digester = "default"
-hash     = "6241e147d107fbc2f786b7149c26abb75185cf9db5d921401e310f78f4e8bced"
+hash = "6241e147d107fbc2f786b7149c26abb75185cf9db5d921401e310f78f4e8bced"
 
 [[FileDigestGroup]]
 package = "libvirt-dbus"
@@ -202,18 +191,7 @@ hash = "9e12a279a21d11c92a41ccd818edcb9b7c89a162984a6e1ca5609b9bbcbbf989"
 [[FileDigestGroup]]
 package  = "gnome-remote-desktop"
 note     = "allows the g-r-d system user to enable/disable itself"
-bug      = "bsc#1222159"
-type     = "polkit"
-[[FileDigestGroup.digests]]
-path     = "/usr/share/polkit-1/rules.d/20-gnome-remote-desktop.rules"
-digester = "default"
-hash     = "559f983aa50bbea8f4927fa96dc06a4e0f781617495339155b2bd4d077ec4607"
-
-# TODO: merge with entry above once GNOME 49 enters Factory
-[[FileDigestGroup]]
-package  = "gnome-remote-desktop"
-note     = "GNOME49 beta changes"
-bug      = "bsc#1248979"
+bugs     = ["bsc#1222159", "bsc#1248979"]
 type     = "polkit"
 [[FileDigestGroup.digests]]
 path     = "/usr/share/polkit-1/rules.d/20-gnome-remote-desktop.rules"
@@ -243,18 +221,7 @@ hash     = "fb2bcf81da84890c74de32b1f4dd6d829058a43bbef9ae7862b92372efe4ddc0"
 [[FileDigestGroup]]
 package  = "gdm"
 note     = "allows the display manager to add WiFi connections via NetworkManager"
-bug      = "bsc#1239719"
-type     = "polkit"
-[[FileDigestGroup.digests]]
-path     = "/usr/share/polkit-1/rules.d/20-gdm.rules"
-digester = "default"
-hash     = "c752f8f6c304404e256fbd3f4bbb04d0ec42408f311454268b667597cb1c8265"
-
-# TODO: merge with entry above once GNOME 49 enters Factory
-[[FileDigestGroup]]
-package  = "gdm"
-note     = "GNOME 49 beta changes to entry above"
-bug      = "bsc#1248881"
+bugs     = ["bsc#1239719","bsc#1248881"]
 type     = "polkit"
 [[FileDigestGroup.digests]]
 path     = "/usr/share/polkit-1/rules.d/20-gdm.rules"


### PR DESCRIPTION
To allow our systemd maintainers to progress this whitelists all the parts of systemd v258 that have already been reviewed. The current integration of v258 can be found in OBS [here](https://build.opensuse.org/package/show/home:fbui:systemd-v258/systemd).

While being at it this PR# also cleans up the previous GDM46 beta whitelistings. GDM46 already reached Factory by now.