### PR TITLE
[opensuse] InputPlumber D-Bus and Polkit whitelistings

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -1749,3 +1749,13 @@ hash     = "865182ed82bfea6ad3bf118b7fb9d2c2fcfc0ddb0568d238c0b15b355348eeb5"
 path     = "/usr/share/dbus-1/system.d/org.freedesktop.UPower.PowerProfiles.conf"
 digester = "xml"
 hash     = "a1b1dda54405102f4a297c836a32a0843dcca50e09b0ac995fa61f0e24977f15"
+
+[[FileDigestGroup]]
+package  = "inputplumber"
+note     = "Allows control over virtual input devices"
+bug      = "bsc#1249149"
+type     = "dbus"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf"
+digester = "xml"
+hash     = "37b05cfeb384fe7f696d7a090153eb464dbc02917f721c01241d655f43a433bb"

--- a/configs/openSUSE/polkit-rules-whitelist.toml
+++ b/configs/openSUSE/polkit-rules-whitelist.toml
@@ -247,3 +247,13 @@ type     = "polkit"
 path     = "/usr/share/polkit-1/rules.d/empower.rules"
 digester = "default"
 hash     = "d9a62ab1ec477a4be1657769dfd194c75d1a07a4357e7717aa19ad5c07c3fc26"
+
+[[FileDigestGroup]]
+package  = "inputplumber"
+note     = "allows members of the inputplumber group to perform any InputPlumber actions"
+bug      = "bsc#1249149"
+type     = "polkit"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/polkit-1/rules.d/org.shadowblip.InputPlumber.rules"
+digester = "default"
+hash     = "75efae6dcf5fecc3a73f851a09d871f768b055ad3049a40550cd81bbbd9f8640"


### PR DESCRIPTION
The Polkit whitelisting digest is based on a patched version of the file, I calculated the digest manually. See [Bugzilla comment](https://bugzilla.suse.com/show_bug.cgi?id=1249149#c35).

The devel package is found in OBS in `hardware/inputplumber`.