### PR TITLE
[opensuse] FileDigestCheck: varlink: don't process files in sub-directories

### DIFF
--- a/configs/openSUSE/security.toml
+++ b/configs/openSUSE/security.toml
@@ -35,6 +35,8 @@ NamePatterns = [
     "*.socket",
 ]
 ContentCheck = "VarlinkServiceCheck"
+# don't deal with sub-directories like "socket.target.wants"
+Recursive = false
 
 [FileDigestLocation.polkit]
 FollowSymlinks = false

--- a/rpmlint/checks/FileDigestCheck.py
+++ b/rpmlint/checks/FileDigestCheck.py
@@ -46,6 +46,9 @@ class FileDigestCheck(AbstractCheck):
             config.setdefault('NamePatterns', [])
             config.setdefault('FollowSymlinks', False)
             config.setdefault('ContentCheck', None)
+            # whether we should consider files in sub-directories of the
+            # locations as well
+            config.setdefault('Recursive', True)
             config['type'] = check_type
             self.checks.append(config)
             self.known_check_types[check_type] = config
@@ -234,15 +237,22 @@ class FileDigestCheck(AbstractCheck):
         for config in self.checks:
             for location in config['Locations']:
                 with contextlib.suppress(ValueError):
-                    if path.relative_to(location):
-                        if not config['NamePatterns']:
-                            # files in this location are unconditionally subject to the check.
-                            return config
-                        else:
-                            # we need to check if the filename matches the configured pattern.
-                            for glob in config['NamePatterns']:
-                                if fnmatch(path.name, glob):
-                                    return config
+                    subpath = path.relative_to(location)
+
+                    if not subpath:
+                        continue
+                    elif not config['Recursive'] and len(subpath.parts) > 1:
+                        # it's not a direct descendant
+                        continue
+
+                    if not config['NamePatterns']:
+                        # files in this location are unconditionally subject to the check.
+                        return config
+                    else:
+                        # we need to check if the filename matches the configured pattern.
+                        for glob in config['NamePatterns']:
+                            if fnmatch(path.name, glob):
+                                return config
 
         # must be a file which isn't matched by a name pattern.
         return None

--- a/test/configs/digests_varlink.config
+++ b/test/configs/digests_varlink.config
@@ -7,6 +7,7 @@ NamePatterns = [
     "*.socket",
 ]
 ContentCheck = "VarlinkServiceCheck"
+Recursive = false
 
 [[FileDigestGroup]]
 package = "socketpkg"

--- a/test/test_file_digest.py
+++ b/test/test_file_digest.py
@@ -427,6 +427,13 @@ def test_varlink_content_check():
         test.check(pkg)
         assert len(output.results) == 1
 
+    # the check should not be recursive
+    output, test = get_digestcheck('digests_varlink.config')
+    with FakePkg('defaultpkg') as pkg:
+        pkg.add_file_with_content('/sockets/sub/unrelated.socket', RESTRICTED_SOCKET_DATA)
+        test.check(pkg)
+        assert len(output.results) == 0
+
 
 def test_varlink_digester():
     # here we want to check the SocketUnitDigester:


### PR DESCRIPTION
Currently in the systemd rpmlint log we see the diagnostics of this type:

```
systemd.x86_64: E: varlink-file-symlink (Badness: 10) /usr/lib/systemd/system/sockets.target.wants/systemd-ask-password.socket
```

This is not intended, since this is internal dependency management done by systemd. We only care for direct descendants for the restricted locations.

For this reason introduce a new "Recursive" setting for file digest checks. It defaults to `true` in which case everything will be as before. If it is set to `false` then files in sub-directories of the restricted locations will no longer be considered.

Set this new property to `true` for the VarlinkServiceCheck to avoid these bogus diagnostics. Also add a new test cast to assert that this actually works.