### PR TITLE
test: Add PKG-INFO to egg-info mocks for Python 3.15 compatibility

### DIFF
--- a/test/mockdata/mock_python.py
+++ b/test/mockdata/mock_python.py
@@ -191,6 +191,13 @@ PythonFlitFedoraMockPackage = get_tested_mock_package(
 PythonIcecreamPackage = get_tested_mock_package(
     lazyload=True,
     files={
+        '/usr/lib/python3.10/site-packages/icecream-2.1.3-py3.10.egg-info/PKG-INFO': {
+            'content': """Metadata-Version: 2.1
+Name: icecream
+Version: 2.1.3
+""",
+            'create_dirs': True
+        },
         '/usr/lib/python3.10/site-packages/icecream-2.1.3-py3.10.egg-info/requires.txt': {
             'content': """
 asttokens>=2.0.1
@@ -198,7 +205,6 @@ colorama>=0.3.9
 executing>=0.3.1
 pygments>=2.2.0
 """,
-            'create_dirs': True
         },
     },
     header={
@@ -278,6 +284,12 @@ PythonSinglePYCMockPackage = get_tested_mock_package(
 IPythonMissingRequirePackage = get_tested_mock_package(
     lazyload=True,
     files={
+        '/usr/lib/python3.12/site-packages/ipython-8.14.0-py3.12.egg-info/PKG-INFO': {
+            'content': """Metadata-Version: 2.1
+Name: ipython
+Version: 8.14.0
+""",
+        },
         '/usr/lib/python3.12/site-packages/ipython-8.14.0-py3.12.egg-info/requires.txt': {
             'content-path': 'files/ipython-requires.txt',
         },


### PR DESCRIPTION
Python 3.15's importlib.metadata now strictly requires PKG-INFO files in egg-info directories when accessing the requires property. Without it, self.metadata is None and triggers AttributeError when reading d.requires. Although reported as a regression, upstream chose to enforce this requirement rather than handle missing metadata gracefully.

https://github.com/python/cpython/issues/143387

In near future, it will raise MetadataNotFound(FileNotFoundError).

https://github.com/python/cpython/pull/146234