### PR TITLE
Pin actions to specific version SHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
       - run: pipx install coveralls
       - run: pipx install pyupgrade
       - run: pipx install ruff
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - run: pytest
       - run: flake8
       - run: /github/home/.local/bin/ruff check .


### PR DESCRIPTION
This just replaces `v3` with the hash of `v3.6.0`, the last version in the `v3.x` line. This format (hash + version comment) is respected by Dependabot once established.

The actual version bump from `v3` to current is left to Dependabot as per #1441 

I have not touched the CodeQL CI configuration file for now, as I believe that is handled via Github web interface.