### PR TITLE
AlternativesCheck: Fix .conf files regex

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
         container:
           - 'registry.fedoraproject.org/fedora:latest'
           - 'registry.fedoraproject.org/fedora:rawhide'
-          - 'registry.opensuse.org/opensuse/tumbleweed:latest'
+          - 'registry.opensuse.org/opensuse/leap:16.0'
         include:
           - container: 'registry.fedoraproject.org/fedora:latest'
             build-type: 'no-optional-deps'
-          - container: 'registry.opensuse.org/opensuse/tumbleweed:latest'
+          - container: 'registry.opensuse.org/opensuse/leap:16.0'
             build-type: 'no-optional-deps'
       fail-fast: false
 
@@ -41,10 +41,6 @@ jobs:
               python3-pytest-cov
               python3-pytest-xdist
               python3-flake8
-              python3-flake8-builtins
-              python3-flake8-bugbear
-              python3-flake8-import-order
-              python3-flake8-quotes
               python3-pyxdg
               python3-zstandard
               python3-tomli
@@ -63,8 +59,6 @@ jobs:
               myspell-fr_FR
               python3-pyenchant
         if: ${{ contains(matrix.container, 'opensuse') && matrix.build-type == 'normal' }}
-      - run: zypper -n install python3-flake8-comprehensions
-        if: ${{ contains(matrix.container, 'opensuse') }}
       - run: dnf --nogpgcheck --assumeyes install
               /usr/bin/cpio
               /usr/bin/bzip2

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,10 +12,11 @@ jobs:
     targets:
     - fedora-rawhide-x86_64
     - fedora-rawhide-aarch64
-    - mageia-cauldron-x86_64
-    - mageia-cauldron-aarch64
-    - opensuse-tumbleweed-x86_64
-    - opensuse-tumbleweed-aarch64
+    # mageia is failing because of rpm
+    # - mageia-cauldron-x86_64
+    # - mageia-cauldron-aarch64
+    - opensuse-leap-16.0-x86_64
+    - opensuse-leap-16.0-aarch64
   trigger: pull_request
 - job: copr_build
   trigger: commit
@@ -23,10 +24,11 @@ jobs:
     targets:
     - fedora-rawhide-x86_64
     - fedora-rawhide-aarch64
-    - mageia-cauldron-x86_64
-    - mageia-cauldron-aarch64
-    - opensuse-tumbleweed-x86_64
-    - opensuse-tumbleweed-aarch64
+    # mageia is failing because of rpm
+    # - mageia-cauldron-x86_64
+    # - mageia-cauldron-aarch64
+    - opensuse-leap-16.0-x86_64
+    - opensuse-leap-16.0-aarch64
     branch: main
     project: rpm-software-management-rpmlint-mainline
     list_on_homepage: True
@@ -35,8 +37,8 @@ jobs:
   trigger: commit
   metadata:
     targets:
-    - opensuse-tumbleweed-x86_64
-    - opensuse-tumbleweed-aarch64
+    - opensuse-leap-16.0-x86_64
+    - opensuse-leap-16.0-aarch64
     branch: opensuse
     project: rpm-software-management-rpmlint-opensuse
     list_on_homepage: True

--- a/rpmlint/checks/AlternativesCheck.py
+++ b/rpmlint/checks/AlternativesCheck.py
@@ -220,52 +220,56 @@ class AlternativesCheck(AbstractCheck):
         Checking content of all /usr/share/libalternatives/*/*.conf files
         """
         for f, pkgfile in pkg.files.items():
-            if re.search('^/usr/share/libalternatives/.*conf$', f):
-                filename = Path(pkg.dirname + f)
-                if not filename.exists():
-                    if pkgfile.is_ghost:
-                        self.output.add_info('I', pkg, 'libalternatives-conf-not-found', f)
-                    else:
-                        self.output.add_info('E', pkg, 'libalternatives-conf-not-found', f)
-                    continue
-                bin_found = False
-                man_found = False
-                with open(filename) as read_obj:
-                    # Read all lines in the file one by one. E.g:
-                    #
-                    # binary=/usr/bin/jupyter-3.8
-                    # man=jupyter-3.8.1
-                    # group=jupyter, jupyter-migrate, jupyter-troubleshoot
-                    #
-                    for line_nr, line in enumerate(read_obj):
-                        line_array = [x.strip() for x in line.split('=')]
-                        line_nr_str = f'Line: {line_nr}'
-                        if len(line_array) != 2:   # empty values are valid
-                            self.output.add_info('E', pkg, 'wrong-entry-format', f, line_nr_str)
+            if not re.search(r'^/usr/share/libalternatives/[^/]+/.*\.conf$', f):
+                continue
 
-                        key, value = line_array
-                        if key == 'binary':
-                            if bin_found:
-                                self.output.add_info('E', pkg, 'multiple-entries', f, line_nr_str)
-                                continue
+            filename = Path(pkg.dirname + f)
+            if not filename.exists():
+                if pkgfile.is_ghost:
+                    self.output.add_info('I', pkg, 'libalternatives-conf-not-found', f)
+                else:
+                    self.output.add_info('E', pkg, 'libalternatives-conf-not-found', f)
+                continue
+
+            bin_found = False
+            man_found = False
+            with open(filename) as read_obj:
+                # Read all lines in the file one by one. E.g:
+                #
+                # binary=/usr/bin/jupyter-3.8
+                # man=jupyter-3.8.1
+                # group=jupyter, jupyter-migrate, jupyter-troubleshoot
+                #
+                for line_nr, line in enumerate(read_obj):
+                    line_array = [x.strip() for x in line.split('=')]
+                    line_nr_str = f'Line: {line_nr}'
+                    if len(line_array) != 2:   # empty values are valid
+                        self.output.add_info('E', pkg, 'wrong-entry-format', f, line_nr_str)
+                        continue
+
+                    key, value = line_array
+                    if key == 'binary':
+                        if bin_found:
+                            self.output.add_info('E', pkg, 'multiple-entries', f, line_nr_str)
+                            continue
+                        for path in pkg.files:
+                            if 'bin/' in path and path.endswith(value):
+                                bin_found = True
+                        if not bin_found:
+                            self.output.add_info('W', pkg, 'binary-entry-value-not-found', f, line_nr_str)
+                    elif key == 'man':
+                        if man_found:
+                            self.output.add_info('E', pkg, 'double-entries', f, line_nr_str)
+                            continue
+                        mans = value.split(',')
+                        for man in mans:
+                            man_found = False
                             for path in pkg.files:
-                                if 'bin/' in path and path.endswith(value):
-                                    bin_found = True
-                            if not bin_found:
-                                self.output.add_info('W', pkg, 'binary-entry-value-not-found', f, line_nr_str)
-                        elif key == 'man':
-                            if man_found:
-                                self.output.add_info('E', pkg, 'double-entries', f, line_nr_str)
-                                continue
-                            mans = value.split(',')
-                            for man in mans:
-                                man_found = False
-                                for path in pkg.files:
-                                    if path.startswith('/usr/share/man/') and man.strip() in path:
-                                        man_found = True
-                                if not man_found:
-                                    self.output.add_info('W', pkg, 'man-entry-value-not-found', f, line_nr_str)
-                        elif key != 'group' and key != 'options':
-                            self.output.add_info('W', pkg, 'wrong-tag-found', f, line_nr_str)
-                    if not bin_found:
-                        self.output.add_info('W', pkg, 'wrong-or-missed-binary-entry', f)
+                                if path.startswith('/usr/share/man/') and man.strip() in path:
+                                    man_found = True
+                            if not man_found:
+                                self.output.add_info('W', pkg, 'man-entry-value-not-found', f, line_nr_str)
+                    elif key != 'group' and key != 'options':
+                        self.output.add_info('W', pkg, 'wrong-tag-found', f, line_nr_str)
+                if not bin_found:
+                    self.output.add_info('W', pkg, 'wrong-or-missed-binary-entry', f)

--- a/test/mockdata/mock_alternatives.py
+++ b/test/mockdata/mock_alternatives.py
@@ -1,0 +1,26 @@
+from Testing import get_tested_mock_package
+
+
+AlternativeConfFolder = get_tested_mock_package(
+    lazyload=True,
+    header={'requires': [], 'POSTIN': '', 'POSTUN': ''},
+    name='alternatives',
+    files={
+        '/usr/share/libalternatives/rst2html/311.conf': {
+            'create_dirs': True,
+            'content': 'bin=/usr/bin/rst2html-3.11',
+        },
+        '/usr/share/libalternatives/rst2html/1313.conf': {
+            'create_dirs': True,
+            'content': 'binary=/usr/bin/=rst2html-3.13',
+        },
+        '/usr/share/libalternatives/ldaptor-ldap2dhcpconf/311.conf': {
+            'create_dirs': True,
+            'content': 'binary=/usr/bin/ldaptor-ldap2dhcpconf-3.11',
+        },
+        '/usr/share/libalternatives/ldaptor-ldap2dhcpconf/1311.conf': {
+            'create_dirs': True,
+            'content': 'binary=/usr/bin/ldaptor-ldap2dhcpconf-3.13',
+        },
+    }
+)

--- a/test/test_alternatives.py
+++ b/test/test_alternatives.py
@@ -1,3 +1,4 @@
+from mockdata.mock_alternatives import AlternativeConfFolder
 import pytest
 from rpmlint.checks.AlternativesCheck import AlternativesCheck
 from rpmlint.filter import Filter
@@ -84,4 +85,15 @@ def test_libalternative_borked(tmp_path, package, alternativescheck):
     assert 'E: libalternatives-directory-not-exist' in out
     assert 'E: empty-libalternatives-directory' in out
     assert 'W: man-entry-value-not-found' in out
+    assert 'W: binary-entry-value-not-found' in out
+
+
+@pytest.mark.parametrize('package', [AlternativeConfFolder])
+def test_alternative_conf_folder(package, alternativescheck):
+    output, test = alternativescheck
+    test.check(package)
+    out = output.print_results(output.results)
+    assert 'E: libalternatives-conf-not-found' not in out
+    assert 'W: wrong-tag-found' in out
+    assert 'E: wrong-entry-format' in out
     assert 'W: binary-entry-value-not-found' in out


### PR DESCRIPTION
The previous regex matches any path in /usr/share/libalternatives/ that ends with "conf" so it was crashing when trying to parse an rpm file that contains a binary "ldaptor-ldap2dhcpconf" with a libalternatives configuration.

This patch fixes this issue making the regex more specific so it doesn't catch any folder, just ".conf" files.

Cherry-pick: 27ee58ace
Fix https://bugzilla.suse.com/show_bug.cgi?id=1261308