### PR TITLE
CI: Use leap containers instead of TW

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
         container:
           - 'registry.fedoraproject.org/fedora:latest'
           - 'registry.fedoraproject.org/fedora:rawhide'
-          - 'registry.opensuse.org/opensuse/tumbleweed:latest'
+          - 'registry.opensuse.org/opensuse/leap:16.0'
         include:
           - container: 'registry.fedoraproject.org/fedora:latest'
             build-type: 'no-optional-deps'
-          - container: 'registry.opensuse.org/opensuse/tumbleweed:latest'
+          - container: 'registry.opensuse.org/opensuse/leap:16.0'
             build-type: 'no-optional-deps'
       fail-fast: false
 
@@ -41,10 +41,6 @@ jobs:
               python3-pytest-cov
               python3-pytest-xdist
               python3-flake8
-              python3-flake8-builtins
-              python3-flake8-bugbear
-              python3-flake8-import-order
-              python3-flake8-quotes
               python3-pyxdg
               python3-zstandard
               python3-tomli
@@ -63,8 +59,6 @@ jobs:
               myspell-fr_FR
               python3-pyenchant
         if: ${{ contains(matrix.container, 'opensuse') && matrix.build-type == 'normal' }}
-      - run: zypper -n install python3-flake8-comprehensions
-        if: ${{ contains(matrix.container, 'opensuse') }}
       - run: dnf --nogpgcheck --assumeyes install
               /usr/bin/cpio
               /usr/bin/bzip2

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,8 +15,8 @@ jobs:
     # mageia is failing because of rpm
     # - mageia-cauldron-x86_64
     # - mageia-cauldron-aarch64
-    - opensuse-tumbleweed-x86_64
-    - opensuse-tumbleweed-aarch64
+    - opensuse-leap-16.0-x86_64
+    - opensuse-leap-16.0-aarch64
   trigger: pull_request
 - job: copr_build
   trigger: commit
@@ -27,8 +27,8 @@ jobs:
     # mageia is failing because of rpm
     # - mageia-cauldron-x86_64
     # - mageia-cauldron-aarch64
-    - opensuse-tumbleweed-x86_64
-    - opensuse-tumbleweed-aarch64
+    - opensuse-leap-16.0-x86_64
+    - opensuse-leap-16.0-aarch64
     branch: main
     project: rpm-software-management-rpmlint-mainline
     list_on_homepage: True
@@ -37,8 +37,8 @@ jobs:
   trigger: commit
   metadata:
     targets:
-    - opensuse-tumbleweed-x86_64
-    - opensuse-tumbleweed-aarch64
+    - opensuse-leap-16.0-x86_64
+    - opensuse-leap-16.0-aarch64
     branch: opensuse
     project: rpm-software-management-rpmlint-opensuse
     list_on_homepage: True


### PR DESCRIPTION
This should fix the current CI failures for opensuse images, using the corresponding leap image.

The fedora:rawhide it still failing because of the change in the rpm sign return value that's fixed in main but not backported here yet.