### PR TITLE
[opensuse] systemd-tmpfiles: whitelist postfix spool directory (bsc#1258381)

### DIFF
--- a/configs/openSUSE/systemd-tmpfiles.toml
+++ b/configs/openSUSE/systemd-tmpfiles.toml
@@ -197,3 +197,12 @@ path = "/usr/lib/tmpfiles.d/ulp-tmp.conf"
 entries = [
     "d /var/livepatches 0755 root root"
 ]
+
+[[SystemdTmpfilesWhitelist]]
+packages = ["postfix", "postfix-bdb"]
+bugs = ["bsc#1258381"]
+note = "manages the spool directory for postfix"
+path = "/usr/lib/tmpfiles.d/postfix.conf"
+entries = [
+    "d /var/spool/mail 1777 root root - -"
+]


### PR DESCRIPTION
The current OBS build producing the diagnostics is found in `server:mail/postfix`.