### PR TITLE
Add checks for atomic update compatibility

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -6,6 +6,10 @@ UseVarLockSubsys = false
 UseVersionInChangelog = false
 BadnessThreshold = 999
 
+# Set to true to issue a warning for ghost entries outside snapshots
+# when checking for atomic update compatibility
+AtomicCheckGhosts = false
+
 # Enabled checks for the rpmlint to be run (besides the default set)
 Checks = [
     "BashismsCheck",
@@ -13,11 +17,31 @@ Checks = [
     "TmpFilesCheck",
     "SysVInitOnSystemdCheck",
     "SharedLibraryPolicyCheck",
+    "AtomicUpdateCheck",
 ]
 
 # List of directory prefixes that are not allowed in packages
 DisallowedDirs = [
     "/etc/NetworkManager/dispatcher.d",
+]
+
+# Only these directories may be used by packages compatible with
+# atomic updates
+AtomicAllowedDirs = [
+    "/etc/",
+    "/usr/",
+    "/bin/",
+    "/lib/",
+    "/lib64/",
+    "/sbin/",
+    "/boot/",
+]
+
+# List of subdirectories which are disallowed for atomic updates
+# despite being within otherwise allowed directories
+AtomicDisallowedSubdirs = [
+    "/usr/local/",
+    "/boot/efi/",
 ]
 
 FilterErrorTitles = [
@@ -73,6 +97,7 @@ Filters = [
     '^filesystem\..*: dir-or-file-in-tmp',
     '^filesystem\..*: dir-or-file-in-mnt',
     '^filesystem\..*: dir-or-file-in-home',
+    '^filesystem\..*: dir-or-file-outside-snapshot',
     '^filesystem\..*: hidden-file-or-dir /root/.gnupg',
     '^filesystem\..*: hidden-file-or-dir /root/.gnupg',
     '^filesystem\..*: hidden-file-or-dir /etc/skel/.config',

--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -39,3 +39,7 @@ executable-stack = 10000
 binary-or-shlib-defines-rpath = 10000
 patchable-function-entry-in-archive = 10000
 patch-macro-old-format = 10000
+
+# Set to 10000 once affected packages have been updated
+# for atomic update compatibility
+dir-or-file-outside-snapshot = 100

--- a/rpmlint/checks/AtomicUpdateCheck.py
+++ b/rpmlint/checks/AtomicUpdateCheck.py
@@ -1,0 +1,44 @@
+from rpmlint.checks.AbstractCheck import AbstractCheck
+
+
+class AtomicUpdateCheck(AbstractCheck):
+
+    """
+    Requirements for atomic updates:
+        * All files must be stored inside the snapshot, which is in our case /etc and /usr, not /var,
+          /opt, /srv, /usr/local or anything else.
+        * (Re)starting daemons is not possible.
+        * Modifying files outside of /usr and /etc is not possible.
+        * Modifications outside the snapshot have to be done via systemd-tmpfiles and systemd services.
+    This check currently only implements checking for files at illegal paths.
+    """
+
+    def __init__(self, config, output):
+        super().__init__(config, output)
+        self.check_ghosts = self.config.configuration['AtomicCheckGhosts']
+        self.allowed_dirs = self.config.configuration['AtomicAllowedDirs']
+        self.disallowed_subdirs = self.config.configuration['AtomicDisallowedSubdirs']
+
+    def check(self, pkg):
+        if pkg.is_source:
+            return
+
+        # Check for files stored outside the snapshot
+        self._check_paths(pkg, self.check_ghosts)
+
+    def _check_paths(self, pkg, check_ghosts=False):
+        for file in pkg.files.keys():
+            if file in pkg.ghost_files:
+                continue  # Ghosts are only handled if explicitly desired
+            if not (self._check_single_path(file)):
+                self.output.add_info('E', pkg, 'dir-or-file-outside-snapshot', file)
+        if check_ghosts:
+            for ghost in pkg.ghost_files:
+                if not (self._check_single_path(ghost)):
+                    self.output.add_info('W', pkg, 'ghost-outside-snapshot', ghost)
+
+    def _check_single_path(self, file):
+        return (
+            file.startswith(tuple(self.allowed_dirs)) and
+            not file.startswith(tuple(self.disallowed_subdirs))
+        )

--- a/rpmlint/descriptions/AtomicUpdateCheck.toml
+++ b/rpmlint/descriptions/AtomicUpdateCheck.toml
@@ -1,0 +1,9 @@
+dir-or-file-outside-snapshot="""
+The package contains files outside the snapshot, e.g. outside /etc and /usr
+or inside /usr/local.
+"""
+ghost-outside-snapshot="""
+The package contains ghosts outside the snapshot, e.g. outside /etc and /usr
+or inside /usr/local. This might become an issue upon removal of this
+package, but not during installation.
+"""


### PR DESCRIPTION
This checks for packages installing into locations which are illegal for compatibility with atomic updates. E.g. a package which installs into /var/ would get corrupted after a rollback from a newer snapshot.