### PR TITLE
[opensuse] SUIDPermissionsCheck: enforce whitelistings for capabilities (bsc#126…

### DIFF
--- a/configs/openSUSE/scoring-strict.override.toml
+++ b/configs/openSUSE/scoring-strict.override.toml
@@ -21,6 +21,7 @@ permissions-file-ghost = 10000
 permissions-file-unauthorized = 10000
 permissions-file-setuid-bit = 10000
 permissions-file-symlink = 10000
+permissions-fscaps = 10000
 # this one is problematic, because e.g. /etc/cron.* is packaged by multiple
 # packages and only one should be responsible for caring about %postin
 permissions-missing-postin = 100

--- a/configs/openSUSE/scoring-strict.override.toml
+++ b/configs/openSUSE/scoring-strict.override.toml
@@ -22,9 +22,7 @@ permissions-file-unauthorized = 10000
 permissions-file-setuid-bit = 10000
 permissions-file-symlink = 10000
 permissions-fscaps = 10000
-# this one is problematic, because e.g. /etc/cron.* is packaged by multiple
-# packages and only one should be responsible for caring about %postin
-permissions-missing-postin = 100
+permissions-missing-postin = 10000
 permissions-parse-error = 10000
 polkit-file-digest-mismatch = 10000
 polkit-file-ghost = 10000

--- a/configs/openSUSE/scoring.toml
+++ b/configs/openSUSE/scoring.toml
@@ -69,6 +69,7 @@ permissions-file-ghost = 10
 permissions-file-unauthorized = 10
 permissions-file-setuid-bit = 10
 permissions-file-symlink = 10
+permissions-fscaps = 10
 permissions-parse-error = 10
 pam-unauthorized-module = 10
 world-writable-unauthorized-file = 10

--- a/rpmlint/checks/SUIDPermissionsCheck.py
+++ b/rpmlint/checks/SUIDPermissionsCheck.py
@@ -35,30 +35,46 @@ class SUIDPermissionsCheck(AbstractCheck):
         parser = PermissionsParser(self.var_handler, path)
         self.perms.update(parser.entries)
 
-    def _complain_restricted_mode(self, pkg, path, mode):
-        msg = f'{path} is packaged with setuid/setgid bits (0{stat.S_IMODE(mode):o})'
-        diag = 'permissions-directory-setuid-bit' if stat.S_ISDIR(mode) else 'permissions-file-setuid-bit'
-        self.output.add_info('E', pkg, diag, msg)
+    def _complain_restricted_privs(self, pkg, path, pkgfile):
+        if stat.S_ISDIR(pkgfile.mode):
+            diag = 'permissions-directory-setuid-bit'
+        else:
+            diag = 'permissions-file-setuid-bit'
 
-    def _verify_entry(self, entry, pkg, path, rpm_mode, rpm_owner):
+        if pkgfile.filecaps:
+            msg = f'{path} is packaged with capabilities ({pkgfile.filecaps})'
+            self.output.add_info('E', pkg, diag, msg)
+        if self._is_suid(pkgfile.mode):
+            msg = f'{path} is packaged with setuid/setgid bits (0{stat.S_IMODE(pkgfile.mode):o})'
+            self.output.add_info('E', pkg, diag, msg)
+
+    def _verify_entry(self, entry, pkg, path, pkgfile):
         """Complains about disagreements between the package metadata and the
         permissions profile settings. We also require the RPM permissions to
         match the reference permissions profile (secure)."""
         is_listed_as_dir = entry.path.endswith('/')
-        is_packaged_as_dir = stat.S_ISDIR(rpm_mode)
+        is_packaged_as_dir = stat.S_ISDIR(pkgfile.mode)
 
         if is_packaged_as_dir and not is_listed_as_dir:
             self.output.add_info('W', pkg, 'permissions-dir-without-slash', path)
         elif is_listed_as_dir and not is_packaged_as_dir:
             self.output.add_info('W', pkg, 'permissions-file-as-dir', f'{path} is a file but listed as directory')
 
+        if stat.S_IMODE(pkgfile.mode) != entry.mode:
+            self.output.add_info('E', pkg, 'permissions-incorrect', f'{path} has mode 0{stat.S_IMODE(pkgfile.mode):o} but should be 0{entry.mode:o}')
+        # it would be too much complexity with little gain to compare the
+        # capabilities found in RPM metadata against the capabilities
+        # configured in the permissions profile(s). Thus simply reject
+        # packaged capabilities outright, they should only be managed by
+        # `permctl`, not by `rpm`.
+        if pkgfile.filecaps:
+            self.output.add_info('E', pkg, 'permissions-fscaps', f'{path} has capabilities "{pkgfile.filecaps}". Capabilities should only be managed by the permissions package.')
+
         entry_owner = ':'.join((entry.owner, entry.group))
+        pkg_owner = ':'.join((pkgfile.user, pkgfile.group))
 
-        if stat.S_IMODE(rpm_mode) != entry.mode:
-            self.output.add_info('E', pkg, 'permissions-incorrect', f'{path} has mode 0{stat.S_IMODE(rpm_mode):o} but should be 0{entry.mode:o}')
-
-        if rpm_owner != entry_owner:
-            self.output.add_info('E', pkg, 'permissions-incorrect-owner', f'{path} belongs to {rpm_owner} but should be {entry_owner}')
+        if pkg_owner != entry_owner:
+            self.output.add_info('E', pkg, 'permissions-incorrect-owner', f'{path} belongs to {pkg_owner} but should be {entry_owner}')
 
     def _check_post_scriptlets(self, pkg, path):
         """Checks whether a call to "permctl -n {path}" is found in %post and
@@ -107,6 +123,9 @@ class SUIDPermissionsCheck(AbstractCheck):
                 return True
 
         return False
+
+    def _is_suid(self, mode):
+        return (mode & (stat.S_ISUID | stat.S_ISGID)) != 0
 
     def check(self, pkg):
         if pkg.is_source:
@@ -158,13 +177,9 @@ class SUIDPermissionsCheck(AbstractCheck):
                 # is that that we don't see warnings for privileges added by
                 # other mechanisms that are described in these %ghost files
                 continue
-            if pkgfile.filecaps:
-                # capabilities are only assigned via permctl, should not be
-                # packaged directly
-                self.output.add_info('E', pkg, 'permissions-fscaps', f"{f} has fscaps '{pkgfile.filecaps}'")
 
             mode = pkgfile.mode
-            owner = pkgfile.user + ':' + pkgfile.group
+            is_link = stat.S_ISLNK(mode)
             # whether we need to check for invocation of permctl in %post or
             # %verifyscript for this path
             check_scriptlets = False
@@ -172,19 +187,20 @@ class SUIDPermissionsCheck(AbstractCheck):
             skip_file = False
             for entry in self.perms.get(f, []):
                 if entry.matches_pkg(pkg.name):
-                    if stat.S_ISLNK(mode):
+                    if is_link:
                         self.output.add_info('W', pkg, 'permissions-symlink', f)
                         skip_file = True
                         break
 
                     check_scriptlets = True
-                    self._verify_entry(entry, pkg, f, mode, owner)
+                    self._verify_entry(entry, pkg, f, pkgfile)
                     break
             else:
+                grants_privileges = pkgfile.filecaps or self._is_suid(pkgfile.mode)
                 # no matching entry found; this means there is no whitelisting for any privileged bits.
-                if not stat.S_ISLNK(mode) and (mode & (stat.S_ISUID | stat.S_ISGID)):
+                if not is_link and grants_privileges:
                     check_scriptlets = True
-                    self._complain_restricted_mode(pkg, f, mode)
+                    self._complain_restricted_privs(pkg, f, pkgfile)
 
             if skip_file:
                 # is a symlink we warned about

--- a/rpmlint/descriptions/SUIDPermissionsCheck.toml
+++ b/rpmlint/descriptions/SUIDPermissionsCheck.toml
@@ -16,8 +16,8 @@ please use the %attr macro to set the correct ownership.
 permissions-file-setuid-bit="""Packaging binaries with setuid/setgid bits or capabilities set requires a
 review and whitelisting by the SUSE security team. #REVIEW_NEEDED_TEXT#"""
 permissions-directory-setuid-bit="""#REVIEW_NEEDED_TEXT#"""
-permissions-fscaps="""Packaging files with capabilities is now allowed. The
-permissions package manages capability assigned via the %set_permissions macro
+permissions-fscaps="""Packaging files with capabilities is not allowed. The
+permissions package manages capabilities via the %set_permissions macro
 during %post. Please remove the capabilities from the file."""
 permissions-missing-postin="""
 Please add an appropriate %post section

--- a/rpmlint/descriptions/SUIDPermissionsCheck.toml
+++ b/rpmlint/descriptions/SUIDPermissionsCheck.toml
@@ -8,17 +8,17 @@ permissions-file-as-dir="""
 the entry in the permissions file refers to a directory but the package actually contains a file. Please contact security@suse.de to remove the slash. Please refer to #AUDIT_BUG_URL# for more information.
 """
 permissions-incorrect="""
-please use the %attr macro to set the correct permissions.
+please use the %attr/%caps macro to set the correct permissions.
 """
 permissions-incorrect-owner="""
 please use the %attr macro to set the correct ownership.
 """
-permissions-file-setuid-bit="""Packaging setuid/setgid binaries requires a
+permissions-file-setuid-bit="""Packaging binaries with setuid/setgid bits or capabilities set requires a
 review and whitelisting by the SUSE security team. #REVIEW_NEEDED_TEXT#"""
 permissions-directory-setuid-bit="""#REVIEW_NEEDED_TEXT#"""
-permissions-fscaps="""
-Packaging file capabilities is currently not supported. Please use normal permissions instead. You may contact the security team to request an entry that sets capabilities in /usr/share/permissions/permissions instead.
-"""
+permissions-fscaps="""Packaging files with capabilities is now allowed. The
+permissions package manages capability assigned via the %set_permissions macro
+during %post. Please remove the capabilities from the file."""
 permissions-missing-postin="""
 Please add an appropriate %post section
 """

--- a/test/test_suid_permissions.py
+++ b/test/test_suid_permissions.py
@@ -88,7 +88,7 @@ def test_permissions_fscaps(tmp_path, package, permissions_check):
     output, test = permissions_check
     test.check(get_tested_package(package, tmp_path))
     out = output.print_results(output.results)
-    assert "testsuidpermissionscheck.x86_64: E: permissions-fscaps /var/lib/testsuidpermissionscheck/test_permissions_fscaps has fscaps 'cap_net_raw=ep'" in out
+    assert 'testsuidpermissionscheck.x86_64: E: permissions-file-setuid-bit /var/lib/testsuidpermissionscheck/test_permissions_fscaps is packaged with capabilities (cap_net_raw=ep)' in out
 
 
 @pytest.mark.parametrize('package', ['binary/testsuidpermissionscheck'])


### PR DESCRIPTION
…8674)

For a while now RPM natively supports packaging file-based capabilities. Thus the diagnostic permissions-fscaps is no longer valid. Even worse, packagers can bypass our whitelisting policy, because permissions-fscaps does not add badness.

For this reason drop permissions-fscaps and use
permissions-file-setuid-bit in case any capabilities are encountered in a file. Capabilities are considered technically similar to the classic setuid/setgid bits, thus reusing the setuid-bit diagnostic is possible in this context.

Regarding the whitelisting enforcement the same logic as with setuid/setgid bits applies: we're looking up the permissions.secure profile and compare what we see packaged in RPM against what is configured in the permissions profile. If there's a mismatch then we complain.