### PR TITLE
[opensuse] FileDigestCheck: detect more varlink socket units

### DIFF
--- a/rpmlint/filedigestcheck.py
+++ b/rpmlint/filedigestcheck.py
@@ -97,9 +97,10 @@ class VarlinkServiceCheck:
         # previous occurences. Having this would be weird, however, so let's
         # consider any appearance of varlink here.
         for name in socket_section.get('FileDescriptorName', []):
-            # this is more of a convention, not a hard requirement, but so far all
-            # Varlink services we have use this scheme.
-            if name == 'varlink':
+            # this is more of a convention, not a hard requirement.
+            # most of the time it is just "varlink", but some services also
+            # use "varlink-monitor" or similar names.
+            if name.find('varlink') != -1:
                 return True
 
         # not a varlink service


### PR DESCRIPTION
While whitelisting existing Varlink socket units found in Factory we noticed that a couple of units use different FileDescriptorName values like "varlink-monitor". Thus catch more of these situations to increase the coverage of this whitelisting restriction.