### PR TITLE
[opensuse] systemd-tmpfiles: whitelist dracut /boot/dracut cleanup entry (bsc#12…

### DIFF
--- a/configs/openSUSE/systemd-tmpfiles.toml
+++ b/configs/openSUSE/systemd-tmpfiles.toml
@@ -135,3 +135,12 @@ entries = [
     "d /var/adm/backup/rpmdb 0755 root root -",
     "d /var/adm/backup/sysconfig 0755 root root -"
 ]
+
+[[SystemdTmpfilesWhitelist]]
+package = "dracut-tools"
+bugs = ["bsc#1256380"]
+note = "Regular directory in /boot/dracut"
+path = "/usr/lib/tmpfiles.d/dracut.conf"
+entries = [
+    "D  /boot/dracut  - - - -"
+]


### PR DESCRIPTION
…56380)

The rpmlint diagnostic is currently found in dracut's devel project in Base:System/dracut