### PR TITLE
ZipCheck: fix utf8 decoding erros in jarfile manifest (bsc#1261696)

### DIFF
--- a/rpmlint/checks/ZipCheck.py
+++ b/rpmlint/checks/ZipCheck.py
@@ -78,7 +78,7 @@ class ZipCheck(AbstractCheck):
             return
 
         # otherwise check for the hardcoded classpath
-        manifest = jarfile.read(mf).decode()
+        manifest = jarfile.read(mf).decode(errors='replace')
         if classpath_regex.search(manifest):
             self.output.add_info('W', pkg, 'class-path-in-manifest', fname)
 


### PR DESCRIPTION
This patch sets the errors="replace" to avoid UnicodeError when trying to match classpath_regex in jarfile manifest files.

https://docs.python.org/3/library/stdtypes.html#bytes.decode

Fix https://github.com/rpm-software-management/rpmlint/issues/1346

(cherry picked from commit ce1a0de22cc8fd9d3bef38b1dc4ef89143b0fea8)