### PR TITLE
BuildRootAndDateCheck: Convert date errs to warning

### DIFF
--- a/rpmlint/checks/BuildRootAndDateCheck.py
+++ b/rpmlint/checks/BuildRootAndDateCheck.py
@@ -38,8 +38,8 @@ class BuildRootAndDateCheck(AbstractFilesCheck):
         data = pkg.read_with_mmap(filename)
         if self.istoday.search(data):
             if self.looksliketime.search(data):
-                self.output.add_info('E', pkg, 'file-contains-date-and-time', filename)
+                self.output.add_info('W', pkg, 'file-contains-date-and-time', filename)
             else:
-                self.output.add_info('E', pkg, 'file-contains-current-date', filename)
+                self.output.add_info('W', pkg, 'file-contains-current-date', filename)
         if self.lookslikebuildroot.search(data):
             self.output.add_info('E', pkg, 'file-contains-buildroot', filename)

--- a/test/test_build_date.py
+++ b/test/test_build_date.py
@@ -23,8 +23,8 @@ def test_build_date_time(package, builddatecheck):
     test.istoday = re.compile('Jan  1 2019')
     test.check(package)
     out = output.print_results(output.results)
-    assert 'E: file-contains-date-and-time /bin/with-datetime' in out
-    assert 'E: file-contains-current-date /bin/with-date' in out
+    assert 'W: file-contains-date-and-time /bin/with-datetime' in out
+    assert 'W: file-contains-current-date /bin/with-date' in out
 
 
 @pytest.mark.parametrize('package', [BashismsPackage])
@@ -33,5 +33,5 @@ def test_build_date_time_correct(package, builddatecheck):
     test.istoday = re.compile('Jan  1 2019')
     test.check(package)
     out = output.print_results(output.results)
-    assert 'E: file-contains-date-and-time' not in out
-    assert 'E: file-contains-current-date' not in out
+    assert 'W: file-contains-date-and-time' not in out
+    assert 'W: file-contains-current-date' not in out


### PR DESCRIPTION
Before the invention of SOURCE_DATE_EPOCH, the check helped people find occurences of __TIME__ to patch them out to avoid extra rebuilds/republishes in OBS. But that is no more needed for 5+ years.

Fix https://github.com/rpm-software-management/rpmlint/issues/1317