### PR TITLE
configs: Support eln release extension

### DIFF
--- a/configs/Fedora/fedora.toml
+++ b/configs/Fedora/fedora.toml
@@ -19,7 +19,7 @@ MaxLineLength = 80
 PythonDefaultVersion = ""
 
 # Regexp string with expected suffix in Release tags.
-ReleaseExtension = '\.(fc|rhe?l|el)\d+(?=\.|$)'
+ReleaseExtension = '\.(fc|rhe?l|el|eln)\d+(?=\.|$)'
 
 # Whether to want default start/stop runlevels specified in init scripts
 UseDefaultRunlevels = false


### PR DESCRIPTION
Now that rpmlint runs on eln builds they will always fail with `incoherent-version-in-changelog` as `eln` is not understood as release extension.