### PR TITLE
[opensuse] pam-modules whitelist: fix account-utils glob pattern

### DIFF
--- a/configs/openSUSE/pam-modules.toml
+++ b/configs/openSUSE/pam-modules.toml
@@ -574,6 +574,6 @@ note     = "pam_unix replacement for use in environments with `no_new_privs` eve
 bug      = "bsc#1254218"
 type     = "pam"
 nodigests = [
-    "global:*/security/pam_debuginfo.so",
-    "global:*/security/pam_unix_ng.so"
+    "glob:*/security/pam_debuginfo.so",
+    "glob:*/security/pam_unix_ng.so"
 ]


### PR DESCRIPTION
we missed a typo here