### PR TITLE
sendmail whitelisting cleanups

### DIFF
--- a/configs/openSUSE/permissions-whitelist.toml
+++ b/configs/openSUSE/permissions-whitelist.toml
@@ -36,17 +36,17 @@ hash = "54d194477fc688076940c93bfd201680b5cc0fd6079bba10bd0101fb986a2231"
 
 [[FileDigestGroup]]
 package = "sendmail"
-bugs = ["bsc#1219339"]
+bugs = ["bsc#1219339", "bsc#1256160"]
 type = "permissions"
 note = """Be careful about calculating digest sums here, the sendmail package
       replaces file contents during RPM build time with architecture dependent
       values."""
 [[FileDigestGroup.digests]]
 path = "/usr/share/permissions/permissions.d/sendmail"
-hash = "e09ca5efebd0b3c123afc2364f9745f4d85c4327fa83f709bccbaa64da764486"
+hash = "544b91b15ce1dd54659a2d98a66ce945db2ca99134acb97f8a0a196612c57bb6"
 [[FileDigestGroup.digests]]
 path = "/usr/share/permissions/permissions.d/sendmail.paranoid"
-hash = "2d5c56cdfb00ec169c182de791cf2934331159842f1849c5f2d7059f0086bd2c"
+hash = "7a593f6678ab48c4eab010bb885989bd06e5a73a307575399d71a2d7c3d3f0c3"
 
 [[FileDigestGroup]]
 package = "texlive-filesystem"

--- a/configs/openSUSE/world-writable-whitelist.toml
+++ b/configs/openSUSE/world-writable-whitelist.toml
@@ -49,16 +49,6 @@ owner = "root"
 group = "root"
 
 [[WorldWritableWhitelist]]
-package = "sendmail"
-bug = "bsc#1179574"
-note = "Public standard sticky-bit directories"
-[[WorldWritableWhitelist.files]]
-path = '/var/spool/mail'
-mode = "drwxrwxrwt"
-owner = "root"
-group = "root"
-
-[[WorldWritableWhitelist]]
 package = "exim"
 bug = "bsc#1179574"
 note = "Public standard sticky-bit directories"


### PR DESCRIPTION
The sendmail maintainer is uncooperative about cleaning up the permissions.d drop-in configuration files. Thus we simply anticipate the digests for the files we would like to see in the future, thereby forcing him to act and at the same time providing him a way to unblock himself.

The digests habe been calculated based on the following diffs:

```
--- /usr/share/permissions/permissions.d/sendmail       2026-02-11 10:31:31.000000000 +0100
+++ sendmail    2026-03-02 13:55:39.847103915 +0100
@@ -3,8 +3,6 @@
 /etc/mail/auth/                                root:root       0750
 /etc/mail/certs/                       root:root       0750
 /etc/mail/system/                      root:root       0755
-/var/spool/clientmqueue/               mail:mail       0770
-/var/spool/mqueue/                     root:root       0700
 /usr/libexec/sendmail.d/bin/           root:root       0755
 /usr/libexec/sendmail.d/bin/smrsh              root:root       0511
 /usr/libexec/sendmail.d/bin/mail.local root:root       0511
```

```
--- /usr/share/permissions/permissions.d/sendmail.paranoid      2026-02-11 10:31:31.000000000 +0100
+++ sendmail.paranoid   2026-03-02 13:55:41.227116174 +0100
@@ -3,8 +3,6 @@
 /etc/mail/auth/                                root:root       0750
 /etc/mail/certs/                       root:root       0750
 /etc/mail/system/                      root:root       0755
-/var/spool/clientmqueue/               mail:mail       0750
-/var/spool/mqueue/                     root:root       0700
 /usr/libexec/sendmail.d/bin/           root:root       0755
 /usr/libexec/sendmail.d/bin/smrsh              root:root       0511
 /usr/libexec/sendmail.d/bin/mail.local root:root       0511
```

Note that the files present in the `sendmail-suse` tarball in the package are different from the files installed in the RPM, because directory paths are replaced during build time. This diff is from a running current Tumbleweed installation.