### PR TITLE
[opensuse] PermissionsParser: fix parse error when spaces occur between package names

### DIFF
--- a/rpmlint/permissions.py
+++ b/rpmlint/permissions.py
@@ -171,7 +171,11 @@ class PermissionsParser:
             for entry in context.active_entries:
                 entry.caps = caps
         elif line.startswith(':package:'):
-            parts = line.split()
-            self._active_packages = parts[1].split(',')
+            # get rid of any trailing comment
+            line = line.split('#')[0]
+            # get rid of the :package: prefix
+            parts = line.split(None, 1)
+            # split comma-separated package names and strip each part from spaces
+            self._active_packages = [part.strip() for part in parts[1].split(',')]
         else:
             raise Exception(f'Unexpected line encountered in {context.label}:{context.line_nr}')

--- a/rpmlint/pkg.py
+++ b/rpmlint/pkg.py
@@ -904,7 +904,7 @@ class FakePkg(AbstractPkg):
 
         return pkgdir
 
-    def add_file_with_content(self, name, content, metadata=None, **flags):
+    def add_file_with_content(self, name, content, metadata=None, perms=0o644, **flags):
         """
         Add file to the FakePkg and fill the file with provided
         string content.
@@ -912,7 +912,7 @@ class FakePkg(AbstractPkg):
         path = os.path.join(self.dir_name(), name.lstrip('/'))
         pkg_file = PkgFile(name)
         pkg_file.path = path
-        pkg_file.mode = stat.S_IFREG | 0o0644
+        pkg_file.mode = stat.S_IFREG | perms
         pkg_file.user = 'root'
         pkg_file.group = 'root'
         self.files[name] = pkg_file

--- a/test/configs/permissions.secure
+++ b/test/configs/permissions.secure
@@ -3,3 +3,5 @@
 /var/lib/testsuidpermissionscheck/test_permissions_incorrect_owner abc:root   600
 /var/lib/testsuidpermissionscheck/test_permissions_file_as_dir/  root:root   755
 /var/lib/testsuidpermissionscheck/test_permissions_dir_without_slash  root:root   755
+:package: first, second   #  funny comment , :stuff:
+/test/path/one root:root 04755

--- a/test/test_suid_permissions.py
+++ b/test/test_suid_permissions.py
@@ -4,10 +4,27 @@ import stat
 import pytest
 from rpmlint.checks.SUIDPermissionsCheck import SUIDPermissionsCheck
 from rpmlint.filter import Filter
+from rpmlint.pkg import FakePkg
 
 import Testing
 from Testing import get_tested_mock_package
 from Testing import get_tested_package, get_tested_path
+
+
+class FakePermPkg(FakePkg):
+
+    def __init__(self, name, paths):
+        super().__init__(name)
+        if not isinstance(paths, list):
+            paths = [paths]
+        # we need to add some extra ingredients for the SUIDPermissionsCheck
+        # to be satisfied with a fake package.
+        script = '\n'.join([f'permctl -n  {path}' for path in paths])
+        self.add_header({
+            'POSTIN': script,
+            'VERIFYSCRIPT': script
+        })
+        self.prereq.append(['permissions'])
 
 
 def get_suid_permissions_check(config_path):
@@ -186,3 +203,26 @@ def test_permissions_permctl(package, permissions_check):
     out = output.print_results(output.results)
     assert 'permissions-missing-postin' not in out
     assert 'permissions-missing-verifyscript' not in out
+
+
+def get_fake_pkg_check():
+    output, test = get_suid_permissions_check(Testing.TEST_CONFIG[0])
+    test._parse_profile(str(get_tested_path('configs/permissions.secure')))
+    return output, test
+
+
+def test_permissions_package_coupling():
+    output, test = get_fake_pkg_check()
+
+    # check that the multi-package specification works correctly, this package
+    # should be accepted
+    with FakePermPkg('second', '/test/path/one') as pkg:
+        pkg.add_file_with_content('/test/path/one', 'stuff', perms=0o4755)
+        test.check(pkg)
+        assert len(output.results) == 0
+
+    # this is an unrelated package which should actually be complained about
+    with FakePermPkg('third', '/test/path/one') as pkg:
+        pkg.add_file_with_content('/test/path/one', 'stuff', perms=0o4755)
+        test.check(pkg)
+        assert len(output.results) == 1


### PR DESCRIPTION
The `:package:` coupling syntax allows spaces between comma-separated package names. This is currently not considered by the PermissionsParser, leading to whitelisting errors e.g. in the mininews packages, because an empty package name `''` is parsed out of the permissions profile.

Fix this by carefully removing comments and `:package` prefix, the splitting and stripping package names.