### PR TITLE
varlink-whitelist: include systemd-mini variants in packages

### DIFF
--- a/configs/openSUSE/varlink-whitelist.toml
+++ b/configs/openSUSE/varlink-whitelist.toml
@@ -47,7 +47,7 @@ digester = "systemd-socket"
 hash     = "22ad4eb46a0ddcd461ce0136548de13b207592fa464521f55948581606b53856"
 
 [[FileDigestGroup]]
-package  = "udev"
+packages = ["udev", "udev-mini"]
 note     = "udev core varlink services, all accessible to root only"
 bug      = "bsc#1261919"
 type     = "varlink"
@@ -133,7 +133,7 @@ digester = "systemd-socket"
 hash     = "0638b4934f81ba81dc0ec5172cc80a02297abb078cea24273d5b87c2e880b046"
 
 [[FileDigestGroup]]
-package  = "systemd"
+packages = ["systemd", "systemd-mini"]
 note     = "service which helps to obtain a password from an interactive user"
 bugs     = ["bsc#1261919", "bsc#1257943"]
 type     = "varlink"
@@ -143,7 +143,7 @@ digester = "systemd-socket"
 hash     = "65796969f76971117b1f8405906e7ed54d95230faa45465714ab71ccf158e5aa"
 
 [[FileDigestGroup]]
-package  = "systemd"
+packages = ["systemd", "systemd-mini"]
 note     = "TPM credential encryption/decryption"
 bugs     = ["bsc#1261919", "bsc#1225317"]
 type     = "varlink"
@@ -153,7 +153,7 @@ digester = "systemd-socket"
 hash     = "bc4fb052a8e1f298a15c0dc8d6e8a9850a3629776b6fa271ef8f9b45cb81d8ae"
 
 [[FileDigestGroup]]
-package  = "systemd"
+packages = ["systemd", "systemd-mini"]
 note     = "provides hardware information"
 bugs     = ["bsc#1261919", "bsc#641924", "bsc#1257388"]
 type     = "varlink"
@@ -163,7 +163,7 @@ digester = "systemd-socket"
 hash     = "0bae10736a17d5b449fd2bfa3726599696b168e5e2cc70d9b2d990cea0a16359"
 
 [[FileDigestGroup]]
-package  = "systemd"
+packages = ["systemd", "systemd-mini"]
 note     = "login/session manager including system power state management"
 bugs     = ["bsc#641924", "bsc#1261919"]
 type     = "varlink"
@@ -173,7 +173,7 @@ digester = "systemd-socket"
 hash     = "7e62a81cb560d9dbb4bf27a8c485ec4a2b2ce8d85a9cfddf3c1061795732ae7d"
 
 [[FileDigestGroup]]
-package  = "systemd"
+packages = ["systemd", "systemd-mini"]
 note     = "management of system extension / configuration images"
 bugs     = ["bsc#1261919", "bsc#1259318"]
 type     = "varlink"
@@ -193,7 +193,7 @@ digester = "systemd-socket"
 hash     = "f18c943e7ee65fea7d34d282111230867b1d309d5bcbf5e0bb00982567c6bb82"
 
 [[FileDigestGroup]]
-package  = "systemd-experimental"
+packages = ["systemd-experimental", "systemd-mini-experimental"]
 note     = "access to information about factory reset status"
 bug      = "bsc#1261919"
 type     = "varlink"
@@ -213,7 +213,7 @@ digester = "systemd-socket"
 hash     = "15703bc772caf1b5604eba1f6dd5709a679374747f6c853012abd6ab2127ff71"
 
 [[FileDigestGroup]]
-package  = "systemd-experimental"
+packages = ["systemd-experimental", "systemd-mini-experimental"]
 note     = "programmatic access to journalctl data"
 bug      = "bsc#1261919"
 type     = "varlink"
@@ -223,7 +223,7 @@ digester = "systemd-socket"
 hash     = "3232616b0acc13ff0b68b014e028662847b1a5692dc64fd29d63983a03f12bcb"
 
 [[FileDigestGroup]]
-package  = "systemd-experimental"
+packages = ["systemd-experimental", "systemd-mini-experimental"]
 note     = "turn of pid1 / kernel messages on a console"
 bug      = "bsc#1261919"
 type     = "varlink"
@@ -243,7 +243,7 @@ digester = "systemd-socket"
 hash     = "2cccfadaadd7c49d63a40f96ba899b590c77cab7e05fcb7824b58a425d064b71"
 
 [[FileDigestGroup]]
-package  = "systemd-experimental"
+packages = ["systemd-experimental", "systemd-mini-experimental"]
 note     = "systemd core metrics read-only access"
 bug      = "bsc#1261919"
 type     = "varlink"
@@ -253,7 +253,7 @@ digester = "systemd-socket"
 hash     = "a0637753ab908ba69ed22619bb7b64e47aa1b00dd6f2d85bb33236da64fceb85"
 
 [[FileDigestGroup]]
-package  = "systemd-experimental"
+packages = ["systemd-experimental", "systemd-mini-experimental"]
 note     = "systemd cgroup metrics read-only access"
 bug      = "bsc#1261919"
 type     = "varlink"
@@ -263,7 +263,7 @@ digester = "systemd-socket"
 hash     = "b546d041421a9828c416c613406ece826a81cc854e8ec528f1322c8adcb3a92f"
 
 [[FileDigestGroup]]
-package  = "systemd-experimental"
+packages = ["systemd-experimental", "systemd-mini-experimental"]
 note     = "read-only access to block devices, authorized read/write access to block devices"
 bugs     = ["bsc#1261919", "bsc#1267504"]
 type     = "varlink"
@@ -273,7 +273,7 @@ digester = "systemd-socket"
 hash     = "3671134aedaccb73fa0a5fca06ea5c664f8177052bdbddc605767b739de274c4"
 
 [[FileDigestGroup]]
-package  = "systemd-experimental"
+packages = ["systemd-experimental", "systemd-mini-experimental"]
 note     = "read-only access to file-systems, authorized read/write access to file systems"
 bug      = "bsc#1261919"
 type     = "varlink"


### PR DESCRIPTION
We overlooked the mini flavour in the systemd build. Add the according packages.

This is the list of violations extracted from the systemd build log for reference (digest are matching the ones already found in the whitelisting):

```
systemd-mini /usr/lib/systemd/system/systemd-ask-password.socket 65796969f76971117b1f8405906e7ed54d95230faa45465714ab71ccf158e5aa
systemd-mini /usr/lib/systemd/system/systemd-creds.socket bc4fb052a8e1f298a15c0dc8d6e8a9850a3629776b6fa271ef8f9b45cb81d8ae
systemd-mini /usr/lib/systemd/system/systemd-hostnamed.socket 0bae10736a17d5b449fd2bfa3726599696b168e5e2cc70d9b2d990cea0a16359
systemd-mini /usr/lib/systemd/system/systemd-logind-varlink.socket 7e62a81cb560d9dbb4bf27a8c485ec4a2b2ce8d85a9cfddf3c1061795732ae7d
systemd-mini /usr/lib/systemd/system/systemd-sysext.socket 695f5a22b67ede89005bbf39065e94d1c17fff449cd925ecc969da654bba5e26
systemd-mini-experimental /usr/lib/systemd/system/systemd-factory-reset.socket 70d4b87386b0f4aa4d3c99d901b912bb604d7932203b772320625bbc448d978d
systemd-mini-experimental /usr/lib/systemd/system/systemd-journalctl.socket 3232616b0acc13ff0b68b014e028662847b1a5692dc64fd29d63983a03f12bcb
systemd-mini-experimental /usr/lib/systemd/system/systemd-mute-console.socket 58a95fcb09c8ab8e0c2f98a2495d14a6a1ef1d0c18aacb751cebc624c9ba41f8
systemd-mini-experimental /usr/lib/systemd/system/systemd-report-basic.socket a0637753ab908ba69ed22619bb7b64e47aa1b00dd6f2d85bb33236da64fceb85
systemd-mini-experimental /usr/lib/systemd/system/systemd-report-cgroup.socket b546d041421a9828c416c613406ece826a81cc854e8ec528f1322c8adcb3a92f
systemd-mini-experimental /usr/lib/systemd/system/systemd-storage-block.socket 3671134aedaccb73fa0a5fca06ea5c664f8177052bdbddc605767b739de274c4
systemd-mini-experimental /usr/lib/systemd/system/systemd-storage-fs.socket 8f6818e0d31544b37d01432d6efd4816f126b12066c41024fa3043bce5116235
udev-mini /usr/lib/systemd/system/systemd-udevd-varlink.socket 9ca1632e762e1e3215c51b08b39b7660b5461072d82013ea3dca9193b0beada9
```