### PR TITLE
GDM 50 beta D-Bus & Polkit Whitelistings

### DIFF
--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -71,17 +71,6 @@ hash = "00d25f898cf4c78cf45d68000ee00be27b0aa15b7ebe22c4ba86bc1b5f33b898"
 package  = "gdm"
 type     = "dbus"
 note     = "D-Bus interface for managing GDM sessions"
-bugs     = ["bsc#1204052", "bsc#1218922", "bsc#1230466"]
-[[FileDigestGroup.digests]]
-path     = "/usr/share/dbus-1/system.d/gdm.conf"
-digester = "xml"
-hash     = "6c74cd8824a587ccd281886c655718dfecd1da530bb823e6625be4a22c5a09e6"
-
-# TEMPORARY ENTRY. Remove as soon as possible (bsc#1230466).
-[[FileDigestGroup]]
-package  = "gdm"
-type     = "dbus"
-note     = "D-Bus interface for managing GDM sessions"
 bugs     = ["bsc#1204052", "bsc#1218922", "bsc#1230466", "bsc#1248881"]
 [[FileDigestGroup.digests]]
 path     = "/usr/share/dbus-1/system.d/gdm.conf"

--- a/configs/openSUSE/dbus-services.toml
+++ b/configs/openSUSE/dbus-services.toml
@@ -77,6 +77,17 @@ path     = "/usr/share/dbus-1/system.d/gdm.conf"
 digester = "xml"
 hash     = "cf4cb93af82aacc9b4a0fc600c602af5089e001df10282a35287b6f27199f7ea"
 
+# TODO: merge with entry above once GDM 50 enters Factory
+[[FileDigestGroup]]
+package  = "gdm"
+note     = "D-Bus interface for managing GDM sessions"
+bug      = "bsc#1258025"
+type     = "dbus"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/dbus-1/system.d/gdm.conf"
+digester = "xml"
+hash     = "a46c9af0b5702e1d4cfa643b8f74ca878c3aa9cdd2d6e42d53ba160d64fc8e20"
+
 [[FileDigestGroup]]
 package = "udisks2"
 type = "dbus"

--- a/configs/openSUSE/polkit-rules-whitelist.toml
+++ b/configs/openSUSE/polkit-rules-whitelist.toml
@@ -228,6 +228,17 @@ path     = "/usr/share/polkit-1/rules.d/20-gdm.rules"
 digester = "default"
 hash     = "38aaac33cd24fca2db1bdf35389b0d52bc17741ae55f0de4ea35d16d5817cd24"
 
+# TODO: merge with entry above once GDM 50 enters Factory
+[[FileDigestGroup]]
+package  = "gdm"
+note     = "allows the display manager to add WiFi connections via NetworkManager, as well as creation of headless VNC displays"
+bug      = "bsc#1258025"
+type     = "polkit"
+[[FileDigestGroup.digests]]
+path     = "/usr/share/polkit-1/rules.d/20-gdm.rules"
+digester = "default"
+hash     = "134e91ed394511cda9e7aec31d95922cb4cd268314688ecd06fe4c11b1e9ae62"
+
 [[FileDigestGroup]]
 packages  = ["systemd", "systemd-mini"]
 note     = "This is just an example file that will not be active by default"


### PR DESCRIPTION
These versions of the files can be found in OBS in GNOME:Next/gdm. I removed one no longer needed compatibility entry for GDM but needed to add new compatibility entries, since GDM 50 will only reach Factory in a couple of weeks.