### PR TITLE
Fix TagsCheck for multiple InvalidRequires

### DIFF
--- a/rpmlint/checks/TagsCheck.py
+++ b/rpmlint/checks/TagsCheck.py
@@ -36,7 +36,7 @@ class TagsCheck(AbstractCheck):
         super().__init__(config, output)
         self.valid_groups = config.configuration['ValidGroups']
         self.valid_licenses = config.configuration['ValidLicenses']
-        self.invalid_requires = map(re.compile, config.configuration['InvalidRequires'])
+        self.invalid_requires = list(map(re.compile, config.configuration['InvalidRequires']))
         self.packager_regex = re.compile(config.configuration['Packager'])
         self.release_ext = config.configuration['ReleaseExtension']
         self.extension_regex = self.release_ext and re.compile(self.release_ext)

--- a/test/test_tags.py
+++ b/test/test_tags.py
@@ -297,6 +297,19 @@ def test_check_invalid_dependency(tmp_path, package, tagscheck):
     assert 'E: no-description-tag' in out
 
 
+@pytest.mark.parametrize('package', ['binary/python39-evtx'])
+def test_check_invalid_dependency_multiple(tmp_path, package, tagscheck):
+    """Test if a package has
+    invalid-dependency, when the invalid dependency is not first in the list"""
+    CONFIG.info = True
+    CONFIG.configuration['InvalidRequires'].append('/bin/sh')
+    output = Filter(CONFIG)
+    test = TagsCheck(CONFIG, output)
+    test.check(get_tested_package(package, tmp_path))
+    out = output.print_results(output.results)
+    assert 'E: invalid-dependency /bin/sh' in out
+
+
 @pytest.mark.parametrize('package', ['binary/random-exp'])
 def test_package_random_warnings(tmp_path, package, tagscheck):
     """Test if a package has check,


### PR DESCRIPTION
Fixes #1443, this also adds a unit test to cover the case using an existing RPM from the test folder with multiple requirements. 