### PR TITLE
[opensuse] BinariesCheck: fix logic for missing-call-to-setgroups-before-setuid

### DIFF
--- a/rpmlint/checks/BinariesCheck.py
+++ b/rpmlint/checks/BinariesCheck.py
@@ -436,7 +436,7 @@ class BinariesCheck(AbstractCheck):
 
         if setgid and setuid and not setgroups:
             is_uid = stat.S_ISUID & pkgfile.mode
-            self.output.add_info('W' if is_uid else 'E', pkg, 'missing-call-to-setgroups-before-setuid', pkgfile.name)
+            self.output.add_info('E' if is_uid else 'W', pkg, 'missing-call-to-setgroups-before-setuid', pkgfile.name)
 
         if mktemp:
             self.output.add_info('E', pkg, 'call-to-mktemp', pkgfile.name)

--- a/test/test_binaries.py
+++ b/test/test_binaries.py
@@ -293,7 +293,7 @@ def test_invalid_ldconfig_symlink(tmp_path, package, binariescheck):
     assert 'E: invalid-ldconfig-symlink' in out
     # executable doesn't call mktemp, setuid or gethostbyname
     assert 'E: call-to-mktemp' not in out
-    assert 'E: missing-call-to-setgroups-before-setuid' not in out
+    assert 'W: missing-call-to-setgroups-before-setuid' not in out
     assert 'W: binary-or-shlib-calls-gethostbyname' not in out
     # it's not statically linked either
     assert 'E: statically-linked-binary' not in out
@@ -316,7 +316,7 @@ def test_multiple_errors(tmp_path, package, binariescheck):
     test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
     assert 'E: call-to-mktemp' in out
-    assert 'E: missing-call-to-setgroups-before-setuid' in out
+    assert 'W: missing-call-to-setgroups-before-setuid' in out
     assert 'W: binary-or-shlib-calls-gethostbyname' in out
 
 

--- a/test/test_readelf_parser.py
+++ b/test/test_readelf_parser.py
@@ -257,7 +257,7 @@ def test_call_setgroups(binariescheck):
         pkg.files[pkgfile.name] = pkgfile
         run_elf_checks(test, pkg, pkgfile)
         out = output.print_results(output.results)
-        assert 'E: missing-call-to-setgroups-before-setuid /bin/call-setgroups' in out
+        assert 'W: missing-call-to-setgroups-before-setuid /bin/call-setgroups' in out
 
 
 @pytest.mark.skipif(not IS_X86_64, reason='x86-64 only')


### PR DESCRIPTION
In commit a6cf2c918 logic was introduced to selectively only report a warning for this diagnostic. The way it is currently done does not make any sense, however, the severity of this diagnostic is higher if the binary is installed setuid. Thus switch the order around.