### PR TITLE
[opensuse] DBusPolicyCheck: Catch unsafe wildcard allow lists in policies (bsc#1…

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -266,6 +266,7 @@ BlockedFilters = [
     "dbus-file-ghost",
     "dbus-file-unauthorized",
     "dbus-file-symlink",
+    "dbus-policy-allow-wildcard",
     "device-mismatched-attrs",
     "device-unauthorized-file",
     "non-position-independent-executable",

--- a/configs/openSUSE/scoring-strict.override.toml
+++ b/configs/openSUSE/scoring-strict.override.toml
@@ -8,6 +8,7 @@ dbus-file-ghost = 10000
 dbus-file-parse-error = 10000
 dbus-file-unauthorized = 10000
 dbus-file-symlink = 10000
+dbus-policy-allow-wildcard = 10000
 device-mismatched-attrs = 10000
 device-unauthorized-file = 10000
 invalid-license = 100000

--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -82,6 +82,7 @@ dbus-file-ghost = 10
 dbus-file-parse-error = 10
 dbus-file-unauthorized = 10
 dbus-file-symlink = 10
+dbus-policy-allow-wildcard = 10
 sudoers-file-digest-mismatch = 10
 sudoers-file-ghost = 10
 sudoers-file-unauthorized = 10

--- a/rpmlint/descriptions/DBusPolicyCheck.toml
+++ b/rpmlint/descriptions/DBusPolicyCheck.toml
@@ -13,3 +13,8 @@ will not work with a dbus that uses deny as default policy"""
 dbus-parsing-exception="""
 A python exception was raised which prevents further analysis
 of the DBus rule file."""
+dbus-policy-allow-wildcard="""
+'allow' directives with wildcard send_<category>="*" attributes are not
+allowed, since they affect the complete system bus, not only a specific
+service. Use a more specific setting like
+send_destination="org.freedesktop.Accounts"."""

--- a/test/files/systemd/org.freedesktop.NetworkManager.conf
+++ b/test/files/systemd/org.freedesktop.NetworkManager.conf
@@ -120,6 +120,7 @@
                        send_interface="org.freedesktop.NetworkManager.Settings"/>
                 <allow send_destination="org.freedesktop.NetworkManager"
                        send_interface="org.freedesktop.NetworkManager.Settings.Connection"/>
+                <allow send_destination="*"/>
 
                 <!-- Agents; secured with PolicyKit.  Any process can talk to
                      the AgentManager API, but only NetworkManager can talk

--- a/test/test_dbus_policy.py
+++ b/test/test_dbus_policy.py
@@ -24,3 +24,4 @@ def test_dbus_policy(package, dbuspolicycheck):
     assert 'W: dbus-policy-allow-receive <allow receive_sender="foo"/>' in out
     assert 'E: dbus-policy-deny-without-destination <deny send_interface="org.freedesktop.NetworkManager.Settings" send_member="ReloadConnections"/>' in out
     assert 'E: dbus-policy-missing-allow /etc/dbus-1/system.d/org.freedesktop.NetworkManager2.conf' in out
+    assert 'E: dbus-policy-allow-wildcard <allow send_destination="*"/> /etc/dbus-1/system.d/org.freedesktop.NetworkManager.conf' in out


### PR DESCRIPTION
…215247)

We had a situation in kauth a while ago ([bsc#1220215](https://bugzilla.suse.com/show_bug.cgi?id=1220215)) where upstream wrongly added a <allow send_destination="*"/> setting to their generated policies. This has a global effect on all D-Bus services (somewhat randomly: to all D-Bus services whose policies are parsed after the problematic policy was encountered).

To catch such situations in the future extend the DBusPolicyCheck accordingly.

We can raise badness for this check right away, I checked all of openSUSE:Factory and there are currently to packages affected by this.