### PR TITLE
configs/openSUSE: whitelist Foomuuri D-Bus and sysctl files (bsc#1254385)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1483,3 +1483,23 @@ hash     = "91b532cb7675218944e9f77705c7bcaaec73ea11fa6e770e0a39dfaab350832b"
 path     = "/usr/share/dbus-1/system.d/org.kde.smb4k.mounthelper.conf"
 digester = "xml"
 hash     = "c67705447819baeede72d3f1efd4f1df22f86b5916af1cdf64e542630821539e"
+
+[[FileDigestGroup]]
+package  = "foomuuri"
+note     = "Firewall management via D-Bus"
+bug      = "bsc#1254385"
+type     = "dbus"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/dbus-1/system.d/fi.foobar.Foomuuri1.conf"
+digester = "xml"
+hash     = "f94635f00f0cc1c8622a9a36677e91736fe37221d7a9ab05484ac238e16790aa"
+
+[[FileDigestGroup]]
+package  = "foomuuri-firewalld"
+note     = "Firewall management via D-Bus (firewalld drop-in)"
+bug      = "bsc#1254385"
+type     = "dbus"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/dbus-1/system.d/fi.foobar.Foomuuri-FirewallD.conf"
+digester = "xml"
+hash     = "a4d61b04ab65225d2e11f60a3fcaf2705ae9ce9dcea9c5d814d7be6724403250"

--- a/configs/openSUSE/sysctl-whitelist.toml
+++ b/configs/openSUSE/sysctl-whitelist.toml
@@ -195,3 +195,13 @@ type     = "sysctl"
 path     = "/usr/lib/sysctl.d/health-checker.conf"
 digester = "shell"
 hash     = "40838811f1f8ec4f4b19ce8f049f63ab616f92a1d0a8190e29d0bbf6fe43e66a"
+
+[[FileDigestGroup]]
+package  = "foomuuri"
+note     = "networking stack and firewall related settings"
+bug      = "bsc#1254385"
+type     = "sysctl"
+[[FileDigestGroup.digests]]
+path     = "/usr/lib/sysctl.d/50-foomuuri.conf"
+digester = "shell"
+hash     = "c5077daeb66bbb4b6f2f160c799950547adf52c9454545080eefef244424e669"


### PR DESCRIPTION
The package for this is found in OBS in home:UbiquitousPhoton/Foomuuri at the moment.