### PR TITLE
checks: Add new RubyCheck

### DIFF
--- a/configs/openSUSE/opensuse.toml
+++ b/configs/openSUSE/opensuse.toml
@@ -29,6 +29,7 @@ Checks = [
     "SUIDPermissionsCheck",
     "WorldWritableCheck",
     "AtomicUpdateCheck",
+    "RubyCheck",
 ]
 
 # List of directory prefixes that are not allowed in packages

--- a/rpmlint/checks/RubyCheck.py
+++ b/rpmlint/checks/RubyCheck.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import re
+import stat
+
+from rpmlint.checks.AbstractCheck import AbstractFilesCheck
+from rpmlint.checks.FilesCheck import FilesCheck
+from rpmlint.checks.FilesCheck import script_interpreter
+
+
+# Only allow "#!/usr/bin/ruby.ruby4.0" shebang format
+# "/usr/bin/env ruby" or "/usr/bin/ruby" will show the
+# ruby-script-wrong-shebang error
+RUBY_SHEBANG_RE = re.compile(r'^/usr/bin/ruby\.(?P<suffix>.*)$')
+BIN_RE = re.compile(r'^/(?:usr/(?:s?bin|games)|s?bin)/(.*)')
+
+
+class RubyCheck(AbstractFilesCheck):
+    man_regex = re.compile(r'/man(?:\d[px]?|n)/')
+    info_regex = re.compile(r'(/usr/share|/usr)/info/')
+
+    def __init__(self, config, output):
+        super().__init__(config, output, r'.*')
+
+    def check_file(self, pkg, filename):
+        self._check_file_shebang(pkg, filename)
+
+    def _check_file_shebang(self, pkg, filename):
+        """
+        Check that the file shebang is correct
+        """
+
+        if not BIN_RE.match(filename):
+            return
+
+        basedir = Path(filename).parent
+        realbin = pkg.files[filename]
+        if realbin.linkto:
+            linkto = str((basedir / Path(realbin.linkto)).resolve())
+            # Link to a file not in the package, so ignore
+            if linkto not in pkg.files:
+                return
+            realbin = pkg.files[linkto]
+
+        if not stat.S_ISREG(realbin.mode):
+            return
+
+        chunk, is_text = FilesCheck.peek(self, realbin.path, pkg)
+        interpreter, interpreter_args = script_interpreter(chunk)
+        if interpreter and RUBY_SHEBANG_RE.match(interpreter) is None:
+            self.output.add_info('E', pkg, 'ruby-script-wrong-shebang', filename)

--- a/rpmlint/descriptions/RubyCheck.toml
+++ b/rpmlint/descriptions/RubyCheck.toml
@@ -1,0 +1,5 @@
+ruby-script-wrong-shebang-="""
+Wrong ruby script found in a file. Any binary ruby file should have a
+shebang that points directly to the especific version, for example
+/usr/bin/ruby.ruby4.0
+"""

--- a/test/test_ruby.py
+++ b/test/test_ruby.py
@@ -1,0 +1,62 @@
+import pytest
+from rpmlint.checks.RubyCheck import RubyCheck
+from rpmlint.filter import Filter
+
+from Testing import CONFIG, get_tested_mock_package
+
+
+@pytest.fixture(scope='function', autouse=True)
+def rubycheck():
+    CONFIG.info = True
+    output = Filter(CONFIG)
+    test = RubyCheck(CONFIG, output)
+    yield output, test
+
+
+@pytest.fixture
+def output(rubycheck):
+    output, _test = rubycheck
+    yield output
+
+
+@pytest.fixture
+def test(rubycheck):
+    _output, test = rubycheck
+    yield test
+
+
+@pytest.mark.parametrize('package', [get_tested_mock_package(
+    files={
+        # Good shebang
+        '/usr/bin/good0.rb': {'content': '#!/usr/bin/ruby.ruby4.0'},
+        '/usr/bin/good0': {'content': '#!/usr/bin/ruby.ruby4.0'},
+        '/usr/bin/good1': {'content': '#!/usr/bin/ruby.ruby3.0\nputs "Hello world"'},
+        '/usr/bin/good2': {'content': '#!/usr/bin/ruby.suffix -w\nputs "Hello world"'},
+        '/usr/lib64/ruby/gems/4.0.0/gems/rbs-3.10.0/exe/rbs': {'content': '#!/usr/bin/env\nputs "Hello world"'},
+        '/usr/lib64/ruby/gem.rb': {'content': '#!/usr/bin/env\nputs "Hello world"'},
+        # Bad shebang
+        '/usr/bin/bad1.rb': {'content': '#!/usr/bin/env ruby.ruby4.0'},
+        '/usr/bin/bad2.rb': {'content': '#!/usr/bin/ruby'},
+        '/usr/bin/bad3': {'content': '#!/usr/bin/ruby -w\nputs "Hello world"'},
+        '/usr/bin/bad4': {'content': '#!/usr/bin/env ruby -w\nputs "Hello world"'},
+        '/usr/bin/link': {
+            'linkto': '/usr/lib64/ruby/gem.rb',
+        },
+    }
+)])
+def test_ruby_shebang(package, test, output):
+    test.check(package)
+    out = output.print_results(output.results)
+    assert 'E: ruby-script-wrong-shebang /usr/bin/good0.rb' not in out
+    assert 'E: ruby-script-wrong-shebang /usr/bin/good0' not in out
+    assert 'E: ruby-script-wrong-shebang /usr/bin/good1' not in out
+    assert 'E: ruby-script-wrong-shebang /usr/bin/good2' not in out
+
+    assert 'E: ruby-script-wrong-shebang /usr/lib64/ruby/gems/4.0.0/gems/rbs-3.10.0/exe/rbs' not in out
+    assert 'E: ruby-script-wrong-shebang /usr/lib64/ruby/bad.rb' not in out
+
+    assert 'E: ruby-script-wrong-shebang /usr/bin/bad1.rb' in out
+    assert 'E: ruby-script-wrong-shebang /usr/bin/bad2.rb' in out
+    assert 'E: ruby-script-wrong-shebang /usr/bin/bad3' in out
+    assert 'E: ruby-script-wrong-shebang /usr/bin/bad4' in out
+    assert 'E: ruby-script-wrong-shebang /usr/bin/link' in out


### PR DESCRIPTION
This patch adds a new check for ruby files. The goal is to detect wrong shebang lines that points to the interpreter that can use libalternatives, so each script should point to the real interpreter.