### PR TITLE
polkit-rules-whitelist: extend whitelisting to systemd-mini flavour

### DIFF
--- a/configs/openSUSE/polkit-rules-whitelist.toml
+++ b/configs/openSUSE/polkit-rules-whitelist.toml
@@ -229,7 +229,7 @@ digester = "default"
 hash     = "38aaac33cd24fca2db1bdf35389b0d52bc17741ae55f0de4ea35d16d5817cd24"
 
 [[FileDigestGroup]]
-package  = "systemd"
+packages  = ["systemd", "systemd-mini"]
 note     = "This is just an example file that will not be active by default"
 bug      = "bsc#1250844"
 type     = "polkit"


### PR DESCRIPTION
The whitelisting from commit 026e2a3ef915845b033985a1c019f008c4f179f5 is missing the `systemd-mini` flavour of the package, which can be seen here:

https://build.opensuse.org/package/live_build_log/Base:System/systemd:mini/openSUSE_Factory/x86_64

No other systemd-related whitelistings should be affected by this.