### PR TITLE
systemd-tmpfiles: add aaa_base /var/adm dirs (bsc#1255794)

### DIFF
--- a/configs/openSUSE/systemd-tmpfiles.toml
+++ b/configs/openSUSE/systemd-tmpfiles.toml
@@ -125,3 +125,13 @@ path = "/usr/lib/tmpfiles.d/samba.conf"
 entries = [
     "d /var/samba/spool 1777 root root"
 ]
+
+[[SystemdTmpfilesWhitelist]]
+package = "aaa_base-extras"
+bugs = ["bsc#1255794"]
+note = "Regular directories in /var/adm/backup"
+path = "/usr/lib/tmpfiles.d/adm-backup.conf"
+entries = [
+    "d /var/adm/backup/rpmdb 0755 root root -",
+    "d /var/adm/backup/sysconfig 0755 root root -"
+]


### PR DESCRIPTION
These only need whitelistings because of the unusual path location. The entries are not otherwise security relevant.