### PR TITLE
scoring: Raise forbidden-controlchar-found to 10k

### DIFF
--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -41,6 +41,7 @@ filelist-forbidden-suseconfig = 10000
 filelist-forbidden-sysconfig = 10000
 filelist-forbidden-xorg = 10000
 filelist-forbidden-yast2 = 10000
+forbidden-controlchar-found = 10000
 kmp-missing-supplements = 10000
 wrong-script-interpreter = 490
 obsolete-insserv-requirement = 10000


### PR DESCRIPTION
Having non ascii characters in package tags can cause problems in tools that handle repositories like createrepo_c. So it's better to have it as a fatal error.

Fix https://github.com/rpm-software-management/rpmlint/issues/1438