### PR TITLE
[opensuse] systemd-tmpfiles: whitelist sendmail spool directory (bsc#1256160)

### DIFF
--- a/configs/openSUSE/systemd-tmpfiles.toml
+++ b/configs/openSUSE/systemd-tmpfiles.toml
@@ -144,3 +144,12 @@ path = "/usr/lib/tmpfiles.d/dracut.conf"
 entries = [
     "D  /boot/dracut  - - - -"
 ]
+
+[[SystemdTmpfilesWhitelist]]
+package = "sendmail"
+bugs = ["bsc#1256160"]
+note = "Spool directory with mode 1777"
+path = "/usr/lib/tmpfiles.d/sendmail.conf"
+entries = [
+    "d /var/spool/mail                      1777 root root -"
+]


### PR DESCRIPTION
The new systemd-tmpfiles configuration is found in the OBS devel package in `server:mail/sendmail`.