### PR TITLE
SystemdTmpfilesCheck: fix argument handling

### DIFF
--- a/test/test_systemd_tmpfiles.py
+++ b/test/test_systemd_tmpfiles.py
@@ -91,6 +91,9 @@ def test_parser(tmpfilescheck):
         'c /some/path 0755 someone root - -',
         'h /some/path - - - - +C',
         'h /some/path - - - - +a',
+        "f '/quoted/field with spaces' 0777 root root - -",
+        'f "/quoted/field with spaces" 0777 root root - -',
+        'f /some/path 0777 root root -   trailing spaces  ',
     )
 
     with FakePkg('testpkg') as pkg:


### PR DESCRIPTION
TmpfilesParser did not handle arguments with spaces correctly. As per the documentation, the last (7th) field is to be treated as one contiguous string.

man tmpfiles.d(5):

> Note that any whitespace found in the line after the beginning of the
argument field will be considered part of the argument field.

Example given in the man page:
```
      Example 2. Create a directory with a SMACK attribute

           D /run/cups - - - -
           t /run/cups - - - - security.SMACK64=printing user.attr-with-spaces="foo bar"
```