### PR TITLE
dbus-services: whitelist snapd (bsc#1256175)

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1503,3 +1503,13 @@ type     = "dbus"
 path     = "/usr/share/dbus-1/system.d/fi.foobar.Foomuuri-FirewallD.conf"
 digester = "xml"
 hash     = "a4d61b04ab65225d2e11f60a3fcaf2705ae9ce9dcea9c5d814d7be6724403250"
+
+[[FileDigestGroup]]
+package  = "snapd"
+note     = "Allow snap packages to install D-Bus services"
+bug      = "bsc#1256175"
+type     = "dbus"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/dbus-1/system.d/snapd.system-services.conf"
+digester = "xml"
+hash     = "ae58e6ec3228e41fe65b2ffdb27908610b11ba501a18f7bf1dff07e639053f46"


### PR DESCRIPTION
Please consider this when reviewing the whitelisting: This change allows snap packages to install D-Bus services on the host system bus. That means we will not have monitoring for these services. 

For example, the `fwupd` snap installs `/var/lib/snapd/dbus-1/system-services/org.freedesktop.fwupd.service`, that looks like this:

```
[D-BUS Service]
Name=org.freedesktop.fwupd
Comment=Bus name for snap application fwupd.fwupd
SystemdService=snap.fwupd.fwupd.service
Exec=/usr/bin/snap run fwupd
AssumedAppArmorLabel=snap.fwupd.fwupd
User=root
X-Snap=fwupd
```

Seems harmless enough, but we can't feasibly monitor all snap packages. Under normal circumstances I would decline such a request, but as we discussed already, snapd is somewhat special due to its high quality. Allowing snap at all, regardless of this feature, implies granting elevated privileges to some of its packages. IMHO, it would be inconsequential to accept snap but not this change. I vote for acceptance.